### PR TITLE
fix(DEV-11940): add error message for onboarding endpoints

### DIFF
--- a/packages/sdk-react/src/core/utils/getLegacyAPIErrorMessage.tsx
+++ b/packages/sdk-react/src/core/utils/getLegacyAPIErrorMessage.tsx
@@ -24,4 +24,15 @@ export function getLegacyAPIErrorMessage(err: unknown): string | undefined {
   ) {
     return err.message;
   }
+
+  if (typeof err === 'object' && err !== null && 'error' in err) {
+    if (
+      typeof err.error === 'object' &&
+      err.error !== null &&
+      'message' in err.error &&
+      typeof err.error.message === 'string'
+    ) {
+      return err.error.message;
+    }
+  }
 }


### PR DESCRIPTION

added error message parsing for onboarding endpoints  


before:
<img width="252" alt="Screenshot 2024-07-23 at 12 20 32 PM" src="https://github.com/user-attachments/assets/84da20f1-e0d3-42a9-9199-b87eb7b966fd">

after:
<img width="470" alt="Screenshot 2024-07-23 at 12 16 40 PM" src="https://github.com/user-attachments/assets/fd508b43-5db3-42e1-8b60-514347f696fa">
