### PR TITLE
fix(proposal): allow `<Menu/>` incorrect nesting 🪹

### DIFF
--- a/.changeset/pink-moons-repeat.md
+++ b/.changeset/pink-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+allow `<Menu/>` incorrect nesting

--- a/packages/sdk-demo/src/components/Layout/ThemeSelect.tsx
+++ b/packages/sdk-demo/src/components/Layout/ThemeSelect.tsx
@@ -41,7 +41,6 @@ export const ThemeSelect = ({ value, onChange }: ThemeSelectorProps) => {
   const { buttonProps, menuProps, open } = useMenuButton();
 
   const { variant: themeVariant, mode: themeMode } = value;
-
   return (
     <>
       <Button
@@ -71,6 +70,10 @@ export const ThemeSelect = ({ value, onChange }: ThemeSelectorProps) => {
           <Divider />
           <MenuItem>
             <FormControlLabel
+              onClick={(event) => {
+                // prevent the menu from closing, since `onClick` is closing the menu
+                event.stopPropagation();
+              }}
               control={
                 <Switch color="primary" checked={themeMode === 'dark'} />
               }

--- a/packages/sdk-react/src/core/hooks/useMenuButton.tsx
+++ b/packages/sdk-react/src/core/hooks/useMenuButton.tsx
@@ -1,4 +1,10 @@
-import { type MouseEvent, type KeyboardEvent, useId, useState } from 'react';
+import {
+  type MouseEvent,
+  type KeyboardEvent,
+  type SyntheticEvent,
+  useId,
+  useState,
+} from 'react';
 
 import { useRootElements } from '@/core/context/RootElementsProvider';
 import { type ButtonProps, type MenuProps } from '@mui/material';
@@ -48,7 +54,12 @@ export const useMenuButton = () => {
     });
   };
 
-  const closeMenu = () => {
+  const closeMenu = (event?: SyntheticEvent | {}) => {
+    if (event && 'preventDefault' in event) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
     setAnchorEl((prev) => ({
       ...prev,
       open: false,


### PR DESCRIPTION
Fixed two issues in `sdk-react`:

1.  Stopped event bubbling from `<Menu/>` when wrapped with `<Button/>`, ensuring that clicking on `<Menu/>` does not trigger `<Button/>` actions.
2.  Ensured `<ThemeSelect/>` remains open when switching between Light and Dark modes.