### PR TITLE
refactor(proposal): improve `<ReceivablesTable/>` ARIA usage 🧼

### DIFF
--- a/.changeset/tricky-turtles-sin.md
+++ b/.changeset/tricky-turtles-sin.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+feat(proposal): improve `<ReceivablesTable/>` ARIA usage


### PR DESCRIPTION
This PR proposes changes to the `<ReceivablesTable/>` component to improve its accessibility and ARIA compliance. 

**Key improvements:**

- **Fixes incorrect `aria-controls` references:**  each tab's element correctly references its corresponding tab panel using `aria-controls`.
- Introduces `role="tabpanel"` to each tab's content area to explicitly define them as interactive tab panels.
- Adds `aria-labelledby` to each tab panel
- Type names refactoring