### PR TITLE
fix(DEV-11937): fix mobile date picker for web component

### DIFF
--- a/.changeset/quick-moons-push.md
+++ b/.changeset/quick-moons-push.md
@@ -1,0 +1,6 @@
+---
+'@monite/sdk-drop-in': patch
+'@monite/sdk-react': patch
+---
+
+fix(onboarding): fix mobile DatePicker for web component

--- a/.changeset/warm-pets-applaud.md
+++ b/.changeset/warm-pets-applaud.md
@@ -1,0 +1,5 @@
+---
+'@team-monite/eslint-plugin': patch
+---
+
+feat(rules): add new rule for slotProps

--- a/packages/eslint-plugin/src/rules/mui-require-container-property.ts
+++ b/packages/eslint-plugin/src/rules/mui-require-container-property.ts
@@ -37,25 +37,6 @@ const ruleModule: RuleModule<string, Options> = {
               },
             },
           },
-          slotPropsDialogContainerPropertyMissing: {
-            description:
-              'List of components that have to match to "<Comp slotProps={{ dialog: { container } }} />"',
-            type: 'array',
-            items: {
-              type: 'object',
-              required: ['component', 'import'],
-              properties: {
-                component: {
-                  type: 'string',
-                  description: 'Component name',
-                },
-                import: {
-                  type: 'string',
-                  description: 'Import name',
-                },
-              },
-            },
-          },
           containerPropertyMissing: {
             description:
               'List of components that have to match to "<Comp container={} />"',
@@ -128,8 +109,6 @@ const ruleModule: RuleModule<string, Options> = {
     messages: {
       slotPropsPopperContainerPropertyMissing:
         'Component {{component}} must have `slotProps={{ popper: { container } }}` property specified.',
-      slotPropsDialogContainerPropertyMissing:
-        'Component {{component}} must have `slotProps={{ dialog: { container } }}` property specified.',
       containerPropertyMissing:
         'Component {{component}} must have `container` property with the specified.',
       menuPropsContainerPropertyMissing:
@@ -144,11 +123,6 @@ const ruleModule: RuleModule<string, Options> = {
       slotPropsPopperContainerPropertyMissing: [
         { component: 'DatePicker', import: '@mui/x-date-pickers' },
         { component: 'Autocomplete', import: '@mui/material' },
-      ],
-
-      // <Comp slotProps={{ dialog: { container } }} />
-      slotPropsDialogContainerPropertyMissing: [
-        { component: 'DatePicker', import: '@mui/x-date-pickers' },
       ],
 
       // <Comp MenuProps={{ container }} />
@@ -298,56 +272,6 @@ const ruleModule: RuleModule<string, Options> = {
             return context.report({
               node,
               messageId: 'slotPropsPopperContainerPropertyMissing',
-              data: { component: componentName },
-            });
-          }
-        }
-
-        const slotPropsDialogContainerPropertyMissingComponentItem =
-          componentsByRule.slotPropsDialogContainerPropertyMissing.find(
-            ({ component }) =>
-              component === muiImportedComponents[componentName]
-          );
-
-        if (slotPropsDialogContainerPropertyMissingComponentItem) {
-          const slotPropsAttribute = jsxOpeningElementNode.attributes.find(
-            (attribute) =>
-              attribute.type === 'JSXAttribute' &&
-              attribute.name.name === 'slotProps' // finds jsx props `<Comp slotProps={} />`
-          );
-
-          if (
-            !slotPropsAttribute ||
-            !('value' in slotPropsAttribute) ||
-            slotPropsAttribute.value.type !== 'JSXExpressionContainer'
-          ) {
-            return context.report({
-              node: node,
-              messageId: 'slotPropsDialogContainerPropertyMissing',
-              data: { component: componentName },
-            });
-          }
-
-          const slotPropsExpression = slotPropsAttribute.value.expression;
-          if (
-            slotPropsExpression.type !== 'ObjectExpression' ||
-            !slotPropsExpression.properties.some(
-              (prop) =>
-                prop.type === 'Property' &&
-                prop.key.type === 'Identifier' &&
-                prop.key.name === 'dialog' && // finds `<Comp slotProps={{ dialog }} />`
-                prop.value.type === 'ObjectExpression' &&
-                prop.value.properties.some(
-                  (innerProp) =>
-                    innerProp.type === 'Property' &&
-                    innerProp.key.type === 'Identifier' &&
-                    innerProp.key.name === 'container' // finds `<Comp slotProps={{ dialog: { container } }} />`
-                )
-            )
-          ) {
-            return context.report({
-              node,
-              messageId: 'slotPropsDialogContainerPropertyMissing',
               data: { component: componentName },
             });
           }
@@ -504,7 +428,6 @@ type Option = {
 
 type Options = Record<
   | 'slotPropsPopperContainerPropertyMissing'
-  | 'slotPropsDialogContainerPropertyMissing'
   | 'containerPropertyMissing'
   | 'menuPropsContainerPropertyMissing'
   | 'selectPropsMenuPropsContainerPropertyMissing',

--- a/packages/eslint-plugin/src/rules/mui-require-container-property.ts
+++ b/packages/eslint-plugin/src/rules/mui-require-container-property.ts
@@ -37,6 +37,25 @@ const ruleModule: RuleModule<string, Options> = {
               },
             },
           },
+          slotPropsDialogContainerPropertyMissing: {
+            description:
+              'List of components that have to match to "<Comp slotProps={{ dialog: { container } }} />"',
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['component', 'import'],
+              properties: {
+                component: {
+                  type: 'string',
+                  description: 'Component name',
+                },
+                import: {
+                  type: 'string',
+                  description: 'Import name',
+                },
+              },
+            },
+          },
           containerPropertyMissing: {
             description:
               'List of components that have to match to "<Comp container={} />"',
@@ -109,6 +128,8 @@ const ruleModule: RuleModule<string, Options> = {
     messages: {
       slotPropsPopperContainerPropertyMissing:
         'Component {{component}} must have `slotProps={{ popper: { container } }}` property specified.',
+      slotPropsDialogContainerPropertyMissing:
+        'Component {{component}} must have `slotProps={{ dialog: { container } }}` property specified.',
       containerPropertyMissing:
         'Component {{component}} must have `container` property with the specified.',
       menuPropsContainerPropertyMissing:
@@ -123,6 +144,11 @@ const ruleModule: RuleModule<string, Options> = {
       slotPropsPopperContainerPropertyMissing: [
         { component: 'DatePicker', import: '@mui/x-date-pickers' },
         { component: 'Autocomplete', import: '@mui/material' },
+      ],
+
+      // <Comp slotProps={{ dialog: { container } }} />
+      slotPropsDialogContainerPropertyMissing: [
+        { component: 'DatePicker', import: '@mui/x-date-pickers' },
       ],
 
       // <Comp MenuProps={{ container }} />
@@ -272,6 +298,56 @@ const ruleModule: RuleModule<string, Options> = {
             return context.report({
               node,
               messageId: 'slotPropsPopperContainerPropertyMissing',
+              data: { component: componentName },
+            });
+          }
+        }
+
+        const slotPropsDialogContainerPropertyMissingComponentItem =
+          componentsByRule.slotPropsDialogContainerPropertyMissing.find(
+            ({ component }) =>
+              component === muiImportedComponents[componentName]
+          );
+
+        if (slotPropsDialogContainerPropertyMissingComponentItem) {
+          const slotPropsAttribute = jsxOpeningElementNode.attributes.find(
+            (attribute) =>
+              attribute.type === 'JSXAttribute' &&
+              attribute.name.name === 'slotProps' // finds jsx props `<Comp slotProps={} />`
+          );
+
+          if (
+            !slotPropsAttribute ||
+            !('value' in slotPropsAttribute) ||
+            slotPropsAttribute.value.type !== 'JSXExpressionContainer'
+          ) {
+            return context.report({
+              node: node,
+              messageId: 'slotPropsDialogContainerPropertyMissing',
+              data: { component: componentName },
+            });
+          }
+
+          const slotPropsExpression = slotPropsAttribute.value.expression;
+          if (
+            slotPropsExpression.type !== 'ObjectExpression' ||
+            !slotPropsExpression.properties.some(
+              (prop) =>
+                prop.type === 'Property' &&
+                prop.key.type === 'Identifier' &&
+                prop.key.name === 'dialog' && // finds `<Comp slotProps={{ dialog }} />`
+                prop.value.type === 'ObjectExpression' &&
+                prop.value.properties.some(
+                  (innerProp) =>
+                    innerProp.type === 'Property' &&
+                    innerProp.key.type === 'Identifier' &&
+                    innerProp.key.name === 'container' // finds `<Comp slotProps={{ dialog: { container } }} />`
+                )
+            )
+          ) {
+            return context.report({
+              node,
+              messageId: 'slotPropsDialogContainerPropertyMissing',
               data: { component: componentName },
             });
           }
@@ -428,6 +504,7 @@ type Option = {
 
 type Options = Record<
   | 'slotPropsPopperContainerPropertyMissing'
+  | 'slotPropsDialogContainerPropertyMissing'
   | 'containerPropertyMissing'
   | 'menuPropsContainerPropertyMissing'
   | 'selectPropsMenuPropsContainerPropertyMissing',

--- a/packages/eslint-plugin/src/tests/rules/mui-require-container-property.test.ts
+++ b/packages/eslint-plugin/src/tests/rules/mui-require-container-property.test.ts
@@ -19,7 +19,7 @@ ruleTester.run<string, readonly unknown[]>(
     valid: [
       {
         code: `import { DatePickerCustom as MyDatePicker } from '@mui/material';
-               <MyDatePicker slotProps={{ popper: { container: root } }} />`,
+               <MyDatePicker slotProps={{ popper: { container: root }, dialog: { container: root } }} />`,
         options: [
           {
             slotPropsPopperContainerPropertyMissing: [
@@ -36,7 +36,7 @@ ruleTester.run<string, readonly unknown[]>(
       },
       {
         code: `import { DatePicker } from '@mui/x-date-pickers';
-               <DatePicker slotProps={{ popper: { container: root } }} />`,
+               <DatePicker slotProps={{ popper: { container: root }, dialog: { container: root } }} />`,
       },
       {
         code: `import { DatePicker } from 'my-custom-mui-datepicker';
@@ -54,7 +54,10 @@ ruleTester.run<string, readonly unknown[]>(
                    popper: {
                      id: 'date-picker',
                      container: root
-                   }
+                   },
+                   dialog: {
+                     container: root
+                   },
                  }}
                  views={['year', 'month', 'day']}
                />`,
@@ -121,6 +124,16 @@ ruleTester.run<string, readonly unknown[]>(
         code: `import { DatePicker } from '@mui/x-date-pickers';
                <DatePicker />`,
         errors: [{ messageId: 'slotPropsPopperContainerPropertyMissing' }],
+      },
+      {
+        code: `import { DatePicker } from '@mui/x-date-pickers';
+               <DatePicker slotProps={{ popper: { container: root } }} />`,
+        errors: [{ messageId: 'slotPropsDialogContainerPropertyMissing' }],
+      },
+      {
+        code: `import { DatePicker } from '@mui/x-date-pickers';
+               <DatePicker slotProps={{ popper: { container: root }, dialog: {} }} />`,
+        errors: [{ messageId: 'slotPropsDialogContainerPropertyMissing' }],
       },
       {
         code: `import { Select } from '@mui/material';

--- a/packages/eslint-plugin/src/tests/rules/mui-require-container-property.test.ts
+++ b/packages/eslint-plugin/src/tests/rules/mui-require-container-property.test.ts
@@ -19,11 +19,15 @@ ruleTester.run<string, readonly unknown[]>(
     valid: [
       {
         code: `import { DatePickerCustom as MyDatePicker } from '@mui/material';
-               <MyDatePicker slotProps={{ popper: { container: root }, dialog: { container: root } }} />`,
+               <MyDatePicker slotProps={{ popperCustom: { container: root }, dialogCustom: { container: root } }} />`,
         options: [
           {
             slotPropsPopperContainerPropertyMissing: [
-              { component: 'DatePickerCustom', import: '@mui/material' },
+              {
+                component: 'DatePickerCustom',
+                import: '@mui/material',
+                slotProps: ['popperCustom', 'dialogCustom'],
+              },
             ],
           },
         ],
@@ -39,6 +43,10 @@ ruleTester.run<string, readonly unknown[]>(
                <DatePicker slotProps={{ popper: { container: root }, dialog: { container: root } }} />`,
       },
       {
+        code: `import { Autocomplete } from '@mui/material';
+               <Autocomplete slotProps={{ popper: { container: root } }} />`,
+      },
+      {
         code: `import { DatePicker } from 'my-custom-mui-datepicker';
                <DatePicker />`,
       },
@@ -48,19 +56,14 @@ ruleTester.run<string, readonly unknown[]>(
            <Menu {...config.menuProps} />`,
       },
       {
-        code: `import { DatePicker } from '@mui/x-date-pickers';
-               <DatePicker
-                 slotProps={{
-                   popper: {
-                     id: 'date-picker',
-                     container: root
-                   },
-                   dialog: {
-                     container: root
-                   },
-                 }}
-                 views={['year', 'month', 'day']}
-               />`,
+        code: `
+        import { DatePicker } from '@mui/x-date-pickers';
+        <DatePicker
+          slotProps={{
+            popper: { container: root },
+            dialog: { container: root },
+          }}
+        />`,
       },
       {
         code: `import { Select } from '@mui/material';
@@ -97,15 +100,24 @@ ruleTester.run<string, readonly unknown[]>(
       },
       {
         code: `import { DatePickerCustom } from '@mui/x-date-pickers';
-               <DatePickerCustom />`,
+               <DatePickerCustom slotProps={{ popper: { container: root } }} />`,
         errors: [{ messageId: 'slotPropsPopperContainerPropertyMissing' }],
         options: [
           {
             slotPropsPopperContainerPropertyMissing: [
-              { component: 'DatePickerCustom', import: '@mui/x-date-pickers' },
+              {
+                component: 'DatePickerCustom',
+                import: '@mui/x-date-pickers',
+                slotProps: ['popper', 'dialog'],
+              },
             ],
           },
         ],
+      },
+      {
+        code: `import { Autocomplete } from '@mui/material';
+               <Autocomplete slotProps={{ }} />`,
+        errors: [{ messageId: 'slotPropsPopperContainerPropertyMissing' }],
       },
       {
         code: `import { DatePicker } from '@mui/x-date-pickers';
@@ -126,14 +138,12 @@ ruleTester.run<string, readonly unknown[]>(
         errors: [{ messageId: 'slotPropsPopperContainerPropertyMissing' }],
       },
       {
-        code: `import { DatePicker } from '@mui/x-date-pickers';
-               <DatePicker slotProps={{ popper: { container: root } }} />`,
-        errors: [{ messageId: 'slotPropsDialogContainerPropertyMissing' }],
-      },
-      {
-        code: `import { DatePicker } from '@mui/x-date-pickers';
-               <DatePicker slotProps={{ popper: { container: root }, dialog: {} }} />`,
-        errors: [{ messageId: 'slotPropsDialogContainerPropertyMissing' }],
+        code: `
+          import { DatePicker } from '@mui/x-date-pickers';
+          <DatePicker
+            slotProps={{ popper: { container: root } }}
+          />`,
+        errors: [{ messageId: 'slotPropsPopperContainerPropertyMissing' }],
       },
       {
         code: `import { Select } from '@mui/material';

--- a/packages/sdk-react/src/components/RHF/RHFDatePicker/RHFDatePicker.tsx
+++ b/packages/sdk-react/src/components/RHF/RHFDatePicker/RHFDatePicker.tsx
@@ -44,6 +44,9 @@ export const RHFDatePicker = <T extends FieldValues>({
                   ...slotProps?.popper,
                   container: root,
                 },
+                dialog: {
+                  container: root,
+                },
                 textField: {
                   ...slotProps?.textField,
                   id: name,

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/Filters/Filters.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/Filters/Filters.tsx
@@ -43,6 +43,9 @@ export const Filters = (props: Props) => {
             popper: {
               container: root,
             },
+            dialog: {
+              container: root,
+            },
             actionBar: {
               actions: ['clear', 'today'],
             },

--- a/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsFilter/ApprovalRequestsFilter.tsx
+++ b/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsFilter/ApprovalRequestsFilter.tsx
@@ -88,6 +88,9 @@ export const ApprovalRequestsFilter = ({ onChangeFilter }: FilterProps) => {
               popper: {
                 container: root,
               },
+              dialog: {
+                container: root,
+              },
               actionBar: {
                 actions: ['clear', 'today'],
               },

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -360,6 +360,7 @@ const PayableDetailsFormBase = forwardRef<
                               maxDate={currentDueDate}
                               slotProps={{
                                 popper: { container: root },
+                                dialog: { container: root },
                                 actionBar: {
                                   actions: ['clear', 'today'],
                                 },
@@ -386,6 +387,7 @@ const PayableDetailsFormBase = forwardRef<
                             minDate={currentInvoiceDate}
                             slotProps={{
                               popper: { container: root },
+                              dialog: { container: root },
                               actionBar: {
                                 actions: ['clear', 'today'],
                               },

--- a/packages/sdk-react/src/components/payables/PayablesTable/Filters/Filters.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/Filters/Filters.tsx
@@ -78,6 +78,9 @@ export const Filters = ({ onChangeFilter }: Props) => {
             popper: {
               container: root,
             },
+            dialog: {
+              container: root,
+            },
             actionBar: {
               actions: ['clear', 'today'],
             },
@@ -97,6 +100,9 @@ export const Filters = ({ onChangeFilter }: Props) => {
           }}
           slotProps={{
             popper: {
+              container: root,
+            },
+            dialog: {
               container: root,
             },
             actionBar: {

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx
@@ -180,6 +180,9 @@ export const EntitySection = ({ disabled, hidden }: EntitySectionProps) => {
                         popper: {
                           container: root,
                         },
+                        dialog: {
+                          container: root,
+                        },
                         actionBar: {
                           actions: ['today'],
                         },

--- a/packages/sdk-react/src/components/receivables/ReceivableFilters/ReceivableFilters.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivableFilters/ReceivableFilters.tsx
@@ -133,6 +133,9 @@ export const ReceivableFilters = ({
               popper: {
                 container: root,
               },
+              dialog: {
+                container: root,
+              },
               actionBar: {
                 actions: ['clear', 'today'],
               },

--- a/packages/sdk-react/src/components/userRoles/UserRolesTable/Filters/Filters.tsx
+++ b/packages/sdk-react/src/components/userRoles/UserRolesTable/Filters/Filters.tsx
@@ -46,6 +46,9 @@ export const Filters = ({ onChangeFilter }: FiltersProps) => {
             popper: {
               container: root,
             },
+            dialog: {
+              container: root,
+            },
             actionBar: {
               actions: ['clear', 'today'],
             },

--- a/packages/sdk-react/src/core/context/MoniteI18nProvider.test.tsx
+++ b/packages/sdk-react/src/core/context/MoniteI18nProvider.test.tsx
@@ -141,7 +141,13 @@ describe('MoniteI18nProvider DatePicker', () => {
   test('should render "DE" format in DatePicker', async () => {
     renderWithClient(
       <SpecificI18nLoader code="de-DE">
-        <DatePicker open slotProps={{ popper: { container: null } }} />
+        <DatePicker
+          open
+          slotProps={{
+            popper: { container: null },
+            dialog: { container: null },
+          }}
+        />
       </SpecificI18nLoader>
     );
 
@@ -154,7 +160,13 @@ describe('MoniteI18nProvider DatePicker', () => {
   test('should render "US" format in DatePicker', async () => {
     renderWithClient(
       <SpecificI18nLoader code="en-US">
-        <DatePicker open slotProps={{ popper: { container: null } }} />
+        <DatePicker
+          open
+          slotProps={{
+            popper: { container: null },
+            dialog: { container: null },
+          }}
+        />
       </SpecificI18nLoader>
     );
 


### PR DESCRIPTION
before:
<img width="426" alt="Screenshot 2024-07-24 at 3 30 46 PM" src="https://github.com/user-attachments/assets/0f061775-e4a6-4722-9a82-18b1006638fc">

after:
<img width="407" alt="Screenshot 2024-07-24 at 3 29 44 PM" src="https://github.com/user-attachments/assets/3e1279f2-12db-4e24-be3f-9c8917e2d98b">

+ added eslint plugin rule
+ fixed for other DatePickers
