### PR TITLE
fix(DEV-11735): do not call "Submit Invoice" when saving Payable 💾🪲

### DIFF
--- a/.changeset/spotty-rules-shave.md
+++ b/.changeset/spotty-rules-shave.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+fix: remove unnecessary `submitInvoice` in "Save" invoice action

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx
@@ -57,7 +57,6 @@ export const PayableDetailsHeader = ({
       variant: 'contained',
       form: 'payableDetailsForm',
       type: 'submit',
-      onClick: submitInvoice,
       children: t(i18n)`Save`,
     },
     cancelEdit: {


### PR DESCRIPTION
Removed the unnecessary `submitInvoice` call in the "Save" invoice action to streamline the Invoice saving process.