### PR TITLE
feat(DEV-10167): add workflows to synchronize with the GitLab repo submodule

### DIFF
--- a/.github/workflows/merge-gitlab-mr.yml
+++ b/.github/workflows/merge-gitlab-mr.yml
@@ -1,0 +1,40 @@
+name: Merge GitLab MR
+
+on:
+  # Avoid using `pull_request_target`, to prevent insecure actions
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
+jobs:
+  merge-gitlab-mr:
+    name: Merge GitLab MR
+    environment: gitlab
+    if: ${{ github.event.pull_request.base.ref == 'main' && startsWith(github.event.pull_request.head.ref, 'changeset-release/') == false }}
+    runs-on: ubuntu-latest
+    env:
+      GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+      GITLAB_HOST: ${{ secrets.GITLAB_HOST }}
+      GITLAB_PROJECT: ${{ secrets.GITLAB_PROJECT }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Merge GitLab MR
+        uses: team-monite/sync-gitlab-repo-submodule-action@40538235a3c9a6819d24692d8087505fe1449162
+        with:
+          action: merge-mr
+          gitlab_token: ${{ secrets.GITLAB_TOKEN }}
+          gitlab_host: ${{ secrets.GITLAB_HOST }}
+          gitlab_project_id: ${{ secrets.GITLAB_PROJECT_ID }}
+          gitlab_target_branch: ${{ secrets.GITLAB_TARGET_BRANCH }}
+          submodule_name: ${{ secrets.GITLAB_SUBMODULE_NAME }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          gitlab_merge_when_pipeline_succeeds: "true"

--- a/.github/workflows/sync-pr-with-gitlab.yml
+++ b/.github/workflows/sync-pr-with-gitlab.yml
@@ -1,0 +1,34 @@
+name: Sync PR with GitLab
+
+on:
+  # Avoid using `pull_request_target`, to prevent insecure actions
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request:
+    branches:
+      - "**"
+      - "!changeset-release/**"
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number }}"
+  # Cancel in-progress runs when a new workflow with the same group name is triggered
+  cancel-in-progress: true
+
+jobs:
+  sync-pr-with-gitlab:
+    name: Sync GitHub PR branch with GitLab MR branch
+    environment: gitlab
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync PR with GitLab
+        uses: team-monite/sync-gitlab-repo-submodule-action@40538235a3c9a6819d24692d8087505fe1449162
+        with:
+          action: sync-branch
+          gitlab_token: ${{ secrets.GITLAB_TOKEN }}
+          gitlab_host: ${{ secrets.GITLAB_HOST }}
+          gitlab_project_id: ${{ secrets.GITLAB_PROJECT_ID }}
+          gitlab_target_branch: ${{ secrets.GITLAB_TARGET_BRANCH }}
+          submodule_name: ${{ secrets.GITLAB_SUBMODULE_NAME }}
+          branch: ${{ github.event.pull_request.head.ref }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          github_pr_url: "${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"


### PR DESCRIPTION
Added workflows to automate synchronization with GitLab:
1.  **Sync GitHub PR with GitLab:** Triggers when a GitHub PR branch is updated, syncing the branch to GitLab as a submodule.
2.  **Merge GitLab MR on PR Close:** Automates GitLab MR merging when the corresponding GitHub PR is closed.