### PR TITLE
fix(DEV-10094): Add usage of empty `NPM_TOKEN` to `Upload to Sentry` job

### DIFF
--- a/.github/workflows/version-or-release-packages.yml
+++ b/.github/workflows/version-or-release-packages.yml
@@ -64,3 +64,6 @@ jobs:
       - name: Upload to Sentry
         if: steps.changesets.outputs.published == 'true'
         run: yarn sentry-cli sourcemaps upload --release="$(node -p 'require("@monite/sdk-api/package.json").version')" packages/sdk-react/dist
+        env:
+          # The 'NPM_TOKEN' must be set to at least empty, as it is used in the ".yarnrc.yml" file
+          NPM_TOKEN: ""


### PR DESCRIPTION
Added setting an empty `NPM_TOKEN` for the `Upload to Sentry` task so that you can use upload to Sentry without reverting to patched `.yarnrc.yml`, where `NPM_TOKEN` is the required env variable.