### PR TITLE
fix(DEV-9738): Update default values for the ProductDetails component

### DIFF
--- a/.changeset/fluffy-forks-pull.md
+++ b/.changeset/fluffy-forks-pull.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+fix(DEV-9738): update default values for the ProductDetails component

--- a/packages/sdk-react/src/components/products/ProductDetails/ProductEditForm/ProductEditForm.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/ProductEditForm/ProductEditForm.tsx
@@ -129,7 +129,7 @@ export const ProductEditForm = (props: IProductEditFormProps) => {
         product.price?.currency as CurrencyEnum
       ) ?? undefined,
     currency: product.price?.currency,
-    description: product.description,
+    description: product.description ?? '',
   };
 
   const handleSubmit = async (values: IProductFormSubmitValues) => {

--- a/packages/sdk-react/src/mocks/products/productsFixtures.ts
+++ b/packages/sdk-react/src/mocks/products/productsFixtures.ts
@@ -20,7 +20,9 @@ export const productsListFixture: Array<ProductServiceResponse> = new Array(130)
       id: faker.string.nanoid(),
       name: faker.commerce.productName(),
       type: getRandomProperty(ProductServiceTypeEnum),
-      description: faker.commerce.productDescription(),
+      description: faker.datatype.boolean()
+        ? faker.commerce.productDescription()
+        : undefined,
       measure_unit_id: getRandomItemFromArray(measureUnitsListFixture.data).id,
       smallest_amount: Number(faker.commerce.price({ min: 1, max: 10 })),
       entity_id: entityIds[0],


### PR DESCRIPTION
If `description` from the server has to be sent as `null` then FE validation couldn't handle it. To fix it we have to set `description` as `''` (empty string) to satisfy validation rules