### PR TITLE
feat(DEV-11864): Implement Counterpart Contacts generation for demo data to enable Payment Reminders

### DIFF
--- a/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/bank-account.ts
+++ b/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/bank-account.ts
@@ -78,33 +78,3 @@ export const createBankAccount = async ({
 
   return data;
 };
-
-export const getBankAccounts = async ({
-  token,
-  entity_id,
-}: {
-  token: AccessToken;
-  entity_id: string;
-}) => {
-  const { GET } = createMoniteClient(token);
-
-  const { data, error, response } = await GET('/bank_accounts', {
-    params: {
-      header: {
-        'x-monite-entity-id': entity_id,
-        'x-monite-version': getMoniteApiVersion(),
-      },
-    },
-  });
-
-  if (error) {
-    console.error(
-      `Failed to get Bank Account for the entity_id: "${entity_id}"`,
-      `x-request-id: ${response.headers.get('x-request-id')}`
-    );
-
-    throw new Error(`Bank account fetch failed: ${JSON.stringify(error)}`);
-  }
-
-  return data.data;
-};

--- a/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/counterparts.ts
+++ b/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/counterparts.ts
@@ -11,11 +11,10 @@ import {
   demoBankAccountBICList,
   chooseRandomCountryForDataGeneration,
 } from '@/lib/monite-api/demo-data-generator/seed-values';
-import { AccessToken } from '@/lib/monite-api/fetch-token';
 import {
-  createMoniteClient,
   getEntity,
   getMoniteApiVersion,
+  MoniteClient,
 } from '@/lib/monite-api/monite-client';
 import { components } from '@/lib/monite-api/schema';
 
@@ -23,8 +22,19 @@ type CounterpartBankAccountResponse =
   components['schemas']['CounterpartBankAccountResponse'];
 type CounterpartVatIDResponse =
   components['schemas']['CounterpartVatIDResponse'];
+type CounterpartResponse = components['schemas']['CounterpartResponse'];
+type EntityOrganizationResponse =
+  components['schemas']['EntityOrganizationResponse'];
+type CounterpartContactResponse =
+  components['schemas']['CounterpartContactResponse'];
 type VatIDTypeEnum = components['schemas']['VatIDTypeEnum'];
 type AllowedCountries = components['schemas']['AllowedCountries'];
+
+const counterpartCountries = [
+  'DE',
+  'US',
+  'GB',
+] satisfies Array<AllowedCountries>;
 
 interface ICounterpartsBuilderOptions {
   counterparts: {
@@ -57,10 +67,21 @@ interface ICounterpartsBuilderOptions {
     enabled: boolean;
     count: number;
   };
+
+  contacts: {
+    /**
+     * Create counterparts with contacts
+     *
+     * By default, it is true, and contacts will be created
+     *  for the counterparts
+     */
+    enabled: boolean;
+    count: number;
+  };
 }
 
-interface IConterpartsServiceResponse {
-  counterparts: Array<components['schemas']['CounterpartResponse']>;
+interface ICounterpartsServiceResponse {
+  counterparts: Array<CounterpartResponse>;
 }
 
 export class CounterpartsService extends GeneralService {
@@ -76,6 +97,10 @@ export class CounterpartsService extends GeneralService {
       enabled: true,
       count: 2,
     },
+    contacts: {
+      enabled: true,
+      count: 1,
+    },
   };
 
   public withOptions(options: Partial<ICounterpartsBuilderOptions>): this {
@@ -87,9 +112,10 @@ export class CounterpartsService extends GeneralService {
     return this;
   }
 
-  public async create(): Promise<IConterpartsServiceResponse> {
-    const counterparts: Array<components['schemas']['CounterpartResponse']> =
-      [];
+  public async create(): Promise<ICounterpartsServiceResponse> {
+    const counterparts: Array<CounterpartResponse> = [];
+    const moniteClient = this.request;
+
     for (
       let counterpartsIndex = 0;
       counterpartsIndex < this.options.counterparts.count;
@@ -104,7 +130,7 @@ export class CounterpartsService extends GeneralService {
       );
 
       const counterpart = await createCounterpart({
-        token: this.token,
+        moniteClient,
         entity_id: this.entityId,
       });
 
@@ -134,18 +160,22 @@ export class CounterpartsService extends GeneralService {
         );
 
         const counterpart = counterparts[counterpartIndex];
-        await createCounterpartBankAccount({
-          is_default_for_currency: true,
-          counterpart_id: counterpart.id,
-          token: this.token,
-          entity_id: this.entityId,
-        })
-          .then((counterpartBankAccount) => {
-            counterpartBankAccounts.push(counterpartBankAccount);
-          })
-          .catch((error) => {
-            console.error(error);
+        try {
+          const counterpartBankAccount = await createCounterpartBankAccount({
+            moniteClient,
+            is_default_for_currency: true,
+            counterpart_id: counterpart.id,
+            entity_id: this.entityId,
           });
+          counterpartBankAccounts.push(counterpartBankAccount);
+        } catch (error) {
+          console.error(
+            chalk.redBright.bgBlack(
+              '❌ Error when creating a counterpart bank account'
+            ),
+            error
+          );
+        }
       }
     }
 
@@ -161,9 +191,7 @@ export class CounterpartsService extends GeneralService {
 
     const entity = await getEntity(this.request, this.entityId);
 
-    const counterpartVats: Array<
-      components['schemas']['CounterpartVatIDResponse']
-    > = [];
+    const counterpartVats: Array<CounterpartVatIDResponse> = [];
     for (
       let counterpartsIndex = 0;
       counterpartsIndex < counterparts.length;
@@ -183,17 +211,21 @@ export class CounterpartsService extends GeneralService {
         );
 
         const counterpart = counterparts[counterpartsIndex];
-        await createCounterpartVatId({
-          counterpart_id: counterpart.id,
-          token: this.token,
-          entity,
-        })
-          .then((counterpartVat) => {
-            counterpartVats.push(counterpartVat);
-          })
-          .catch((error) => {
-            console.error(error);
+        try {
+          const counterpartVat = await createCounterpartVatId({
+            moniteClient,
+            counterpart_id: counterpart.id,
+            entity,
           });
+          counterpartVats.push(counterpartVat);
+        } catch (error) {
+          console.error(
+            chalk.redBright.bgBlack(
+              '❌ Error when creating a counterpart vat id'
+            ),
+            error
+          );
+        }
       }
     }
 
@@ -203,6 +235,54 @@ export class CounterpartsService extends GeneralService {
       console.error(chalk.black.bgYellow(`❌ Counterparts vats list is empty`));
     }
 
+    const counterpartContacts: Array<CounterpartContactResponse> = [];
+    for (
+      let counterpartsIndex = 0;
+      counterpartsIndex < counterparts.length;
+      counterpartsIndex++
+    ) {
+      for (
+        let contactIndex = 0;
+        contactIndex < this.options.contacts.count;
+        contactIndex++
+      ) {
+        console.log(
+          chalk.bgBlueBright(
+            ` - Creating Contact for (${counterpartsIndex + 1}) counterpart (${
+              contactIndex + 1
+            }/${this.options.contacts.count})`
+          )
+        );
+
+        const counterpart = counterparts[counterpartsIndex];
+        try {
+          const counterpartContact = await createCounterpartContact({
+            moniteClient,
+            counterpart_id: counterpart.id,
+            entity,
+          });
+          counterpartContacts.push(counterpartContact);
+        } catch (error) {
+          console.error(
+            chalk.redBright.bgBlack(
+              '❌ Error when creating a counterpart contact'
+            ),
+            error
+          );
+        }
+      }
+    }
+
+    if (counterpartContacts.length) {
+      console.log(
+        chalk.black.bgGreenBright(`✅ Counterparts contacts created 👤`)
+      );
+    } else {
+      console.error(
+        chalk.black.bgYellow(`❌ Counterparts contacts list is empty`)
+      );
+    }
+
     return {
       counterparts,
     };
@@ -210,18 +290,16 @@ export class CounterpartsService extends GeneralService {
 }
 
 export const createCounterpart = async ({
-  token,
+  moniteClient,
   entity_id,
 }: {
-  token: AccessToken;
+  moniteClient: MoniteClient;
   entity_id: string;
-}): Promise<components['schemas']['CounterpartResponse']> => {
-  const { POST } = createMoniteClient(token);
-
+}): Promise<CounterpartResponse> => {
   const is_vendor = faker.datatype.boolean();
   const addressCountries = ['DE'] satisfies Array<AllowedCountries>;
 
-  const { data, error, response } = await POST('/counterparts', {
+  const { data, error, response } = await moniteClient.POST('/counterparts', {
     params: {
       header: {
         'x-monite-entity-id': entity_id,
@@ -263,23 +341,85 @@ export const createCounterpart = async ({
   return data;
 };
 
-export const createCounterpartVatId = async ({
+const orgEmailDomain = (legalName: string) => {
+  let result = '';
+  for (let c of legalName) {
+    c = c.toLowerCase();
+    if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) result += c;
+    else result += '-';
+  }
+  return result + '.com';
+};
+
+export const createCounterpartContact = async ({
+  moniteClient,
   counterpart_id,
   entity,
-  token,
 }: {
+  moniteClient: MoniteClient;
+  counterpart_id: string;
+  entity: EntityOrganizationResponse;
+}): Promise<CounterpartContactResponse> => {
+  const isMale = Math.random() >= 0.5;
+  const sex = isMale ? 'male' : 'female';
+  const firstName = faker.person.firstName(sex);
+  const lastName = faker.person.lastName(sex);
+  const emailDomain = orgEmailDomain(entity.organization.legal_name);
+
+  const payload = {
+    first_name: firstName,
+    last_name: lastName,
+    email: faker.internet.email({
+      firstName,
+      lastName,
+      provider: emailDomain,
+    }),
+    phone: faker.phone.number(),
+    address: entity.address,
+    title: isMale ? 'Mr.' : 'Ms.',
+  } as components['schemas']['CreateCounterpartContactPayload'];
+  const { data, error, response } = await moniteClient.POST(
+    '/counterparts/{counterpart_id}/contacts',
+    {
+      params: {
+        path: {
+          counterpart_id,
+        },
+        header: {
+          'x-monite-version': getMoniteApiVersion(),
+          'x-monite-entity-id': entity.id,
+        },
+      },
+      body: payload,
+    }
+  );
+
+  if (error) {
+    console.error(
+      `Failed to create Contact for the counterpart_id: "${counterpart_id}" in the entity_id: "${entity.id}"`,
+      `x-request-id: ${response.headers.get('x-request-id')}`
+    );
+
+    throw new Error(`Contact creation failed: ${JSON.stringify(error)}`);
+  }
+
+  return data;
+};
+
+export const createCounterpartVatId = async ({
+  moniteClient,
+  counterpart_id,
+  entity,
+}: {
+  moniteClient: MoniteClient;
   counterpart_id: string;
   entity: { id: string; address: { country: string } };
-  token: AccessToken;
 }): Promise<CounterpartVatIDResponse> => {
-  const { POST } = createMoniteClient(token);
-
   const value = String(faker.number.int(10_000));
-  const addressCountries = ['DE', 'US', 'GB'] satisfies Array<AllowedCountries>;
-  const counterpartCountry = getRandomItemFromArray(addressCountries);
+  const counterpartCountry = getRandomItemFromArray(counterpartCountries);
   const vatIdType = getVatIdType(entity.address.country, counterpartCountry);
 
-  const { data, error, response } = await POST(
+  const { data, error, response } = await moniteClient.POST(
     '/counterparts/{counterpart_id}/vat_ids',
     {
       params: {
@@ -312,22 +452,20 @@ export const createCounterpartVatId = async ({
 };
 
 export const createCounterpartBankAccount = async ({
+  moniteClient,
   is_default_for_currency,
   counterpart_id,
   entity_id,
-  token,
 }: {
+  moniteClient: MoniteClient;
   is_default_for_currency: true;
   counterpart_id: string;
   entity_id: string;
-  token: AccessToken;
 }): Promise<CounterpartBankAccountResponse> => {
-  const { POST } = createMoniteClient(token);
-
   const countryCode = chooseRandomCountryForDataGeneration();
   const currency = bankCountriesToCurrencies[countryCode];
 
-  const { data, error, response } = await POST(
+  const { data, error, response } = await moniteClient.POST(
     '/counterparts/{counterpart_id}/bank_accounts',
     {
       params: {

--- a/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/generate-payables.ts
+++ b/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/generate-payables.ts
@@ -5,6 +5,7 @@ import { faker } from '@faker-js/faker';
 import {
   createCounterpart,
   createCounterpartBankAccount,
+  createCounterpartContact,
   createCounterpartVatId,
 } from '@/lib/monite-api/demo-data-generator/counterparts';
 import {
@@ -14,7 +15,11 @@ import {
   PayableCounterpart,
 } from '@/lib/monite-api/demo-data-generator/payables';
 import { AccessToken } from '@/lib/monite-api/fetch-token';
-import { createMoniteClient, getEntity } from '@/lib/monite-api/monite-client';
+import {
+  createMoniteClient,
+  MoniteClient,
+  getEntity,
+} from '@/lib/monite-api/monite-client';
 
 export const generateCounterpartsWithPayables = async (
   {
@@ -52,7 +57,7 @@ export const generateCounterpartsWithPayables = async (
 
     try {
       const counterpart = await createCounterpart({
-        token,
+        moniteClient,
         entity_id,
       });
 
@@ -61,7 +66,7 @@ export const generateCounterpartsWithPayables = async (
       const counterpart_bank_account = await createCounterpartBankAccount({
         is_default_for_currency: true,
         counterpart_id: counterpart.id,
-        token,
+        moniteClient,
         entity_id,
       });
 
@@ -69,7 +74,7 @@ export const generateCounterpartsWithPayables = async (
 
       const vat = await createCounterpartVatId({
         counterpart_id: counterpart.id,
-        token,
+        moniteClient,
         entity,
       });
 
@@ -82,6 +87,22 @@ export const generateCounterpartsWithPayables = async (
             currency: counterpart_bank_account.currency,
           },
         });
+
+        if (counterpart.type == 'organization') {
+          console.log(chalk.green('- Creating Counterpart Contact'));
+
+          await createCounterpartContact({
+            counterpart_id: counterpart.id,
+            moniteClient,
+            entity,
+          });
+        } else {
+          console.log(
+            chalk.blue(
+              "- Skipping Contact creation because the counterpart isn't an organization"
+            )
+          );
+        }
 
         logger?.({ message: 'Generating counterparts...' });
       } else {
@@ -104,7 +125,7 @@ export const generateCounterpartsWithPayables = async (
   for (let payableIndex = 0; payableIndex < payable_count; payableIndex++) {
     try {
       await generatePayableWithLineItems({
-        token,
+        moniteClient,
         entity_id,
         counterparts,
       });
@@ -133,7 +154,7 @@ const generatePayableWithLineItems = async (
     ...entityParams
   }: {
     entity_id: string;
-    token: AccessToken;
+    moniteClient: MoniteClient;
     counterparts: PayableCounterpart[];
   },
   {

--- a/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/payables.ts
+++ b/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/demo-data-generator/payables.ts
@@ -2,10 +2,9 @@ import chalk from 'chalk';
 
 import { faker } from '@faker-js/faker';
 
-import { AccessToken } from '@/lib/monite-api/fetch-token';
 import {
-  createMoniteClient,
   getMoniteApiVersion,
+  MoniteClient,
 } from '@/lib/monite-api/monite-client';
 import { components } from '@/lib/monite-api/schema';
 
@@ -19,17 +18,15 @@ export type PayableCounterpart = {
 };
 
 export const createPayable = async ({
+  moniteClient,
   counterpart: { counterpart_bank, ...counterpart },
   entity_id,
-  token,
 }: {
+  moniteClient: MoniteClient;
   counterpart: PayableCounterpart;
   entity_id: string;
-  token: AccessToken;
 }) => {
-  const { POST } = createMoniteClient(token);
-
-  const { data, error, response } = await POST('/payables', {
+  const { data, error, response } = await moniteClient.POST('/payables', {
     params: {
       header: {
         'x-monite-version': getMoniteApiVersion(),
@@ -60,16 +57,14 @@ export const createPayable = async ({
 };
 
 export const createPayableLineItems = async ({
+  moniteClient,
   payable_id,
   entity_id,
-  token,
 }: {
+  moniteClient: MoniteClient;
   payable_id: string;
   entity_id: string;
-  token: AccessToken;
 }) => {
-  const { POST } = createMoniteClient(token);
-
   const quantity = faker.number.int({ min: 1, max: 10 });
   const unit_price = 100 * faker.number.int({ min: 150, max: 80000 });
   const tax = 100 * faker.number.int({ min: 1, max: 35 });
@@ -80,7 +75,7 @@ export const createPayableLineItems = async ({
     )
   );
 
-  const { data, error, response } = await POST(
+  const { data, error, response } = await moniteClient.POST(
     '/payables/{payable_id}/line_items',
     {
       params: {
@@ -117,17 +112,15 @@ export const createPayableLineItems = async ({
 };
 
 export const approvePayablePaymentOperation = async ({
+  moniteClient,
   payable_id,
   entity_id,
-  token,
 }: {
+  moniteClient: MoniteClient;
   payable_id: string;
   entity_id: string;
-  token: AccessToken;
 }) => {
-  const { POST } = createMoniteClient(token);
-
-  const { data, error, response } = await POST(
+  const { data, error, response } = await moniteClient.POST(
     '/payables/{payable_id}/approve_payment_operation',
     {
       params: {


### PR DESCRIPTION
**Objective**

Enhance the demo data generation process in the sdk-demo-with-nextjs-and-clerk-auth project to include the creation of Counterpart Contacts for organization-type Counterparts, specifically to enable the demonstration of Payment Reminders functionality.

**Background**

Currently, our demo data generation process creates Counterparts but does not generate associated Contacts. This limitation prevents us from showcasing the Payment Reminders feature, as reminders are sent to the email address of the counterpart's default contact (stored in the counterpart_contact.email field of the invoice).