### PR TITLE
fix(DEV-11506): prevent incorrect rendering of images in `<FileViewer />` 😶‍🌫️

### DIFF
--- a/.changeset/gold-avocados-join.md
+++ b/.changeset/gold-avocados-join.md
@@ -1,0 +1,8 @@
+---
+'@monite/sdk-react': patch
+---
+
+fix(DEV-11506): prevent PDFObject.embed() call for image URLs
+
+We've updated the file preview logic to skip calling `PDFObject.embed()` when the URL points to an image. This fix
+addresses an issue where attempting to embed image files as PDFs was causing errors or unexpected behavior.

--- a/packages/sdk-react/src/ui/FileViewer/FileViewer.test.tsx
+++ b/packages/sdk-react/src/ui/FileViewer/FileViewer.test.tsx
@@ -1,0 +1,29 @@
+import { FileViewer } from '@/ui/FileViewer/FileViewer';
+import { renderWithClient } from '@/utils/test-utils';
+import { screen } from '@testing-library/react';
+
+describe('FileViewer', () => {
+  test('renders image tag when mime type is an image', () => {
+    renderWithClient(
+      <FileViewer
+        url="test.jpg"
+        mimetype="image/jpeg"
+        name="test"
+        onReloadCallback={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'test.jpg');
+  });
+
+  test('renders iframe when mime type is an pdf', () => {
+    renderWithClient(
+      <FileViewer
+        url="test.pdf"
+        mimetype="application/pdf"
+        name="test"
+        onReloadCallback={jest.fn()}
+      />
+    );
+  });
+});

--- a/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
+++ b/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
@@ -67,9 +67,26 @@ export const FileViewer = ({
   name,
   onReloadCallback,
 }: FileViewerProps) => {
+  if (!url) return <ErrorComponent onError={onReloadCallback} />;
+
+  if (mimetype === 'application/pdf') return <PdfFileViewer url={url} />;
+
+  return (
+    <img
+      src={url}
+      alt={name}
+      loading="lazy"
+      style={{ width: '100%', objectFit: 'contain' }}
+    />
+  );
+};
+
+const PdfFileViewer = ({ url }: { url: string }) => {
   const pdfRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!pdfRef.current) return;
+
     PDFObject.embed(url, pdfRef.current, {
       fallbackLink: true,
       pdfOpenParams: {
@@ -83,23 +100,10 @@ export const FileViewer = ({
     });
   }, [url]);
 
-  if (!url) {
-    return <ErrorComponent onError={onReloadCallback} />;
-  }
-
-  const isPdf = mimetype === 'application/pdf';
-
-  const renderFile = () => {
-    if (isPdf) {
-      return (
-        <div
-          ref={pdfRef}
-          style={{ width: '100%', minHeight: '100%', border: 'none' }}
-        />
-      );
-    }
-    return <img src={url} alt={name} style={{ width: '100%' }} />;
-  };
-
-  return renderFile();
+  return (
+    <div
+      ref={pdfRef}
+      style={{ width: '100%', minHeight: '100%', border: 'none' }}
+    />
+  );
 };


### PR DESCRIPTION
## Problem
When an image was selected instead of a PDF for an invoice, the `PDFObject.embed()` function was still being called, even though the PDF container wasn't rendered. This caused the entire page content to be replaced with the image inside an iframe, as the `ref` wasn't properly set.

## Solution
We've refactored the `FileViewer` component to correctly handle different file types, particularly distinguishing between PDFs and images.

## Changes

- Added a check to prevent `PDFObject.embed()` calls for non-PDF files
- Implemented separate rendering logic for PDFs and images:
  - For PDFs: Use `PDFFileViewer` component
  - For images: Render a simple `<img />` tag with appropriate styling

## Impact
- Prevents unintended page content replacement when viewing non-PDF files
- Simplifies the codebase by removing redundant conditional checks

## Testing
Please test the following scenarios:
1. Uploading and viewing PDF files for invoices
2. Uploading and viewing image files for invoices
3. Switching between PDF invoice and image file invoice to ensure correct rendering
4. Checking that the page layout remains intact when viewing non-PDF files