### PR TITLE
fix(DEV-12020): remove duplicate error notifications for persons and entity editing

### DIFF
--- a/packages/sdk-react/src/components/onboarding/hooks/useOnboardingEntity.ts
+++ b/packages/sdk-react/src/components/onboarding/hooks/useOnboardingEntity.ts
@@ -57,6 +57,7 @@ export function useOnboardingEntity(): OnboardingEntityReturnType {
         queryClient
       );
     },
+    onError: () => {},
   });
 
   const entity = useMemo(

--- a/packages/sdk-react/src/components/onboarding/hooks/useOnboardingPerson.ts
+++ b/packages/sdk-react/src/components/onboarding/hooks/useOnboardingPerson.ts
@@ -76,13 +76,17 @@ export function useOnboardingPerson(): OnboardingPersonReturnType {
     mutateAsync: createPersonMutation,
     isPending: isCreateLoading,
     error: createPersonError,
-  } = api.persons.postPersons.useMutation(undefined);
+  } = api.persons.postPersons.useMutation(undefined, {
+    onError: () => {},
+  });
 
   const {
     mutateAsync: updatePersonMutation,
     isPending: isUpdateLoading,
     error: updatePersonError,
-  } = api.persons.patchPersonsId.useMutation(undefined);
+  } = api.persons.patchPersonsId.useMutation(undefined, {
+    onError: () => {},
+  });
 
   const {
     mutateAsync: deletePersonMutation,


### PR DESCRIPTION
<img width="1014" alt="Screenshot 2024-07-29 at 4 08 39 PM" src="https://github.com/user-attachments/assets/e1790148-0f1c-4c7e-85ab-08ba23006acd">


remove error toast for entities and persons as we have error messages near the fields