### PR TITLE
feat(DEV-11928): enhanced Counterpart Handling for Payables with OCR processing 🤖

### DIFF
--- a/.changeset/dirty-peas-drop.md
+++ b/.changeset/dirty-peas-drop.md
@@ -1,0 +1,10 @@
+---
+'@monite/sdk-react': minor
+---
+
+feat(DEV-11928): introduced icon states to indicate the status of Counterparts for Payables processed via OCR.
+
+- **State 1**: Counterpart not found in the system.
+- **State 2**: Counterpart found but not selected in the document.
+- Added two images to illustrate these states with appropriate color indications.
+- Note: If a Counterpart is already selected for the Payable, no icon will be displayed.

--- a/.changeset/sixty-hats-deliver.md
+++ b/.changeset/sixty-hats-deliver.md
@@ -1,0 +1,7 @@
+---
+'@monite/sdk-react': minor
+---
+
+feat(DEV-11928): implemented automatic selection of Counterparts for Payables processed via OCR in the editing form.
+
+- If a Counterpart is not selected for a Payable after file upload and OCR processing, it will be auto-selected if available.

--- a/packages/sdk-react/src/components/counterparts/helpers.ts
+++ b/packages/sdk-react/src/components/counterparts/helpers.ts
@@ -40,7 +40,9 @@ export function getIndividualName(
   return `${first_name?.trim() ?? ''} ${last_name?.trim() ?? ''}`.trim();
 }
 
