### PR TITLE
feat(DEV-10397): add `currencyNumberFormat` to `MoniteLocale` object 🌐

### DIFF
--- a/.changeset/brave-pigs-give.md
+++ b/.changeset/brave-pigs-give.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+feat(DEV-10397): add `currencyNumberFormat` option to `MoniteLocale` to allow customization of currency formatting in different locales.

--- a/packages/sdk-react/src/core/context/MoniteProvider.tsx
+++ b/packages/sdk-react/src/core/context/MoniteProvider.tsx
@@ -30,11 +30,8 @@ export interface MoniteProviderProps {
   /**
    * `locale` responsible for internationalisation
    *  of all Widgets provided.
-   *
-   * `locale.code` is used for global Widgets translation. (e.g. `en`)
-   * `locale.messages` is used for translation for some of the Widgets.
    */
-  locale?: Partial<MoniteLocale>;
+  locale?: MoniteLocale;
 }
 
 export const MoniteProvider = ({

--- a/packages/sdk-react/src/core/hooks/useCurrencies.ts
+++ b/packages/sdk-react/src/core/hooks/useCurrencies.ts
@@ -13,7 +13,7 @@ import { useMoniteContext } from '../context/MoniteContext';
  */
 export const useCurrencies = () => {
   const { data: currencyList, isSuccess, isError, error } = useCurrencyList();
-  const { i18n } = useMoniteContext();
+  const { locale } = useMoniteContext();
 
   //TODO: Remove this error handling and replace with proper error handling
   useEffect(() => {
@@ -118,10 +118,14 @@ export const useCurrencies = () => {
     );
 
     if (currencyData && amountFromMinorUnits !== null) {
-      const formatter = new Intl.NumberFormat(i18n.locale, {
-        style: 'currency',
-        currency,
-      });
+      const formatter = new Intl.NumberFormat(
+        locale.currencyNumberFormat.localeCode,
+        {
+          style: 'currency',
+          currencyDisplay: locale.currencyNumberFormat.display,
+          currency,
+        }
+      );
 
       return formatter.format(amountFromMinorUnits);
     }

--- a/packages/sdk-react/src/utils/test-utils.tsx
+++ b/packages/sdk-react/src/utils/test-utils.tsx
@@ -1,13 +1,15 @@
 import React, { ReactElement, ReactNode } from 'react';
 
 import { MoniteContext } from '@/core/context/MoniteContext';
-import { MoniteI18nProvider } from '@/core/context/MoniteI18nProvider';
+import {
+  getLocaleWithDefaults,
+  MoniteI18nProvider,
+} from '@/core/context/MoniteI18nProvider';
 import { MoniteProviderProps } from '@/core/context/MoniteProvider';
 import { ENTITY_USERS_QUERY_ID } from '@/core/queries';
 import { createThemeWithDefaults } from '@/core/utils/createThemeWithDefaults';
 import { entityIds } from '@/mocks/entities';
 import { setupI18n } from '@lingui/core';
-import { I18nProvider } from '@lingui/react';
 import { MoniteSDK } from '@monite/sdk-api';
 import {
   BrowserClient,
@@ -95,6 +97,7 @@ export const Provider = ({
     <QueryClientProvider client={client}>
       <MoniteContext.Provider
         value={{
+          locale: getLocaleWithDefaults(moniteProviderProps?.locale),
           monite,
           i18n,
           sentryHub,


### PR DESCRIPTION
To provide our customers the ability to tailor currency display formats according to their preferences, we've introduced the `currencyNumberFormat` property to the `MoniteLocale` type. This enhancement boosts the flexibility of our locale management and ensures that currency representations can be aligned with user-specific or regional requirements.

Here's how the `currencyNumberFormat` parameter changes the display format:

1.  **Symbol Display (`currencyNumberFormat: { display: 'symbol' }`)**: 
    -   Locale: `en-US`
        -   Display Example: `$100.00` for an amount of 100 dollars.
    -   Locale: `de-DE`
        -   Display Example: `100,00 $` for an amount of 100 dollars.
2.  **Code Display (`currencyNumberFormat: { display: 'code' }`)**:
    -   Locale: `en-US`
        -   Display Example: `USD 100.00` for an amount of 100 dollars.
    -   Locale: `de-DE`
        -   Display Example: `100,00 USD` for an amount of 100 dollars.
3.  **Name Display (`currencyNumberFormat: { display: 'name' }`)**:
    -   Locale: `en-US`
        -   Display Example: `100.00 US dollars` for an amount of 100 dollars.
    -   Locale: `de-DE`
        -   Display Example: `100,00 US-Dollar` for an amount of 100 dollars.
4. **Code Display with custom Locale (`currencyNumberFormat: { display: 'code', localeCode }`)**:
    -   Locale: `{ display: 'code', localeCode: 'en-US' }`
        -   Display Example: `USD 100.00` for an amount of 100 dollars.
    -   Locale: `{ display: 'code', localeCode: 'en-150' }`
        -   Display Example: `100.00 USD` for an amount of 100 dollars.