### PR TITLE
fix(DEV-10942): filter invoices by Counterpart name in `<InvoicesTable/>` ▧

### DIFF
--- a/.changeset/sour-insects-rest.md
+++ b/.changeset/sour-insects-rest.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-api': patch
+---
+
+fix(DEV-10942): filter invoices by counterpart name in `<InvoicesTable/>`

--- a/packages/sdk-api/src/api/services/ReceivableService.ts
+++ b/packages/sdk-api/src/api/services/ReceivableService.ts
@@ -72,7 +72,7 @@ export class ReceivableService extends CommonService {
    * @param createdAtGte
    * @param createdAtLte
    * @param counterpartName
-   * @param counterpartNameContains
+   * @param counterpartId
    * @param counterpartNameIcontains
    * @param amount
    * @param amountGt
@@ -109,7 +109,7 @@ export class ReceivableService extends CommonService {
     createdAtGte?: string,
     createdAtLte?: string,
     counterpartName?: string,
-    counterpartNameContains?: string,
+    counterpartId?: string,
     counterpartNameIcontains?: string,
     amount?: number,
     amountGt?: number,
@@ -144,7 +144,7 @@ export class ReceivableService extends CommonService {
           created_at__gte: createdAtGte,
           created_at__lte: createdAtLte,
           counterpart_name: counterpartName,
-          counterpart_name__contains: counterpartNameContains,
+          counterpart_id: counterpartId,
           counterpart_name__icontains: counterpartNameIcontains,
           amount: amount,
           amount__gt: amountGt,


### PR DESCRIPTION
This PR addresses an issue in the `InvoiceTable` tab where the Counterpart filter was using the counterpart's name instead of ID.

**Testing:**

- Manually tested the Counterpart filter in the Invoices Table to confirm that it is now filtering by ID instead of name.