### PR TITLE
fix(DEV-10644): prevent theme selector overlap when menu exceeds viewport height

### DIFF
--- a/.changeset/quick-cobras-visit.md
+++ b/.changeset/quick-cobras-visit.md
@@ -1,0 +1,5 @@
+---
+'@team-monite/sdk-demo': patch
+---
+
+fix(DEV-10644): prevent theme selector overlap when menu exceeds viewport height

--- a/packages/sdk-demo/src/components/Layout/index.tsx
+++ b/packages/sdk-demo/src/components/Layout/index.tsx
@@ -81,16 +81,11 @@ export const DefaultLayout = ({
               </Box>
             )}
           </Box>
-          <Menu />
-          <Box
-            sx={{
-              width: '100%',
-              position: 'absolute',
-              bottom: 0,
-              p: 2,
-            }}
-          >
-            <Stack direction="column" spacing={2} ml={2}>
+          <Box display="flex" sx={{ flex: 1 }}>
+            <Menu />
+          </Box>
+          <Box>
+            <Stack direction="column" spacing={2} mx={2} mb={2}>
               {/*Themes are unfinished.*/}
               {/*We want to show the theme switcher only in development mode and on the dev deployment only.*/}
               {isDev && (

--- a/packages/sdk-demo/src/components/Menu/index.tsx
+++ b/packages/sdk-demo/src/components/Menu/index.tsx
@@ -27,7 +27,7 @@ export const Menu = () => {
   };
 
   return (
-    <List>
+    <List sx={{ width: '100%' }}>
       {Object.keys(navigationData).map((key) => {
         const item = navigationData[key];
 


### PR DESCRIPTION
![image](https://github.com/team-monite/monite-sdk/assets/754498/f792661f-72f5-4609-9e55-0dff5010e353)
