### PR TITLE
docs(proposal): add comments to GitHub workflows explaining potential vulnerability issues

### DIFF
--- a/.github/workflows/contribution-guidelines-check.yml
+++ b/.github/workflows/contribution-guidelines-check.yml
@@ -4,6 +4,9 @@
 name: Contribution Guidelines Check
 
 on:
+  # The event `pull_request_target` is safe because the workflow does not use `action/checkout`,
+  # and does not run untrusted code.
+  # See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
   pull_request_target:
     branches:
       - "**"
@@ -16,7 +19,7 @@ on:
       - unlabeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number }}"
   # Cancel in-progress runs when a new workflow with the same group name is triggered
   cancel-in-progress: true
 

--- a/.github/workflows/monorepo-main-suite.yaml
+++ b/.github/workflows/monorepo-main-suite.yaml
@@ -11,7 +11,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
   # Cancel in-progress runs when a new workflow with the same group name is triggered
   cancel-in-progress: true
 

--- a/.github/workflows/monorepo-main-suite.yaml
+++ b/.github/workflows/monorepo-main-suite.yaml
@@ -1,6 +1,8 @@
 name: Main Suite
 
 on:
+  # Avoid using `pull_request_target`, to prevent insecure actions
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/version-or-release-packages.yml
+++ b/.github/workflows/version-or-release-packages.yml
@@ -10,7 +10,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: "${{ github.workflow }}-${{ github.ref }}"
   # Do not cancel ✖︎ in-progress runs when a new workflow with the same group name is triggered
   cancel-in-progress: false
 


### PR DESCRIPTION
Added comments to clarify the use of `on: pull_request` and `on: pull_request_target` triggers in GitHub Actions. This is to prevent confusion and align with best practices for security as outlined in the provided articles:

-   [Preventing pwn requests in GitHub Actions](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
-   [GitHub Actions and the threat of malicious pull requests](https://nathandavison.com/blog/github-actions-and-the-threat-of-malicious-pull-requests)

_Additional Changes_
- Fixed syntax highlighting to be compatible with the latest IDEA release