### PR TITLE
fix(proposal): display correct information for the "Fulfillment date" field in Invoice Details ⛽

### DIFF
--- a/.changeset/empty-dots-dress.md
+++ b/.changeset/empty-dots-dress.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+fix(DEV-10943): Invoice Details "Fulfillment date" output

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { MoniteCard } from '@/ui/Card/Card';
+import { DateTimeFormatOptions } from '@/utils/DateTimeFormatOptions';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import { InvoiceResponsePayload } from '@monite/sdk-api';
@@ -31,9 +32,12 @@ export const PreviewDetailsSection = ({
           },
           {
             label: t(i18n)`Fulfillment date`,
-            value:
-              invoice.counterpart_contact &&
-              `${invoice.counterpart_contact.first_name} ${invoice.counterpart_contact.last_name}`,
+            value: invoice.fulfillment_date
+              ? i18n.date(
+                  invoice.fulfillment_date,
+                  DateTimeFormatOptions.EightDigitDate
+                )
+              : '—',
             withEmptyStateFiller: true,
           },
           {


### PR DESCRIPTION
Update the "_Fulfillment date_" field in the Invoice Details component to display the correct date format. The previous implementation displayed contact details instead of the fulfillment date.

[📷 Fixed UI screenshot](https://github.com/team-monite/monite-sdk/assets/725645/e2b5517b-a0e3-46a8-9373-e141df3bfe44)