-export function getCounterpartName(counterpart?: CounterpartResponse): string {
+export function getCounterpartName(
+  counterpart: CounterpartResponse | undefined
+): string {
   if (!counterpart) {
     return '';
   }

--- a/packages/sdk-react/src/components/counterparts/heplers.test.tsx
+++ b/packages/sdk-react/src/components/counterparts/heplers.test.tsx
@@ -1,4 +1,11 @@
-import { getIndividualName } from '@/components/counterparts/helpers';
+import {
+  getCounterpartName,
+  getIndividualName,
+} from '@/components/counterparts/helpers';
+import {
+  counterpartIndividualFixture,
+  counterpartOrganizationFixture,
+} from '@/mocks';
 
 describe('counterparts helpers', () => {
   test('# getIndividualName(...) matches the expected behavior', () => {
@@ -24,5 +31,45 @@ describe('counterparts helpers', () => {
         last_name: ' Last ',
       })
     ).toBe('Last');
+  });
+
+  test('# getCounterpartName(...)', () => {
+    expect(getCounterpartName(counterpartOrganizationFixture)).toBe(
+      counterpartOrganizationFixture.organization.legal_name
+    );
+
+    expect(getCounterpartName(counterpartIndividualFixture)).toBe(
+      `${counterpartIndividualFixture.individual.first_name} ${counterpartIndividualFixture.individual.last_name}`
+    );
+
+    expect(
+      getCounterpartName({
+        ...counterpartOrganizationFixture,
+        organization: {
+          ...counterpartOrganizationFixture.organization,
+          legal_name: '',
+        },
+      })
+    ).toBe('');
+
+    expect(
+      getCounterpartName({
+        ...counterpartIndividualFixture,
+        individual: {
+          ...counterpartIndividualFixture.individual,
+          first_name: '',
+          last_name: '',
+        },
+      })
+    ).toBe('');
+
+    expect(
+      getCounterpartName(
+        // @ts-expect-error - checking invalid payload without `individual` or `organization` properties
+        {}
+      )
+    ).toBe('');
+
+    expect(getCounterpartName(undefined)).toBe('');
   });
 });

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetails.test.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetails.test.tsx
@@ -26,7 +26,6 @@ import userEvent from '@testing-library/user-event';
 
 import { format } from 'date-fns';
 
-import { payablesDefaultQueryConfig } from '../consts';
 import { PayableDataTestId } from '../types';
 import { PayableDetails } from './PayableDetails';
 
@@ -598,7 +597,7 @@ describe('PayableDetails', () => {
 
         const newDocumentId = changeDocumentIdByPayableId(payableId);
 
-        jest.advanceTimersByTime(payablesDefaultQueryConfig.refetchInterval);
+        jest.advanceTimersByTime(15_000);
 
         const newDocumentIdElement = await screen.findByDisplayValue(
           newDocumentId

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx
@@ -100,10 +100,6 @@ const PayableDetailsInfoBase = ({
   const { data: approvalPolicy, isLoading: isApprovalPolicyLoading } =
     useApprovalPolicyById(payable.approval_policy_id);
 
-  const counterpartName = getCounterpartName(counterpart);
-
-  //    '—';
-
   const defaultContact = useMemo(
     () => contacts?.data.find((contact) => contact.is_default),
     [contacts]

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx
@@ -3,24 +3,29 @@ import React, { useMemo } from 'react';
 import { components } from '@/api';
 import { ScopedCssBaselineContainerClassName } from '@/components/ContainerCssBaseline';
 import {
+  getCounterpartName,
   getIndividualName,
-  isIndividualCounterpart,
-  isOrganizationCounterpart,
 } from '@/components/counterparts/helpers';
 import { UserAvatar } from '@/components/UserAvatar/UserAvatar';
+import { useMoniteContext } from '@/core/context/MoniteContext';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useCurrencies } from '@/core/hooks/useCurrencies';
 import { useOptionalFields } from '@/core/hooks/useOptionalFields';
-import { useApprovalPolicyById, useEntityUserById } from '@/core/queries';
+import {
+  useApprovalPolicyById,
+  useCounterpartById,
+  useEntityUserById,
+} from '@/core/queries';
 import { useCounterpartContactList } from '@/core/queries/useCounterpart';
 import { CenteredContentBox } from '@/ui/box';
 import { DateTimeFormatOptions } from '@/utils/DateTimeFormatOptions';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import CachedOutlinedIcon from '@mui/icons-material/CachedOutlined';
+import { CachedOutlined, InfoOutlined } from '@mui/icons-material';
 import {
   Box,
   Chip,
+  CircularProgress,
   Grid,
   Paper,
   Stack,
@@ -29,6 +34,7 @@ import {
   TableCell,
   TableHead,
   TableRow,
+  Tooltip,
   Typography,
 } from '@mui/material';
 import { styled } from '@mui/material/styles';
@@ -94,16 +100,10 @@ const PayableDetailsInfoBase = ({
   const { data: approvalPolicy, isLoading: isApprovalPolicyLoading } =
     useApprovalPolicyById(payable.approval_policy_id);
 
-  const counterpartName =
-    counterpart &&
-    (isIndividualCounterpart(counterpart)
-      ? getIndividualName(
-          counterpart.individual.first_name,
-          counterpart.individual.last_name
-        )
-      : isOrganizationCounterpart(counterpart)
-      ? counterpart.organization.legal_name
-      : '—');
+  const counterpartName = getCounterpartName(counterpart);
+
+  //    '—';
+
   const defaultContact = useMemo(
     () => contacts?.data.find((contact) => contact.is_default),
     [contacts]
@@ -121,7 +121,7 @@ const PayableDetailsInfoBase = ({
       <DetailsWrapper className={ScopedCssBaselineContainerClassName}>
         <CenteredContentBox>
           <Box textAlign="center">
-            <CachedOutlinedIcon color="primary" fontSize="large" />
+            <CachedOutlined color="primary" fontSize="large" />
             <Typography variant="h3" mb={2}>
               {t(i18n)`File is being processed...`}
             </Typography>
@@ -129,7 +129,7 @@ const PayableDetailsInfoBase = ({
               {t(i18n)`Hold on, we’re processing the file you’ve uploaded.`}
             </Typography>
             <Typography variant="body1">
-              {t(i18n)`Usually it takes no more than 1–2 mins.`}
+              {t(i18n)`Usually it takes no more than 1–2 minutes.`}
             </Typography>
           </Box>
         </CenteredContentBox>
@@ -157,7 +157,9 @@ const PayableDetailsInfoBase = ({
                   <StyledLabelTableCell>
                     {t(i18n)`Supplier`}:
                   </StyledLabelTableCell>
-                  <TableCell>{counterpartName}</TableCell>
+                  <TableCell>
+                    <PayableCounterpartName payable={payable} />
+                  </TableCell>
                 </TableRow>
                 {defaultContact && (
                   <TableRow>
@@ -442,5 +444,75 @@ const PayableDetailsInfoBase = ({
         </Grid>
       </Grid>
     </DetailsWrapper>
+  );
+};
+
+const PayableCounterpartName = ({
+  payable,
+}: {
+  payable: components['schemas']['PayableResponseSchema'];
+}) => {
+  const { i18n } = useLingui();
+  const { data: counterpart } = useCounterpartById(payable.counterpart_id);
+
+  const { api } = useMoniteContext();
+  const {
+    data: isCounterpartMatchingToOCRFound,
+    isLoading: isCounterpartMatchingToOCRLoading,
+  } = api.counterparts.getCounterparts.useQuery(
+    {
+      query: {
+        counterpart_name__icontains: payable.counterpart_raw_data?.name,
+        limit: 1,
+      },
+    },
+    {
+      enabled: Boolean(
+        !payable.counterpart_id && payable.counterpart_raw_data?.name
+      ),
+      select: (data) => Boolean(data.data.at(0)),
+    }
+  );
+
+  const counterpartName = getCounterpartName(counterpart);
+
+  if (counterpartName) {
+    return <>{counterpartName}</>;
+  }
+
+  if (!payable.counterpart_raw_data?.name) {
+    return <>—</>;
+  }
+
+  return (
+    <Stack component="span" gap={2} direction="row">
+      {payable.counterpart_raw_data.name}
+      {isCounterpartMatchingToOCRLoading && (
+        <CircularProgress
+          size={14}
+          color="secondary"
+          sx={{ alignSelf: 'center' }}
+        />
+      )}
+      {!isCounterpartMatchingToOCRLoading && (
+        <Tooltip
+          title={
+            isCounterpartMatchingToOCRFound
+              ? t(
+                  i18n
+                )`A counterpart with this name exists but has not been specified in the document.`
+              : t(
+                  i18n
+                )`There is no such counterpart yet, you can create it in respective section.`
+          }
+        >
+          <InfoOutlined
+            color={isCounterpartMatchingToOCRFound ? 'disabled' : 'info'}
+            fontSize="small"
+            sx={{ alignSelf: 'center' }}
+          />
+        </Tooltip>
+      )}
+    </Stack>
   );
 };

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.test.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.test.tsx
@@ -18,7 +18,6 @@ import {
 import { MoniteSDK } from '@monite/sdk-api';
 import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 
-import { payablesDefaultQueryConfig } from '../consts';
 import { PayablesTable } from './PayablesTable';
 
 jest.useFakeTimers();
@@ -329,7 +328,7 @@ describe('PayablesTable', () => {
        *  to wait until the table will be re-fetched
        *  and new data will come
        */
-      jest.advanceTimersByTime(payablesDefaultQueryConfig.refetchInterval);
+      jest.advanceTimersByTime(2_000);
 
       expect(
         await screen.findByText(String(resultItem!.document_id))

--- a/packages/sdk-react/src/components/payables/consts.ts
+++ b/packages/sdk-react/src/components/payables/consts.ts
@@ -11,10 +11,6 @@ import ScheduleOutlinedIcon from '@mui/icons-material/ScheduleOutlined';
 import TaskOutlinedIcon from '@mui/icons-material/TaskOutlined';
 import { ChipTypeMap, type SvgIcon } from '@mui/material';
 
-export const payablesDefaultQueryConfig = {
-  refetchInterval: 15_000,
-};
-
 export const ROW_TO_STATUS_MUI_MAP: {
   [key in components['schemas']['PayableStateEnum']]: ChipTypeMap['props']['color'];
 } = {

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -36,7 +36,7 @@ msgid "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has 
 msgstr "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has been sent} quote {Quote has been sent} other {Receivable has been sent}}"
 
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:50
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:75
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:81
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:22
 msgid "{0}"
 msgstr "{0}"
@@ -62,6 +62,10 @@ msgstr "{bankAccountName} (Default)"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:330
 msgid "CounterpartDetails--CounterpartOrganizationForm--businessAddressSection--caption"
 msgstr "🚫"
+
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:501
+msgid "A counterpart with this name exists but has not been specified in the document."
+msgstr "A counterpart with this name exists but has not been specified in the document."
 
 #: src/components/onboarding/dicts/mccCodes.ts:12
 msgid "A/C, Refrigeration Repair"
@@ -90,7 +94,7 @@ msgstr "Access Restricted"
 msgid "Account holder name"
 msgstr "Account holder name"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:100
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:106
 msgid "Account Holder Name"
 msgstr "Account Holder Name"
 
@@ -105,7 +109,7 @@ msgstr "Account name"
 msgid "Account number"
 msgstr "Account number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:109
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:115
 msgid "Account Number"
 msgstr "Account Number"
 
@@ -206,11 +210,11 @@ msgstr "Add VAT ID"
 
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:286
 #: src/components/approvalRequests/ApprovalRequestsTable/AutocompleteCreatedBy/AutocompleteCreatedBy.tsx:75
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:389
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:391
 msgid "Added by"
 msgstr "Added by"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:415
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:417
 msgid "Added on"
 msgstr "Added on"
 
@@ -334,7 +338,7 @@ msgstr "American Samoa"
 #: src/components/approvalPolicies/ApprovalPoliciesTable/ApprovalPoliciesTable.test.tsx:14
 #: src/components/approvalPolicies/ApprovalPoliciesTable/components/ApprovalPoliciesTriggers.tsx:82
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:270
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:210
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:212
 #: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:168
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:219
 #: src/components/receivables/InvoiceDetails/InvoiceItems/InvoiceItems.tsx:37
@@ -345,7 +349,7 @@ msgstr "Amount"
 
 #. Payables Table "Amount" heading title
 #. js-lingui-explicit-id
-#: src/components/payables/PayablesTable/PayablesTable.tsx:320
+#: src/components/payables/PayablesTable/PayablesTable.tsx:324
 msgid "Amount Name"
 msgstr "Amount"
 
@@ -397,7 +401,7 @@ msgstr "Antique Reproductions"
 msgid "Antique Shops"
 msgstr "Antique Shops"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:267
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:269
 msgid "Applied policy"
 msgstr "Applied policy"
 
@@ -430,9 +434,9 @@ msgstr "Approval request"
 msgid "Approval Requests"
 msgstr "Approval Requests"
 
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:192
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:524
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:545
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:188
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:519
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:540
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:87
 #: src/components/userRoles/consts.ts:72
 #: src/components/userRoles/UserRoleDetails/UserRoleDetailsDialog/UserRoleDetailsDialog.tsx:222
@@ -633,7 +637,7 @@ msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:103
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:175
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:177
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/PaymentSection.tsx:66
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/PaymentSection.tsx:73
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:95
@@ -643,8 +647,8 @@ msgid "Bank account"
 msgstr "Bank account"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:124
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:323
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:329
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:354
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:360
 msgid "Bank Account"
 msgstr "Bank Account"
 
@@ -941,14 +945,13 @@ msgstr "Canadian Dollar"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:384
 #: src/components/counterparts/CounterpartDetails/CounterpartTestHelpers.ts:27
 #: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:105
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:465
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:432
 #: src/components/onboarding/hooks/useOnboardingActions.ts:130
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:88
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:109
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:146
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:186
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:398
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:419
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:87
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:108
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:145
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:393
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:414
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:71
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:93
 #: src/components/products/ProductDeleteModal/ProductDeleteModal.tsx:81
@@ -982,8 +985,8 @@ msgid "Cancel without saving?"
 msgstr "Cancel without saving?"
 
 #: src/components/approvalRequests/helpers.ts:13
-#: src/components/payables/consts.ts:42
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:168
+#: src/components/payables/consts.ts:38
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:167
 #: src/components/receivables/getCommonStatusLabel.ts:31
 msgid "Canceled"
 msgstr "Canceled"
@@ -1026,7 +1029,7 @@ msgstr "Carpet/Upholstery Cleaning"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartIndividualView/CounterpartIndividualView.tsx:43
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartOrganizationView/CounterpartOrganizationView.tsx:33
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:322
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:314
 #: src/components/counterparts/CounterpartsTable/Filters/Filters.tsx:80
 #: src/components/counterparts/CounterpartsTable/Filters/Filters.tsx:83
 msgid "Category"
@@ -1273,11 +1276,11 @@ msgstr "Construction Materials (Not Elsewhere Classified)"
 msgid "Consulting, Public Relations"
 msgstr "Consulting, Public Relations"
 
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:365
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:353
 msgid "Contact information"
 msgstr "Contact information"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:165
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:167
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx:253
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewCustomerSection.tsx:65
 msgid "Contact person"
@@ -1363,10 +1366,10 @@ msgstr "Counseling Services"
 
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:226
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartView.tsx:194
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:83
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:282
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:288
-#: src/components/payables/PayablesTable/PayablesTable.tsx:239
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:84
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:313
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:319
+#: src/components/payables/PayablesTable/PayablesTable.tsx:243
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:93
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:125
 #: src/components/userRoles/consts.ts:28
@@ -1381,7 +1384,7 @@ msgstr "Counterpart “{0}” has been created."
 msgid "Counterpart “{0}” has been updated."
 msgstr "Counterpart “{0}” has been updated."
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:86
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:87
 msgid "Counterpart bank account"
 msgstr "Counterpart bank account"
 
@@ -1425,7 +1428,7 @@ msgstr "Counterparts"
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:105
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:75
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:45
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:70
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:76
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:28
 #: src/components/onboarding/validators/validationSchemas.ts:115
 #: src/components/onboarding/validators/validationSchemas.ts:147
@@ -1612,7 +1615,7 @@ msgstr "Cuba"
 #: src/components/approvalPolicies/ApprovalPoliciesTable/components/ApprovalPoliciesTriggers.tsx:91
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:20
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:109
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:52
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:58
 #: src/components/onboarding/validators/validationSchemas.ts:116
 #: src/components/products/ProductDetails/validation.ts:46
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:13
@@ -1631,7 +1634,7 @@ msgstr "Current status"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:256
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartIndividualView/CounterpartIndividualView.tsx:47
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartOrganizationView/CounterpartOrganizationView.tsx:37
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:338
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:326
 #: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:147
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx:141
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:103
@@ -1706,7 +1709,7 @@ msgstr "Declined"
 #: src/components/counterparts/CounterpartsTable/CounterpartsTable.test.tsx:311
 #: src/components/counterparts/CounterpartsTable/CounterpartsTable.test.tsx:341
 #: src/components/counterparts/CounterpartsTable/CounterpartsTable.test.tsx:373
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:473
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:440
 #: src/components/products/ProductDeleteModal/ProductDeleteModal.tsx:97
 #: src/components/products/ProductDetails/ExistingProductDetails.tsx:241
 #: src/components/products/Products.test.tsx:162
@@ -1750,12 +1753,12 @@ msgstr "Delete {type} “{name}”?"
 
 #: src/components/counterparts/ConfirmDeleteDialogue/ConfirmDeleteDialogue.tsx:42
 #: src/components/counterparts/CounterpartDetails/CounterpartTestHelpers.ts:12
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:441
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:408
 #: src/core/context/MoniteI18nProvider.test.tsx:36
 msgid "Delete confirmation"
 msgstr "Delete confirmation"
 
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:449
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:416
 msgid "Delete Counterpart \"{0}\"?"
 msgstr "Delete Counterpart \"{0}\"?"
 
@@ -1812,7 +1815,7 @@ msgstr "Description"
 msgid "Description:"
 msgstr "Description:"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:252
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:283
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:145
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:95
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:93
@@ -1920,9 +1923,9 @@ msgstr "Door-To-Door Sales"
 msgid "Download PDF"
 msgstr "Download PDF"
 
-#: src/components/payables/consts.ts:36
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:85
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:122
+#: src/components/payables/consts.ts:32
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:84
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:121
 #: src/components/receivables/getCommonStatusLabel.ts:11
 msgid "Draft"
 msgstr "Draft"
@@ -1956,10 +1959,10 @@ msgid "Dry Cleaners"
 msgstr "Dry Cleaners"
 
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:249
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:90
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:402
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:197
-#: src/components/payables/PayablesTable/Filters/Filters.tsx:90
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:91
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:435
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:199
+#: src/components/payables/PayablesTable/Filters/Filters.tsx:93
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:232
 #: src/components/receivables/QuotesTable/QuotesTable.tsx:179
 #: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:118
@@ -1968,7 +1971,7 @@ msgstr "Due date"
 
 #. Payables Table "Due date" heading title
 #. js-lingui-explicit-id
-#: src/components/payables/PayablesTable/PayablesTable.tsx:291
+#: src/components/payables/PayablesTable/PayablesTable.tsx:295
 msgid "Due date Name"
 msgstr "Due date"
 
@@ -2022,13 +2025,13 @@ msgstr "Ecuador"
 #: src/components/counterparts/CounterpartsTable/CounterpartsTable.test.tsx:261
 #: src/components/counterparts/CounterpartsTable/CounterpartsTable.test.tsx:287
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingPersonsReview.tsx:44
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:103
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:124
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:143
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:274
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:345
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:371
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:590
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:102
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:123
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:142
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:269
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:340
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:366
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:585
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:57
 #: src/components/products/ProductDetails/ExistingProductDetails.tsx:249
 #: src/components/products/Products.test.tsx:161
@@ -2220,7 +2223,7 @@ msgstr "Ethiopian Birr"
 msgid "Euro"
 msgstr "Euro"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:315
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:317
 msgid "excl. VAT"
 msgstr "excl. VAT"
 
@@ -2653,7 +2656,7 @@ msgstr "Hearing Aids Sales and Supplies"
 msgid "Heating, Plumbing, A/C"
 msgstr "Heating, Plumbing, A/C"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:381
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:383
 msgid "History"
 msgstr "History"
 
@@ -2728,7 +2731,7 @@ msgstr "I own 25% or more of the company."
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:115
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:8
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:89
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:91
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:97
 #: src/components/onboarding/validators/validationSchemas.ts:120
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:33
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:47
@@ -2820,7 +2823,7 @@ msgstr "Intra-Company Purchases"
 msgid "INV-auto"
 msgstr "INV-auto"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:89
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:90
 msgid "Invalid date"
 msgstr "Invalid date"
 
@@ -2838,13 +2841,13 @@ msgid "Invoice {documentId}"
 msgstr "Invoice {documentId}"
 
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:220
-#: src/components/payables/PayablesTable/PayablesTable.tsx:218
+#: src/components/payables/PayablesTable/PayablesTable.tsx:222
 msgid "Invoice #"
 msgstr "Invoice #"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:375
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:407
 #: src/components/payables/PayablesTable/Filters/Filters.tsx:69
-#: src/components/payables/PayablesTable/PayablesTable.tsx:249
+#: src/components/payables/PayablesTable/PayablesTable.tsx:253
 msgid "Invoice date"
 msgstr "Invoice date"
 
@@ -2861,12 +2864,12 @@ msgstr "Invoice not found"
 msgid "Invoice number"
 msgstr "Invoice number"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:81
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:263
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:82
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:294
 msgid "Invoice Number"
 msgstr "Invoice Number"
 
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:280
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:275
 msgid "Invoice Number *"
 msgstr "Invoice Number *"
 
@@ -2923,7 +2926,7 @@ msgid "Issue and send"
 msgstr "Issue and send"
 
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:236
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:183
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:185
 #: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:139
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:191
 msgid "Issue date"
@@ -2931,7 +2934,7 @@ msgstr "Issue date"
 
 #. Payables Table "Issue date" heading title
 #. js-lingui-explicit-id
-#: src/components/payables/PayablesTable/PayablesTable.tsx:274
+#: src/components/payables/PayablesTable/PayablesTable.tsx:278
 msgid "Issue date Name"
 msgstr "Issue date"
 
@@ -2979,36 +2982,36 @@ msgstr "Italy"
 msgid "Item"
 msgstr "Item"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:97
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:98
 msgid "Item name"
 msgstr "Item name"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:107
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:108
 msgid "Item price"
 msgstr "Item price"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:110
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:111
 msgid "Item price must be a number"
 msgstr "Item price must be a number"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:101
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:102
 msgid "Item quantity"
 msgstr "Item quantity"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:104
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:105
 msgid "Item quantity must be a number"
 msgstr "Item quantity must be a number"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:113
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:114
 msgid "Item tax"
 msgstr "Item tax"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:117
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:118
 msgid "Item tax must be a number between 0 and 100"
 msgstr "Item tax must be a number between 0 and 100"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:463
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:280
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:496
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:282
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:203
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:90
 #: src/components/receivables/InvoiceDetails/InvoiceItems/InvoiceItems.tsx:25
@@ -3515,7 +3518,7 @@ msgstr "Music Stores-Musical Instruments, Pianos, and Sheet Music"
 msgid "Myanmar"
 msgstr "Myanmar"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:286
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:288
 #: src/components/payables/PayableDetails/PayableLineItemsForm/PayableLineItemsForm.tsx:40
 #: src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx:73
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:123
@@ -3535,7 +3538,7 @@ msgstr "Name"
 msgid "Name *"
 msgstr "Name *"
 
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:297
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:293
 msgid "Name, country, city"
 msgstr "Name, country, city"
 
@@ -3587,7 +3590,7 @@ msgstr "Netherlands Antillean Guilder"
 msgid "Netherlands Antilles"
 msgstr "Netherlands Antilles"
 
-#: src/components/payables/consts.ts:37
+#: src/components/payables/consts.ts:33
 msgid "New"
 msgstr "New"
 
@@ -3677,7 +3680,7 @@ msgstr "No file provided"
 msgid "No items yet"
 msgstr "No items yet"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:271
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:273
 msgid "no policy"
 msgstr "no policy"
 
@@ -3764,7 +3767,7 @@ msgstr "Onboarding Completed"
 msgid "One Stop Shop Value Added Tax (EU)"
 msgstr "One Stop Shop Value Added Tax (EU)"
 
-#: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsFilter/ApprovalRequestsFilter.tsx:102
+#: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsFilter/ApprovalRequestsFilter.tsx:105
 msgid "Only my approvals"
 msgstr "Only my approvals"
 
@@ -3822,8 +3825,8 @@ msgstr "Ownership declaration"
 msgid "Package Stores-Beer, Wine, and Liquor"
 msgstr "Package Stores-Beer, Wine, and Liquor"
 
-#: src/components/payables/consts.ts:41
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:248
+#: src/components/payables/consts.ts:37
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:243
 #: src/components/receivables/getCommonStatusLabel.ts:25
 msgid "Paid"
 msgstr "Paid"
@@ -3876,7 +3879,7 @@ msgstr "Paraguayan Guarani"
 msgid "Parking Lots, Garages"
 msgstr "Parking Lots, Garages"
 
-#: src/components/payables/consts.ts:40
+#: src/components/payables/consts.ts:36
 msgid "Partially paid"
 msgstr "Partially paid"
 
@@ -3897,8 +3900,8 @@ msgstr "Passenger Railways"
 msgid "Pawn Shops"
 msgstr "Pawn Shops"
 
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:230
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:564
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:225
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:559
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:98
 #: src/components/payables/PayablesTable/components/PayablesTableAction.tsx:45
 #: src/components/userRoles/consts.ts:73
@@ -3915,27 +3918,27 @@ msgstr "Pay"
 msgid "Payable"
 msgstr "Payable"
 
-#: src/components/payables/PayableDetails/usePayableDetails.tsx:755
+#: src/components/payables/PayableDetails/usePayableDetails.tsx:773
 msgid "Payable \"{0}\" has been approved"
 msgstr "Payable \"{0}\" has been approved"
 
-#: src/components/payables/PayableDetails/usePayableDetails.tsx:698
+#: src/components/payables/PayableDetails/usePayableDetails.tsx:716
 msgid "Payable \"{0}\" has been canceled"
 msgstr "Payable \"{0}\" has been canceled"
 
-#: src/components/payables/PayableDetails/usePayableDetails.tsx:550
+#: src/components/payables/PayableDetails/usePayableDetails.tsx:568
 msgid "Payable \"{0}\" has been created"
 msgstr "Payable \"{0}\" has been created"
 
-#: src/components/payables/PayableDetails/usePayableDetails.tsx:736
+#: src/components/payables/PayableDetails/usePayableDetails.tsx:754
 msgid "Payable \"{0}\" has been rejected"
 msgstr "Payable \"{0}\" has been rejected"
 
-#: src/components/payables/PayableDetails/usePayableDetails.tsx:717
+#: src/components/payables/PayableDetails/usePayableDetails.tsx:735
 msgid "Payable \"{0}\" has been submitted"
 msgstr "Payable \"{0}\" has been submitted"
 
-#: src/components/payables/PayableDetails/usePayableDetails.tsx:605
+#: src/components/payables/PayableDetails/usePayableDetails.tsx:623
 msgid "Payable \"{0}\" has been updated"
 msgstr "Payable \"{0}\" has been updated"
 
@@ -3990,8 +3993,8 @@ msgstr "Payment term"
 msgid "Payment terms"
 msgstr "Payment terms"
 
-#: src/components/payables/consts.ts:38
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:184
+#: src/components/payables/consts.ts:34
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:183
 msgid "Pending"
 msgstr "Pending"
 
@@ -4208,7 +4211,7 @@ msgstr "Precious Stones and Metals, Watches and Jewelry"
 msgid "Previous page"
 msgstr "Previous page"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:288
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:290
 #: src/components/payables/PayableDetails/PayableLineItemsForm/PayableLineItemsForm.tsx:102
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:128
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:218
@@ -4233,7 +4236,7 @@ msgstr "Price:"
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/components/payables/PayablesTable/PayablesTable.tsx:257
+#: src/components/payables/PayablesTable/PayablesTable.tsx:261
 msgid "Processing file…"
 msgstr "Processing file…"
 
@@ -4318,7 +4321,7 @@ msgstr "Public Warehousing and Storage - Farm Products, Refrigerated Goods, Hous
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:236
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:239
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:105
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:137
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:41
@@ -4333,7 +4336,7 @@ msgstr "Qatar"
 msgid "Qatari Rial"
 msgstr "Qatari Rial"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:287
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:289
 #: src/components/payables/PayableDetails/PayableLineItemsForm/PayableLineItemsForm.tsx:57
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:216
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:33
@@ -4419,9 +4422,9 @@ msgstr "Registered business address"
 msgid "Registered Number (Japan)"
 msgstr "Registered Number (Japan)"
 
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:189
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:482
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:503
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:185
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:477
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:498
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:82
 msgid "Reject"
 msgstr "Reject"
@@ -4431,8 +4434,8 @@ msgid "Reject request"
 msgstr "Reject request"
 
 #: src/components/approvalRequests/helpers.ts:14
-#: src/components/payables/consts.ts:43
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:212
+#: src/components/payables/consts.ts:39
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:207
 msgid "Rejected"
 msgstr "Rejected"
 
@@ -4528,7 +4531,7 @@ msgstr "Roofing/Siding, Sheet Metal"
 msgid "Routing number"
 msgstr "Routing number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:118
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:124
 msgid "Routing Number"
 msgstr "Routing Number"
 
@@ -4584,7 +4587,7 @@ msgstr "Sales"
 msgid "Sales and Service Tax (Malaysia)"
 msgstr "Sales and Service Tax (Malaysia)"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:220
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:223
 msgid "Same as invoice date"
 msgstr "Same as invoice date"
 
@@ -4612,11 +4615,11 @@ msgstr "Saudi Arabia"
 msgid "Saudi Riyal"
 msgstr "Saudi Riyal"
 
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:90
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:111
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:286
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:351
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:377
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:89
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:110
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:281
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:346
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:372
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:63
 #: src/components/tags/TagFormModal/TagFormModal.test.tsx:157
 #: src/components/tags/TagFormModal/TagFormModal.test.tsx:224
@@ -4825,7 +4828,7 @@ msgstr "Something went wrong. Please try again"
 msgid "Sort code"
 msgstr "Sort code"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:127
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:133
 msgid "Sort Code"
 msgstr "Sort Code"
 
@@ -4924,7 +4927,7 @@ msgstr "Status"
 
 #. Payables Table "Status" heading title
 #. js-lingui-explicit-id
-#: src/components/payables/PayablesTable/PayablesTable.tsx:307
+#: src/components/payables/PayablesTable/PayablesTable.tsx:311
 msgid "Status Name"
 msgstr "Status"
 
@@ -4933,9 +4936,9 @@ msgstr "Status"
 msgid "Subject"
 msgstr "Subject"
 
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:149
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:440
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:461
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:148
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:435
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:456
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:76
 #: src/components/userRoles/consts.ts:71
 #: src/components/userRoles/UserRoleDetails/UserRoleDetailsDialog/UserRoleDetailsDialog.tsx:218
@@ -4946,8 +4949,8 @@ msgstr "Submit"
 msgid "Submit invoice"
 msgstr "Submit invoice"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:474
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:342
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:507
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:344
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:357
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:158
 #: src/components/receivables/InvoiceDetails/InvoiceTotal/InvoiceTotal.tsx:33
@@ -5023,8 +5026,8 @@ msgid "Tag “{0}” was deleted"
 msgstr "Tag “{0}” was deleted"
 
 #: src/components/approvalPolicies/ApprovalPoliciesTable/components/ApprovalPoliciesTriggers.tsx:118
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:443
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:244
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:476
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:246
 #: src/components/tags/Tags.tsx:52
 msgid "Tags"
 msgstr "Tags"
@@ -5110,8 +5113,8 @@ msgstr "Tax Preparation Services"
 msgid "Tax Registration Number (UAE)"
 msgstr "Tax Registration Number (UAE)"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:488
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:353
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:521
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:355
 msgid "Taxes"
 msgstr "Taxes"
 
@@ -5232,12 +5235,16 @@ msgstr "There is no receivable by provided id: {0}"
 msgid "There is no role by provided id: {id}"
 msgstr "There is no role by provided id: {id}"
 
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:504
+msgid "There is no such counterpart yet, you can create it in respective section."
+msgstr "There is no such counterpart yet, you can create it in respective section."
+
 #: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:138
 msgid "There was an issue reading the file."
 msgstr "There was an issue reading the file."
 
 #: src/components/counterparts/ConfirmDeleteDialogue/ConfirmDeleteDialogue.tsx:51
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:455
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:422
 #: src/components/products/ProductDeleteModal/ProductDeleteModal.tsx:75
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceDeleteModal.tsx:59
 #: src/components/tags/ConfirmDeleteModal/ConfirmDeleteModal.tsx:99
@@ -5313,8 +5320,8 @@ msgstr "Tonga"
 msgid "Tongan Paʻanga"
 msgstr "Tongan Paʻanga"
 
-#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:502
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:364
+#: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:535
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:366
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:363
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:173
 #: src/components/receivables/InvoiceDetails/InvoiceItems/InvoiceItems.tsx:40
@@ -5327,7 +5334,7 @@ msgstr "Total"
 msgid "Total taxes"
 msgstr "Total taxes"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:289
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:291
 msgid "Total, tax"
 msgstr "Total, tax"
 
@@ -5572,7 +5579,7 @@ msgstr "Update Vat Id"
 msgid "Updated at"
 msgstr "Updated at"
 
-#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:428
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:430
 msgid "Updated on"
 msgstr "Updated on"
 
@@ -5625,8 +5632,12 @@ msgid "Users from the list{0}"
 msgstr "Users from the list{0}"
 
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:132
-msgid "Usually it takes no more than 1–2 mins."
-msgstr "Usually it takes no more than 1–2 mins."
+#~ msgid "Usually it takes no more than 1–2 mins."
+#~ msgstr "Usually it takes no more than 1–2 mins."
+
+#: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:132
+msgid "Usually it takes no more than 1–2 minutes."
+msgstr "Usually it takes no more than 1–2 minutes."
 
 #: src/components/onboarding/dicts/mccCodes.ts:1390
 msgid "Utilities"
@@ -5783,7 +5794,7 @@ msgstr "Vat Value"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:279
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartIndividualView/CounterpartIndividualView.tsx:48
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartOrganizationView/CounterpartOrganizationView.tsx:38
-#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:341
+#: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:329
 msgid "Vendor"
 msgstr "Vendor"
 
@@ -5845,8 +5856,8 @@ msgstr "Virgin Islands, U.S."
 msgid "Vocational/Trade Schools"
 msgstr "Vocational/Trade Schools"
 
-#: src/components/payables/consts.ts:39
-#: src/components/payables/PayableDetails/PayableDetails.test.tsx:228
+#: src/components/payables/consts.ts:35
+#: src/components/payables/PayableDetails/PayableDetails.test.tsx:223
 msgid "Waiting to be paid"
 msgstr "Waiting to be paid"
 


### PR DESCRIPTION
This Pull Request introduces the following updates:
 

1. **Two Icon States for Counterpart**:

	•  **State 1**: Counterpart not found in the system.
	•  **State 2**: Counterpart found but not selected in the document.
	•  Added two images to illustrate these states with appropriate color indications.
	•  **Note**: If a Counterpart is already selected for the Payable, no icon will be displayed.

2. **Automatic Selection of Counterpart in Payable Editing Form**:
	•  Implemented functionality to automatically select the appropriate Counterpart in the Payable editing form.
	•  If a Counterpart is not selected for a Payable but is available from counterpart_raw_data, it will be auto-selected.

<details>
  <summary>Screenshots 🖥️</summary>
  
  State 1: Counterpart not found in the system.
  <img width="809" alt="image" src="https://github.com/user-attachments/assets/79e8a57a-132c-4e4e-8309-268a474430df">
  
  State 2: Counterpart found but not selected in the document.
    <img width="803" alt="image" src="https://github.com/user-attachments/assets/e148a2a3-50b1-4e3e-8598-48a853b271b0">
</details>