### PR TITLE
fix(proposal): auth demo query client provider

### DIFF
--- a/examples/with-nextjs-and-clerk-auth/src/app/layout.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/app/layout.tsx
@@ -3,8 +3,8 @@ import { ReactNode } from 'react';
 import { ClerkProvider, MultisessionAppSupport } from '@clerk/nextjs';
 
 import { RootQueryClientProvider } from '@/components/RootQueryClientProvider';
+import { RootThemeProvider } from '@/components/ThemeRegistry/RootThemeProvider';
 import { themeFont } from '@/components/ThemeRegistry/themeFont';
-import { ThemeRegistry } from '@/components/ThemeRegistry/ThemeRegistry';
 
 import './globals.css';
 
@@ -19,9 +19,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <MultisessionAppSupport>
         <html lang="en">
           <body className={themeFont.className}>
-            <ThemeRegistry>
+            <RootThemeProvider>
               <RootQueryClientProvider>{children}</RootQueryClientProvider>
-            </ThemeRegistry>
+            </RootThemeProvider>
           </body>
         </html>
       </MultisessionAppSupport>

--- a/examples/with-nextjs-and-clerk-auth/src/app/layout.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import { ClerkProvider, MultisessionAppSupport } from '@clerk/nextjs';
 
+import { RootQueryClientProvider } from '@/components/RootQueryClientProvider';
 import { themeFont } from '@/components/ThemeRegistry/themeFont';
 import { ThemeRegistry } from '@/components/ThemeRegistry/ThemeRegistry';
 
@@ -18,7 +19,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <MultisessionAppSupport>
         <html lang="en">
           <body className={themeFont.className}>
-            <ThemeRegistry>{children}</ThemeRegistry>
+            <ThemeRegistry>
+              <RootQueryClientProvider>{children}</RootQueryClientProvider>
+            </ThemeRegistry>
           </body>
         </html>
       </MultisessionAppSupport>

--- a/examples/with-nextjs-and-clerk-auth/src/app/regenerate-entity/RegenerateOrganizationEntity.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/app/regenerate-entity/RegenerateOrganizationEntity.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ReactNode, useState } from 'react';
+import { useState } from 'react';
 
 import NextLink from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -28,11 +28,7 @@ import {
   Snackbar,
   Typography,
 } from '@mui/material';
-import {
-  QueryClient,
-  QueryClientProvider,
-  useMutation,
-} from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 export const RegenerateOrganizationEntity = ({
   entity_user_id,
@@ -249,17 +245,6 @@ export const RegenerateOrganizationEntity = ({
         </Alert>
       </Snackbar>
     </Box>
-  );
-};
-
-export const RegenerateOrganizationEntityProvider = ({
-  children,
-}: {
-  children: ReactNode;
-}) => {
-  const [queryClient] = useState(() => new QueryClient());
-  return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
 };
 

--- a/examples/with-nextjs-and-clerk-auth/src/app/regenerate-entity/page.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/app/regenerate-entity/page.tsx
@@ -1,18 +1,13 @@
-import {
-  RegenerateOrganizationEntity,
-  RegenerateOrganizationEntityProvider,
-} from '@/app/regenerate-entity/RegenerateOrganizationEntity';
+import { RegenerateOrganizationEntity } from '@/app/regenerate-entity/RegenerateOrganizationEntity';
 import { getCurrentUserEntity } from '@/lib/clerk-api/get-current-user-entity';
 
 export default async function RegenerateEntityPage() {
   const { entity_user_id, entity_id } = await getCurrentUserEntity();
 
   return (
-    <RegenerateOrganizationEntityProvider>
-      <RegenerateOrganizationEntity
-        entity_id={entity_id}
-        entity_user_id={entity_user_id}
-      />
-    </RegenerateOrganizationEntityProvider>
+    <RegenerateOrganizationEntity
+      entity_id={entity_id}
+      entity_user_id={entity_user_id}
+    />
   );
 }

--- a/examples/with-nextjs-and-clerk-auth/src/components/RootQueryClientProvider.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/components/RootQueryClientProvider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { ReactNode, useState } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * Provides the QueryClient to the Root Application's TansTack Query Hooks.
+ * Does not affect the Monite SDK.
+ */
+export const RootQueryClientProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const [queryClient] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};

--- a/examples/with-nextjs-and-clerk-auth/src/components/ThemeRegistry/RootThemeProvider.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/components/ThemeRegistry/RootThemeProvider.tsx
@@ -8,7 +8,11 @@ import { ThemeProvider } from '@mui/material/styles';
 import NextAppDirEmotionCacheProvider from './EmotionCache';
 import { theme } from './theme';
 
-export function ThemeRegistry({ children }: { children: React.ReactNode }) {
+/**
+ * Provides the theme to the Root Application
+ * Does not affect the Monite SDK.
+ */
+export function RootThemeProvider({ children }: { children: React.ReactNode }) {
   return (
     <NextAppDirEmotionCacheProvider options={{ key: 'mui' }}>
       <ThemeProvider theme={theme}>


### PR DESCRIPTION
Added a standalone `QueryClientProvider` to the `Layout` for the Next.js demo application, replacing the inherited `QueryClientProvider` from Monite SDK to ensure proper functionality.