### PR TITLE
fix(DEV-10643): fix pdf layout to have fixed pdf toolbar when scroll

### DIFF
--- a/.changeset/clean-taxis-push.md
+++ b/.changeset/clean-taxis-push.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+style(DEV-10643): fix pdf layout to have fixed pdf toolbar when scroll

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx
@@ -324,6 +324,7 @@ const ExistingInvoiceDetailsBase = (props: ExistingReceivableDetailsProps) => {
                 flexDirection: 'column',
                 justifyContent: 'center',
                 minHeight: 500,
+                height: '100%',
                 overflow: 'auto',
               }}
             >

--- a/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
+++ b/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
@@ -71,14 +71,14 @@ export const FileViewer = (props: FileViewerProps) => {
      */
     loadReactPDF()
       .then((components) => {
-        setReactPdfDynamic((prev) => ({
+        setReactPdfDynamic(() => ({
           components,
           error: null,
           loading: false,
         }));
       })
       .catch((error) => {
-        setReactPdfDynamic((prev) => {
+        setReactPdfDynamic(() => {
           const errorMessage = error.message;
           return {
             components: null,

--- a/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
+++ b/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
@@ -273,10 +273,7 @@ const FileViewerComponent = ({
           </Grid>
         </Grid>
       </Grid>
-      <Grid
-        container
-        sx={{ flex: '1 1 auto', overflow: 'auto', height: 'auto' }}
-      >
+      <Grid container sx={{ flex: '1 1 auto', overflow: 'auto', height: 0 }}>
         {renderFile()}
       </Grid>
     </>

--- a/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
+++ b/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useEffect, useState } from 'react';
-import { useMeasure } from 'react-use';
+import { useMeasure, useScrollbarWidth } from 'react-use';
 
 import { CenteredContentBox } from '@/ui/box';
 import { LoadingPage } from '@/ui/loadingPage';
@@ -161,6 +161,7 @@ const FileViewerComponent = ({
   onReloadCallback,
 }: FileViewerProps & AsyncReturnType<typeof loadReactPDF>) => {
   const [ref, { width }] = useMeasure<HTMLDivElement>();
+  const scrollbarWidth = useScrollbarWidth();
   const [numPages, setNumPages] = useState<number>(0);
   const [pageNumber, setPageNumber] = useState<number>(1);
   const [scale, setScale] = useState<number>(1);
@@ -202,7 +203,7 @@ const FileViewerComponent = ({
         >
           <Page
             pageNumber={pageNumber}
-            width={width}
+            width={scrollbarWidth ? width - scrollbarWidth : width}
             scale={scale}
             renderTextLayer={false}
             renderAnnotationLayer={false}
@@ -215,7 +216,7 @@ const FileViewerComponent = ({
 
   return (
     <>
-      <Grid container ref={ref}>
+      <Grid container ref={ref} flexWrap="nowrap">
         <Grid
           item
           container


### PR DESCRIPTION
<img width="857" alt="Screenshot 2024-05-29 at 08 15 03" src="https://github.com/team-monite/monite-sdk/assets/25366338/6970f298-eb9e-4d51-ae66-f285535c8d5f">
<img width="860" alt="Screenshot 2024-05-29 at 08 14 38" src="https://github.com/team-monite/monite-sdk/assets/25366338/8a6081dd-b3ff-49ba-975f-4b51196acd1c">
<img width="858" alt="Screenshot 2024-05-29 at 08 14 19" src="https://github.com/team-monite/monite-sdk/assets/25366338/4b6d68bd-dafe-4625-aa24-03ce940ccf3d">
