### PR TITLE
feat(DEV-11167): implement receivables header styling

### DIFF
--- a/examples/with-nextjs-and-clerk-auth/src/components/Layout.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/components/Layout.tsx
@@ -36,7 +36,7 @@ export const Layout = ({ children }: { children: ReactNode }) => {
           />
         </Box>
       </Drawer>
-      <Box component="main" flexGrow={1} mx={3} my={1} minWidth={0}>
+      <Box component="main" flexGrow={1} minWidth={0} m={4}>
         {children}
       </Box>
     </Box>

--- a/examples/with-nextjs-and-clerk-auth/src/themes/monite.ts
+++ b/examples/with-nextjs-and-clerk-auth/src/themes/monite.ts
@@ -1,49 +1,15 @@
 import { createTheme } from '@mui/material';
 import type { Components } from '@mui/material/styles/components';
-import type {
-  Palette,
-  PaletteOptions,
-} from '@mui/material/styles/createPalette';
+import type { Palette } from '@mui/material/styles/createPalette';
 import type { Theme } from '@mui/material/styles/createTheme';
 import type { TypographyOptions } from '@mui/material/styles/createTypography';
 import { deepmerge } from '@mui/utils';
 import {
   moniteLight as baseMoniteLight,
   moniteDark as baseMoniteDark,
+  neutralLight,
+  neutralDark,
 } from '@team-monite/sdk-themes';
-
-const paletteLight: PaletteOptions = {
-  primary: {
-    dark: '#1D59CC',
-    main: '#3737FF',
-    light: '#F4F8FF',
-  },
-  background: {
-    menu: '#F1F2F5',
-    highlight: '#EBEBFF',
-  },
-  neutral: {
-    '10': '#111111',
-    '50': '#707070',
-    '80': '#DDDDDD',
-  },
-};
-
-const paletteDark: PaletteOptions = {
-  primary: {
-    dark: '#1D59CC',
-    main: '#3737FF',
-    light: '#F4F8FF',
-  },
-  background: {
-    menu: '#F1F2F505',
-  },
-  neutral: {
-    '80': '#B8B8B8',
-    '50': '#F3F3F3',
-    '10': '#FFFFFF',
-  },
-};
 
 const typography:
   | TypographyOptions
@@ -60,11 +26,6 @@ const typography:
     fontSize: '0.875rem',
     fontWeight: 500,
   },
