### PR TITLE
feat(DEV-10391): support multiple translations for the same `msgstr` with different contexts ◈▣

### DIFF
--- a/.changeset/friendly-windows-compete.md
+++ b/.changeset/friendly-windows-compete.md
@@ -1,0 +1,8 @@
+---
+'@monite/sdk-react': minor
+---
+
+feat(DEV-10391): add support for multiple message contexts
+
+Adds support for multiple translations of the same message string (`msgstr`) based on different message
+contexts (`msgctxt`).

--- a/packages/sdk-react/src/core/context/MoniteI18nProvider.tsx
+++ b/packages/sdk-react/src/core/context/MoniteI18nProvider.tsx
@@ -26,8 +26,33 @@ export type MoniteLocale = {
   code?: string;
 
   /**
-   * `messages` responsible for internationalised Widgets translation.
-   * By default it uses `enLocaleMessages` as a fallback in MoniteProvider.
+   * Message` responsible for internationalised Widgets translation.
+   * By default, it uses `enLocaleMessages` as a fallback in MoniteProvider.
+   *
+   * The message object is a key-value pair where the key is the Message ID,
+   * and the value is the message string or a `LinguiContextMessage` object.
+   *
+   * If you need to use context (`msgctxt`) for differentiating messages with the same ID,
+   * you can use the LinguiContextMessage object.
+   *
+   * @example Without context:
+   * ```ts
+   * {
+   *   "Hello": "Hallo"
+   * }
+   * ```
+   *
+   * @example With the context:
+   * ```ts
+   * {
+   *   "View": [
+   *     { msgstr: "Rechnung ansehen", msgctxt: "InvoicesTableRowActionMenu" },
+   *     { msgstr: "Siehe" },
+   *   ]
+   * }
+   * ```
+   * In the example with context, `InvoicesTableRowActionMenu` is the context for the message "View".
+   * This can be useful when the same message ID needs to be translated differently in different contexts.
    */
   messages?: MoniteSupportedMessages;
 
@@ -128,7 +153,7 @@ const createDynamicI18nProvider = async (
 ) => {
   const [linguiCompiledMessages, dateFnsLocale] = await Promise.all([
     locale.messages
-      ? await compileLinguiDynamicMessages(locale.messages)
+      ? compileLinguiDynamicMessages(locale.messages)
       : Promise.resolve(),
     loadDateFnsLocale(locale.code),
   ]);

--- a/packages/sdk-react/src/utils/compile-lingui-dynamic-messages.test.ts
+++ b/packages/sdk-react/src/utils/compile-lingui-dynamic-messages.test.ts
@@ -1,29 +1,70 @@
-import { compileLinguiDynamicMessages } from '@/utils/compile-lingui-dynamic-messages';
+import {
+  compileLinguiDynamicMessages,
+  generateLinguiMessageId,
+} from '@/utils/compile-lingui-dynamic-messages';
 
 describe('compileLinguiDynamicMessages()', () => {
-  it('compiles dynamic messages with ICU MessageFormat', async () => {
-    expect(await compileLinguiDynamicMessages(plainMessages)).toEqual(
+  test('compiles dynamic messages with ICU MessageFormat', async () => {
+    expect(compileLinguiDynamicMessages(plainMessages)).toEqual(
       compiledMessages
     );
   });
 
-  it('keeps compiled ICU messages', async () => {
+  test('keeps compiled ICU messages', async () => {
     const compiledICUMessages = Object.fromEntries(
       Object.entries(compiledMessages).filter(
         ([, message]) => typeof message !== 'string'
       )
     );
-    expect(await compileLinguiDynamicMessages(compiledICUMessages)).toEqual(
+    expect(compileLinguiDynamicMessages(compiledICUMessages)).toEqual(
       compiledICUMessages
     );
   });
 
-  it('uses context for key hashing', async () => {
+  test('uses multiple context for key hashing', async () => {
     expect(
-      await compileLinguiDynamicMessages({
-        'Hey Monkeys!': { message: 'Hey Jirafs!', context: 'animals' },
+      compileLinguiDynamicMessages({
+        'Hey Monkeys!': [
+          { msgstr: 'Hey Jirafs!', msgctxt: 'animals' },
+          { msgstr: 'Hey Elephant!', msgctxt: 'giant-animals' },
+        ],
       })
-    ).toEqual({ sVfpdY: 'Hey Jirafs!', 'Hey Monkeys!': 'Hey Jirafs!' });
+    ).toEqual({
+      [generateLinguiMessageId('Hey Monkeys!', 'animals')]: 'Hey Jirafs!',
+      [generateLinguiMessageId('Hey Monkeys!', 'giant-animals')]:
+        'Hey Elephant!',
+    });
+  });
+
+  test('uses single context for key hashing', async () => {
+    expect(
+      compileLinguiDynamicMessages({
+        'Hey Monkeys!': { msgstr: 'Hey Jirafs!', msgctxt: 'animals' },
+      })
+    ).toEqual({
+      [generateLinguiMessageId('Hey Monkeys!', 'animals')]: 'Hey Jirafs!',
+    });
+  });
+
+  test('uses msgstr if no msgctxt specified', async () => {
+    expect(
+      compileLinguiDynamicMessages({
+        'ZIP code': { msgstr: 'My ZIP code' },
+      })
+    ).toEqual({
+      [generateLinguiMessageId('ZIP code', undefined)]: 'My ZIP code',
+      'ZIP code': 'My ZIP code',
+    });
+  });
+
+  test('hashes the "msgid" with the "msgctx"', async () => {
+    expect(generateLinguiMessageId('Hey Monkeys!', 'animals')).toEqual(
+      'sVfpdY'
+    );
+  });
+
+  test('hashes the "msgid" without the "msgctx"', async () => {
+    expect(generateLinguiMessageId('ZIP code', undefined)).toEqual('pVZUS0');
   });
 });
 
@@ -32,9 +73,11 @@ const plainMessages = {
     '{0, plural, zero {no monkeys} one {# monkey} two {# monkeys} few {# monkeys} many {# monkeys} other {# monkeys}}',
   'Counterpart Name': 'Contractor',
   'Hey {counters}!': 'Hey {counters}!',
+  'ZIP code': 'ZIP code',
 };
 
 const compiledMessages = {
+  // Hashed keys is the result of the `generateLinguiMessageId(...)` function
   NelGC6: [
     [
       '0',
@@ -46,6 +89,7 @@ const compiledMessages = {
         few: ['#', ' monkeys'],
         many: ['#', ' monkeys'],
         other: ['#', ' monkeys'],
+        offset: undefined,
       },
     ],
   ],
@@ -61,6 +105,7 @@ const compiledMessages = {
           few: ['#', ' monkeys'],
           many: ['#', ' monkeys'],
           other: ['#', ' monkeys'],
+          offset: undefined,
         },
       ],
     ],
@@ -68,4 +113,6 @@ const compiledMessages = {
   'Counterpart Name': 'Contractor',
   vjxzEb: ['Hey ', ['counters'], '!'],
   'Hey {counters}!': ['Hey ', ['counters'], '!'],
+  pVZUS0: 'ZIP code',
+  'ZIP code': 'ZIP code',
 };

--- a/packages/sdk-react/src/utils/compile-lingui-dynamic-messages.ts
+++ b/packages/sdk-react/src/utils/compile-lingui-dynamic-messages.ts
@@ -2,6 +2,9 @@ import { Messages } from '@lingui/core';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore-next-line
 import { compileMessage } from '@lingui/message-utils/compileMessage';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore-next-line
+import { generateMessageId } from '@lingui/message-utils/generateMessageId';
 
 export async function compileLinguiDynamicMessages<
   T extends { context: string; message: string } | string | object
@@ -52,33 +55,6 @@ const isMessageWithContext = (
   );
 };
 
-const UNIT_SEPARATOR = '\u001F';
-
 export async function generateLinguiMessageId(messageId: string, context = '') {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(messageId + UNIT_SEPARATOR + (context || ''));
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-  const hashArray = Array.from(new Uint8Array(hashBuffer));
-  return toBase64(hashArray).slice(0, 6);
-}
-
-export function toBase64(input: number[]) {
-  const characters =
-    // eslint-disable-next-line lingui/no-unlocalized-strings
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-  let result = '';
-  let pad = 0;
-  let current = 0;
-
-  for (let i = 0; i < input.length; i += 3) {
-    current = (input[i] << 16) | (input[i + 1] << 8) | input[i + 2];
-    pad = i + 1 < input.length ? (i + 2 < input.length ? 0 : 1) : 2;
-
-    result += characters[current >> 18];
-    result += characters[(current >> 12) & 63];
-    result += pad < 2 ? characters[(current >> 6) & 63] : '=';
-    result += pad < 1 ? characters[current & 63] : '=';
-  }
-
-  return result;
+  return generateMessageId(messageId, context);
 }


### PR DESCRIPTION
Intrducing support for multiple translations of the same `msgstr` (message string) based on different `msgctxt` (message context) values. This enhancement enables more accurate and nuanced translations, especially when the same phrase requires different translations depending on the context.

**Key changes:**

- **Updated `compileLinguDynamicMessages` function:** The function now handles an object where keys can be either plain strings representing `msgstr` or objects specifying both `msgstr` and `msgctxt`. For objects with multiple entries, each entry can have an optional `msgctxt` key to define a context-specific translation. This change aligns with the structure used in `.po` files, enabling better support for context-based translations.
- **Adopted `generateMessageId()` for context-aware message IDs:**  Instead of relying on our custom, we now leverage `generateMessageId(msgstr, msgctxt?)` from LinguiJS package, since the browser support has been added in _v4.6.0_.

**Example Usage (.po file):**
```po
#: src/components/receivables/InvoicesTable/useInvoiceRowActionMenuCell.tsx:154
msgctxt "InvoicesTableRowActionMenu"
msgid "View"
msgstr "View Invoice"

#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:123
msgid "View"
msgstr "View"
```

**Example Usage (end customer, no pre-compiled translations):**
```javascript
<MoniteProvider
  monite={monite}
  locale={{
    code: 'de-DE',
    messages: {
      Sales: {
        // single context translation
        msgstr: 'Vertrieb',
        msgctxt: 'InvoicesTableHeader', // translation for the context
      },
      Delete: { msgstr: 'Löschen' }, // object format without context
      View: [
        // multiple context translations
        {
          msgstr: 'Rechnung ansehen',
          msgctxt: 'InvoicesTableRowActionMenu', // translation for the context
        },
        {
          msgstr: 'Rechnung', // Normal transaltion without context
        },
      ],
      Counterpart: 'Gegenstück', // Plain translation
    },
  }}
>
  {children}
</MoniteProvider>
```

**Benefits:**

- More precise translations for phrases with context-dependent meanings.

~~**Breaking Changes:**~~

- This change does **not** introduce any breaking changes. Since we were not previously utilizing context-based translations, existing code and translation files will continue to function as expected.