### PR TITLE
feat(DEV-10896): fix tables incorrect height calculation 📐

### DIFF
--- a/.changeset/silent-paws-divide.md
+++ b/.changeset/silent-paws-divide.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+feat(DEV-10896): fixed table height jumping and scrollbar issues during pagination by refactoring the theme props and adding `autoHeight` to `<DataGrid />`.

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/ApprovalPoliciesTable.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/ApprovalPoliciesTable.tsx
@@ -140,6 +140,7 @@ const ApprovalPoliciesTableBase = ({
           <Filters onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           sx={{
             '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': {

--- a/packages/sdk-react/src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx
@@ -260,6 +260,7 @@ const CounterpartsTableBase = ({
           />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           loading={isLoading}
           onRowClick={(params) => onRowClick?.(params.row.id)}

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
@@ -176,6 +176,7 @@ const PayablesTableBase = ({
           <FiltersComponent onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           loading={isLoading}
           onRowClick={(params) => {

--- a/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.tsx
+++ b/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.tsx
@@ -190,6 +190,7 @@ const ProductsTableBase = ({
           <FiltersComponent onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           rows={products?.data || []}
           onRowClick={(params) => {

--- a/packages/sdk-react/src/components/receivables/CreditNotesTable/CreditNotesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/CreditNotesTable/CreditNotesTable.tsx
@@ -120,6 +120,7 @@ const CreditNotesTableBase = ({ onRowClick }: CreditNotesTableProps) => {
           <Filters onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           loading={isLoading}
           sx={{

--- a/packages/sdk-react/src/components/receivables/InvoicesTable/InvoicesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoicesTable/InvoicesTable.tsx
@@ -135,6 +135,7 @@ const InvoicesTableBase = ({
           <Filters onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           loading={isLoading}
           sx={{

--- a/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.tsx
@@ -135,6 +135,7 @@ const QuotesTableBase = ({
           <Filters onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           loading={isLoading}
           sortModel={sortModel}

--- a/packages/sdk-react/src/components/tags/TagsTable/TagsTable.tsx
+++ b/packages/sdk-react/src/components/tags/TagsTable/TagsTable.tsx
@@ -134,6 +134,7 @@ const TagsTableBase = ({
         className={ScopedCssBaselineContainerClassName}
       >
         <DataGrid
+          autoHeight
           rowSelection={false}
           loading={isLoading}
           sortModel={sortModels}

--- a/packages/sdk-react/src/components/userRoles/UserRolesTable/UserRolesTable.tsx
+++ b/packages/sdk-react/src/components/userRoles/UserRolesTable/UserRolesTable.tsx
@@ -159,6 +159,7 @@ const UserRolesTableBase = ({
           <Filters onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid
+          autoHeight
           rowSelection={false}
           loading={isLoading}
           columns={[

--- a/packages/sdk-themes/src/themes/monite.ts
+++ b/packages/sdk-themes/src/themes/monite.ts
@@ -115,8 +115,6 @@ const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
       },
     },
     defaultProps: {
-      autoHeight: true,
-      hideFooterSelectedRowCount: true,
       disableColumnMenu: true,
       density: 'comfortable',
     },


### PR DESCRIPTION
Resolved the issue where tables jumped in height and scrollbars appeared during data loading when clicking on the pagination button. This refactor ensures a stable user experience by preventing height changes in tables across the application.

#### Changes

1.  Removed unneeded props from the `monite` theme.
2.  Added `autoHeight` prop usage to the `<DataGrid />` component to prevent incorrect height calculation of tables.

- [🐛 Screencast with the issue](https://github.com/team-monite/monite-sdk/assets/725645/5263cae6-c3b1-43f6-9d7f-5998248c5158)
- [🔧 Screencast with the **fixed** issue](https://github.com/team-monite/monite-sdk/assets/725645/f7a7497e-f5c3-4fec-91e3-f3c775968fc4)