### PR TITLE
fix(proposal): allow creation of Invoice containing products without `smallest_amount` 0️⃣

### DIFF
--- a/.changeset/eighty-boats-count.md
+++ b/.changeset/eighty-boats-count.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+fix(proposal): allow nullable `smallest_amount` to allow invoices creation for products without a defined minimum amount.

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts
@@ -75,7 +75,10 @@ const getLineItemsSchema = (i18n: I18n) =>
           .string()
           .label(t(i18n)`Measure unit`)
           .required(),
-        smallest_amount: yup.number().label(t(i18n)`Smallest amount`),
+        smallest_amount: yup
+          .number()
+          .nullable()
+          .label(t(i18n)`Smallest amount`),
       })
     )
     .min(1, t(i18n)`Please, add at least 1 item to proceed with this invoice`)


### PR DESCRIPTION
The `smallest_amount` field within `getLineItemsSchema(...)` was previously non-nullable, preventing Invoices from being created for products where this field is not applicable (e.g., has a `null` value). 

This PR makes the `smallest_amount` field nullable, allowing for Invoices to be created for all products regardless of whether they have a defined `smallest_amount`. 