-  h2: {
-    fontSize: 32,
-    fontStyle: 'normal',
-    fontWeight: 600,
-  },
   label2: {
     fontSize: '0.875rem',
     fontStyle: 'normal',
@@ -79,44 +40,23 @@ const typography:
 
 const typographyLight = deepmerge(typography, {
   body2: {
-    color: paletteLight.neutral && paletteLight.neutral['10'],
+    color: neutralLight['10'],
   },
   label3: {
-    color: paletteLight.neutral && paletteLight.neutral['50'],
+    color: neutralLight['50'],
   },
 });
 
 const typographyDark = deepmerge(typography, {
   body2: {
-    color: paletteDark.neutral && paletteDark.neutral['10'],
+    color: neutralDark['10'],
   },
   label3: {
-    color: paletteDark.neutral && paletteDark.neutral['80'],
+    color: neutralDark['80'],
   },
 });
 
 const components: Components<Omit<Theme, 'components'>> = {
-  MuiButton: {
-    styleOverrides: {
-      containedPrimary: {
-        padding: '6px 16px',
-        height: 40,
-        boxShadow: 'none',
-        borderRadius: 8,
-        fontSize: 16,
-        fontWeight: 500,
-      },
-
-      root: {
-        '&.ThemeSelect': {
-          borderRadius: 8,
-        },
-        '&.ThemeSelect .ThemeSelect-modeLabel': {
-          display: 'flex',
-        },
-      },
-    },
-  },
   MuiDrawer: {
     styleOverrides: {
       root: {
@@ -166,54 +106,11 @@ const components: Components<Omit<Theme, 'components'>> = {
       },
     },
   },
-  MuiTab: {
-    styleOverrides: {
-      root: {
-        fontSize: 14,
-        marginRight: 24,
-        color: paletteLight.neutral && paletteLight.neutral['50'],
-
-        '&.Mui-selected': {
-          color: paletteLight.neutral && paletteLight.neutral['10'],
-        },
-      },
-    },
-  },
-  MuiTabs: {
-    styleOverrides: {
-      root: {
-        marginBottom: 32,
-      },
-      indicator: {
-        height: 4,
-        backgroundColor: paletteLight.neutral && paletteLight.neutral['50'],
-        borderTopRightRadius: 8,
-        borderTopLeftRadius: 8,
-      },
-    },
-  },
 };
-
-const componentsDark = deepmerge(components, {
-  MuiTab: {
-    styleOverrides: {
-      root: {
-        color: paletteDark.neutral && paletteDark.neutral['80'],
-        '&.Mui-selected': { color: 'primary.main' },
-      },
-    },
-  },
-  MuiTabs: {
-    styleOverrides: {
-      indicator: { backgroundColor: 'primary.main' },
-    },
-  },
-});
 
 export const moniteLight = () =>
   createTheme(
     deepmerge(baseMoniteLight, {
-      palette: paletteLight,
       typography: typographyLight,
       components,
     })
@@ -222,8 +119,7 @@ export const moniteLight = () =>
 export const moniteDark = () =>
   createTheme(
     deepmerge(baseMoniteDark, {
-      palette: paletteDark,
       typography: typographyDark,
-      components: componentsDark,
+      components,
     })
   );

--- a/examples/with-nextjs-and-clerk-auth/src/themes/monite.ts
+++ b/examples/with-nextjs-and-clerk-auth/src/themes/monite.ts
@@ -60,6 +60,11 @@ const typography:
     fontSize: '0.875rem',
     fontWeight: 500,
   },
+  h2: {
+    fontSize: 32,
+    fontStyle: 'normal',
+    fontWeight: 600,
+  },
   label2: {
     fontSize: '0.875rem',
     fontStyle: 'normal',
@@ -91,6 +96,27 @@ const typographyDark = deepmerge(typography, {
 });
 
 const components: Components<Omit<Theme, 'components'>> = {
+  MuiButton: {
+    styleOverrides: {
+      containedPrimary: {
+        padding: '6px 16px',
+        height: 40,
+        boxShadow: 'none',
+        borderRadius: 8,
+        fontSize: 16,
+        fontWeight: 500,
+      },
+
+      root: {
+        '&.ThemeSelect': {
+          borderRadius: 8,
+        },
+        '&.ThemeSelect .ThemeSelect-modeLabel': {
+          display: 'flex',
+        },
+      },
+    },
+  },
   MuiDrawer: {
     styleOverrides: {
       root: {
@@ -131,18 +157,6 @@ const components: Components<Omit<Theme, 'components'>> = {
       },
     },
   },
-  MuiButton: {
-    styleOverrides: {
-      root: {
-        '&.ThemeSelect': {
-          borderRadius: 8,
-        },
-        '&.ThemeSelect .ThemeSelect-modeLabel': {
-          display: 'flex',
-        },
-      },
-    },
-  },
   MuiPopover: {
     styleOverrides: {
       paper: {
@@ -152,7 +166,49 @@ const components: Components<Omit<Theme, 'components'>> = {
       },
     },
   },
+  MuiTab: {
+    styleOverrides: {
+      root: {
+        fontSize: 14,
+        marginRight: 24,
+        color: paletteLight.neutral && paletteLight.neutral['50'],
+
+        '&.Mui-selected': {
+          color: paletteLight.neutral && paletteLight.neutral['10'],
+        },
+      },
+    },
+  },
+  MuiTabs: {
+    styleOverrides: {
+      root: {
+        marginBottom: 32,
+      },
+      indicator: {
+        height: 4,
+        backgroundColor: paletteLight.neutral && paletteLight.neutral['50'],
+        borderTopRightRadius: 8,
+        borderTopLeftRadius: 8,
+      },
+    },
+  },
 };
+
+const componentsDark = deepmerge(components, {
+  MuiTab: {
+    styleOverrides: {
+      root: {
+        color: paletteDark.neutral && paletteDark.neutral['80'],
+        '&.Mui-selected': { color: 'primary.main' },
+      },
+    },
+  },
+  MuiTabs: {
+    styleOverrides: {
+      indicator: { backgroundColor: 'primary.main' },
+    },
+  },
+});
 
 export const moniteLight = () =>
   createTheme(
@@ -168,6 +224,6 @@ export const moniteDark = () =>
     deepmerge(baseMoniteDark, {
       palette: paletteDark,
       typography: typographyDark,
-      components,
+      components: componentsDark,
     })
   );

--- a/packages/sdk-themes/src/index.ts
+++ b/packages/sdk-themes/src/index.ts
@@ -1,10 +1,12 @@
 export {
-  moniteLight,
-  moniteDark,
-  paletteDark,
-  paletteLight,
   defaultMoniteComponents,
   defaultMoniteTypography,
+  moniteDark,
+  moniteLight,
+  neutralDark,
+  neutralLight,
+  paletteDark,
+  paletteLight,
 } from './themes/monite.js';
 
 export { materialLight, materialDark } from './themes/material.js';

--- a/packages/sdk-themes/src/themes/monite.ts
+++ b/packages/sdk-themes/src/themes/monite.ts
@@ -9,6 +9,24 @@ import type { TypographyOptions } from '@mui/material/styles/createTypography.js
 import { deepmerge } from '@mui/utils';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
+const primaryLight = {
+  dark: '#1D59CC',
+  main: '#3737FF',
+  light: '#F4F8FF',
+  lightest: '#F4F4FE',
+};
+
+const primaryDark = {
+  dark: '#1D59CC',
+  main: '#3737FF',
+  light: '#12129E',
+  lightest: '#0C0C40',
+};
+
+const secondary = {
+  main: '#707070',
+};
+
 export const neutralLight = {
   '10': '#111111',
   '50': '#707070',
@@ -21,26 +39,26 @@ export const neutralDark = {
   '80': '#B8B8B8',
 };
 
+export const neutralTransparentLight = {
+  '50': '#0000008F',
+  '80': '#00000021',
+  '90': '#0000000D',
+};
+
+export const neutralTransparentDark = {
+  '50': '#9595958F',
+  '80': '#FFFFFF21',
+  '90': '#FFFFFF0D',
+};
+
 export const paletteLight: PaletteOptions = {
-  primary: {
-    dark: '#1D59CC',
-    main: '#3737FF',
-    light: '#F4F8FF',
-  },
-  secondary: {
-    main: '#707070',
-  },
+  primary: primaryLight,
+  secondary,
 };
 
 export const paletteDark: PaletteOptions = {
-  primary: {
-    dark: '#1D59CC',
-    main: '#3737FF',
-    light: '#F4F8FF',
-  },
-  secondary: {
-    main: '#707070',
-  },
+  primary: primaryDark,
+  secondary,
 };
 
 export const defaultMoniteTypography:
@@ -183,12 +201,36 @@ export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
   MuiTab: {
     styleOverrides: {
       root: {
+        position: 'relative',
         fontSize: 14,
+        fontWeight: 700,
         marginRight: 24,
-        color: neutralLight['50'],
+        color: neutralTransparentLight['50'],
+        padding: '10px 40px',
+        borderRadius: 10,
+        overflow: 'visible',
+
+        '&:active': {
+          backgroundColor: neutralTransparentLight['90'],
+        },
+
+        '&:after': {
+          position: 'absolute',
+          display: 'block',
+          content: '""',
+          backgroundColor: 'transparent',
+          width: '100%',
+          height: 4,
+          bottom: 0,
+          borderRadius: 10,
+        },
+
+        '&:hover:after': {
+          backgroundColor: neutralTransparentLight['50'],
+        },
 
         '&.Mui-selected': {
-          color: neutralLight['10'],
+          backgroundColor: primaryLight.lightest,
         },
       },
     },
@@ -196,13 +238,14 @@ export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
   MuiTabs: {
     styleOverrides: {
       root: {
+        borderBottomColor: neutralTransparentLight['80'],
+        borderBottomStyle: 'solid',
+        borderBottomWidth: 1,
         marginBottom: 32,
       },
       indicator: {
         height: 4,
-        backgroundColor: neutralLight['50'],
-        borderTopRightRadius: 8,
-        borderTopLeftRadius: 8,
+        borderRadius: 10,
       },
     },
   },
@@ -252,14 +295,16 @@ const defaultMoniteComponentsDark = deepmerge(defaultMoniteComponents, {
   MuiTab: {
     styleOverrides: {
       root: {
-        color: neutralDark['80'],
-        '&.Mui-selected': { color: 'primary.main' },
+        color: neutralTransparentDark['50'],
+        '&:active': { backgroundColor: neutralTransparentDark['90'] },
+        '&:hover:after': { backgroundColor: neutralTransparentDark['50'] },
+        '&.Mui-selected': { backgroundColor: primaryDark.lightest },
       },
     },
   },
   MuiTabs: {
     styleOverrides: {
-      indicator: { backgroundColor: 'primary.main' },
+      root: { borderBottomColor: neutralTransparentDark['80'] },
     },
   },
 });

--- a/packages/sdk-themes/src/themes/monite.ts
+++ b/packages/sdk-themes/src/themes/monite.ts
@@ -6,12 +6,26 @@ import type {
 } from '@mui/material/styles/createPalette.js';
 import type { Theme, ThemeOptions } from '@mui/material/styles/createTheme.js';
 import type { TypographyOptions } from '@mui/material/styles/createTypography.js';
+import { deepmerge } from '@mui/utils';
 import type {} from '@mui/x-data-grid/themeAugmentation';
+
+export const neutralLight = {
+  '10': '#111111',
+  '50': '#707070',
+  '80': '#DDDDDD',
+};
+
+export const neutralDark = {
+  '10': '#FFFFFF',
+  '50': '#F3F3F3',
+  '80': '#B8B8B8',
+};
 
 export const paletteLight: PaletteOptions = {
   primary: {
-    main: '#246FFF',
-    light: '#F4F4FE',
+    dark: '#1D59CC',
+    main: '#3737FF',
+    light: '#F4F8FF',
   },
   secondary: {
     main: '#707070',
@@ -20,8 +34,9 @@ export const paletteLight: PaletteOptions = {
 
 export const paletteDark: PaletteOptions = {
   primary: {
-    main: '#f5d14d',
-    light: '#e1e1ef',
+    dark: '#1D59CC',
+    main: '#3737FF',
+    light: '#F4F8FF',
   },
   secondary: {
     main: '#707070',
@@ -42,6 +57,7 @@ export const defaultMoniteTypography:
   },
   h3: {
     fontSize: '1.5rem',
+    fontStyle: 'normal',
     fontWeight: 600,
   },
   subtitle2: {
@@ -71,6 +87,27 @@ export const defaultMoniteTypography:
 };
 
 export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
+  MuiButton: {
+    styleOverrides: {
+      containedPrimary: {
+        padding: '6px 16px',
+        height: 40,
+        boxShadow: 'none',
+        borderRadius: 8,
+        fontSize: 16,
+        fontWeight: 500,
+      },
+
+      root: {
+        '&.ThemeSelect': {
+          borderRadius: 8,
+        },
+        '&.ThemeSelect .ThemeSelect-modeLabel': {
+          display: 'flex',
+        },
+      },
+    },
+  },
   MuiTypography: {
     styleOverrides: {
       subtitle2: {
@@ -143,6 +180,32 @@ export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
       variant: 'outlined',
     },
   },
+  MuiTab: {
+    styleOverrides: {
+      root: {
+        fontSize: 14,
+        marginRight: 24,
+        color: neutralLight['50'],
+
+        '&.Mui-selected': {
+          color: neutralLight['10'],
+        },
+      },
+    },
+  },
+  MuiTabs: {
+    styleOverrides: {
+      root: {
+        marginBottom: 32,
+      },
+      indicator: {
+        height: 4,
+        backgroundColor: neutralLight['50'],
+        borderTopRightRadius: 8,
+        borderTopLeftRadius: 8,
+      },
+    },
+  },
   MuiTableHead: {
     styleOverrides: {
       root: {
@@ -185,6 +248,22 @@ export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
   },
 };
 
+const defaultMoniteComponentsDark = deepmerge(defaultMoniteComponents, {
+  MuiTab: {
+    styleOverrides: {
+      root: {
+        color: neutralDark['80'],
+        '&.Mui-selected': { color: 'primary.main' },
+      },
+    },
+  },
+  MuiTabs: {
+    styleOverrides: {
+      indicator: { backgroundColor: 'primary.main' },
+    },
+  },
+});
+
 export const moniteLight: ThemeOptions = {
   palette: {
     mode: 'light',
@@ -200,5 +279,5 @@ export const moniteDark: ThemeOptions = {
     ...paletteDark,
   },
   typography: defaultMoniteTypography,
-  components: defaultMoniteComponents,
+  components: defaultMoniteComponentsDark,
 };

--- a/packages/sdk-themes/src/themes/monite.ts
+++ b/packages/sdk-themes/src/themes/monite.ts
@@ -10,17 +10,17 @@ import { deepmerge } from '@mui/utils';
 import type {} from '@mui/x-data-grid/themeAugmentation';
 
 const primaryLight = {
-  dark: '#1D59CC',
-  main: '#3737FF',
-  light: '#F4F8FF',
-  lightest: '#F4F4FE',
+  '30': '#2E2EE5',
+  '50': '#3737FF',
+  '60': '#9999FF',
+  '95': '#F4F4FE',
 };
 
 const primaryDark = {
-  dark: '#1D59CC',
-  main: '#3737FF',
-  light: '#12129E',
-  lightest: '#0C0C40',
+  '30': '#4545E8',
+  '50': '#3737FF',
+  '60': '#12129E',
+  '95': '#0C0C40',
 };
 
 const secondary = {
@@ -52,12 +52,20 @@ export const neutralTransparentDark = {
 };
 
 export const paletteLight: PaletteOptions = {
-  primary: primaryLight,
+  primary: {
+    dark: primaryLight['30'],
+    main: primaryLight['50'],
+    light: primaryLight['60'],
+  },
   secondary,
 };
 
 export const paletteDark: PaletteOptions = {
-  primary: primaryDark,
+  primary: {
+    dark: primaryDark['30'],
+    main: primaryDark['50'],
+    light: primaryDark['60'],
+  },
   secondary,
 };
 
@@ -108,12 +116,22 @@ export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
   MuiButton: {
     styleOverrides: {
       containedPrimary: {
-        padding: '6px 16px',
-        height: 40,
+        padding: '12px 20px',
         boxShadow: 'none',
         borderRadius: 8,
         fontSize: 16,
         fontWeight: 500,
+        backgroundColor: primaryLight['50'],
+
+        '&:hover': {
+          boxShadow: 'none',
+          backgroundColor: primaryLight['60'],
+        },
+
+        '&:active': {
+          boxShadow: 'none',
+          backgroundColor: primaryLight['30'],
+        },
       },
 
       root: {
@@ -230,7 +248,7 @@ export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
         },
 
         '&.Mui-selected': {
-          backgroundColor: primaryLight.lightest,
+          backgroundColor: primaryLight['95'],
         },
       },
     },
@@ -298,7 +316,7 @@ const defaultMoniteComponentsDark = deepmerge(defaultMoniteComponents, {
         color: neutralTransparentDark['50'],
         '&:active': { backgroundColor: neutralTransparentDark['90'] },
         '&:hover:after': { backgroundColor: neutralTransparentDark['50'] },
-        '&.Mui-selected': { backgroundColor: primaryDark.lightest },
+        '&.Mui-selected': { backgroundColor: primaryDark['95'] },
       },
     },
   },


### PR DESCRIPTION
Adds Monite styling for `h3`, `<Tabs />` and ` <Button variant="contained" variant="primary" />` components:

![image](https://github.com/team-monite/monite-sdk/assets/754498/f6fa000b-7407-4ec4-a79c-751eec4df294)

![image](https://github.com/team-monite/monite-sdk/assets/754498/61cfd75c-2236-46a8-8cb1-fd602103a94a)

Material UI theme is unaffected.