### PR TITLE
fix(DEV-12158): use flex for datagrid height instead of absolute unit px

### DIFF
--- a/.changeset/breezy-bugs-begin.md
+++ b/.changeset/breezy-bugs-begin.md
@@ -1,0 +1,6 @@
+---
+'@monite/sdk-react': minor
+'@team-monite/sdk-demo': minor
+---
+
+fix(DEV-12158): fix tables styles and improve height calculations

--- a/packages/sdk-demo/src/components/Layout/index.tsx
+++ b/packages/sdk-demo/src/components/Layout/index.tsx
@@ -43,7 +43,6 @@ export const DefaultLayout = ({
           display: 'flex',
           m: 0,
           height: '100vh',
-          overflow: 'hidden',
         }}
       >
         <Drawer
@@ -92,14 +91,9 @@ export const DefaultLayout = ({
         <Box
           sx={{
             display: 'flex',
-            flex: '1 1 auto',
+            flex: 1,
             flexDirection: 'column',
-            minWidth: 0,
-            height: '100vh',
-
-            // '& .MuiDataGrid-root': {
-            //   height: 'calc(100vh - 272px)',
-            // },
+            height: 'inherit',
           }}
         >
           {children}

--- a/packages/sdk-demo/src/components/Layout/index.tsx
+++ b/packages/sdk-demo/src/components/Layout/index.tsx
@@ -39,7 +39,12 @@ export const DefaultLayout = ({
   return (
     <>
       <Box
-        sx={{ display: 'flex', margin: 0, height: '100%', minHeight: '100vh' }}
+        sx={{
+          display: 'flex',
+          m: 0,
+          height: '100vh',
+          overflow: 'hidden',
+        }}
       >
         <Drawer
           sx={{
@@ -87,25 +92,17 @@ export const DefaultLayout = ({
         <Box
           sx={{
             display: 'flex',
-            flex: 1,
+            flex: '1 1 auto',
+            flexDirection: 'column',
             minWidth: 0,
+            height: '100vh',
+
+            // '& .MuiDataGrid-root': {
+            //   height: 'calc(100vh - 272px)',
+            // },
           }}
         >
-          <Box
-            sx={{
-              display: 'flex',
-              flex: '1 1 auto',
-              flexDirection: 'column',
-              minWidth: 0,
-              minHeight: '100vh',
-
-              '& .MuiDataGrid-root': {
-                height: 'calc(100vh - 272px)',
-              },
-            }}
-          >
-            {children}
-          </Box>
+          {children}
         </Box>
       </Box>
     </>

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/ApprovalPoliciesTable.stories.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/ApprovalPoliciesTable.stories.tsx
@@ -15,7 +15,11 @@ export const Default: Story = {
     onChangeFilter: action('onChangeFilter'),
     onChangeSort: action('onChangeSort'),
   },
-  render: (args) => <ApprovalPoliciesTable {...args} />,
+  render: (args) => (
+    <div style={{ height: 600, padding: 20 }}>
+      <ApprovalPoliciesTable {...args} />
+    </div>
+  ),
 };
 
 export default meta;

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/ApprovalPoliciesTable.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/ApprovalPoliciesTable.tsx
@@ -133,101 +133,104 @@ const ApprovalPoliciesTableBase = ({
   };
 
   return (
-    <>
-      <Box
-        sx={{ padding: 2, width: '100%', height: '100%' }}
-        className={ScopedCssBaselineContainerClassName}
-      >
-        <Box sx={{ marginBottom: 2 }}>
-          <Filters onChangeFilter={onChangeFilter} />
-        </Box>
-        <DataGrid
-          autoHeight
-          disableColumnFilter={true}
-          rowSelection={false}
-          sx={{
-            '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': {
-              py: '8px',
-            },
-            '&.MuiDataGrid-root--densityStandard .MuiDataGrid-cell': {
-              py: '15px',
-            },
-            '&.MuiDataGrid-root--densityComfortable .MuiDataGrid-cell': {
-              py: '22px',
-            },
-            '& .MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-            '&.MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-          }}
-          loading={isLoading}
-          getRowHeight={() => 'auto'}
-          columns={[
-            {
-              field: 'name',
-              headerName: t(i18n)`Policy name`,
-              sortable: false,
-              flex: 1,
-            },
-            {
-              field: 'triggers',
-              headerName: t(i18n)`Triggers`,
-              sortable: false,
-              flex: 1,
-              renderCell: (params) => (
-                <ApprovalPoliciesTriggers approvalPolicyId={params.row.id} />
-              ),
-            },
-            {
-              field: 'rule',
-              headerName: t(i18n)`Rule`,
-              sortable: false,
-              flex: 1,
-              renderCell: (params) => (
-                <ApprovalPoliciesRules approvalPolicyId={params.row.id} />
-              ),
-            },
-            {
-              field: 'created_at',
-              headerName: t(i18n)`Created at`,
-              sortable: false,
-              flex: 0.7,
-              valueFormatter: (value) =>
-                i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-            },
-            {
-              field: 'created_by',
-              headerName: t(i18n)`Created by`,
-              sortable: false,
-              flex: 0.8,
-              renderCell: ({ value }) => (
-                <ApprovalPoliciesUser entityUserId={value} />
-              ),
-            },
-          ]}
-          rows={approvalPolicies?.data || []}
-          onRowClick={(params) => onRowClick?.(params.row)}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                nextPage={approvalPolicies?.next_pagination_token}
-                prevPage={approvalPolicies?.prev_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: currentPaginationToken,
-                }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setPageSize(pageSize);
-                  setCurrentPaginationToken(page);
-                }}
-              />
-            ),
-          }}
-        />
+    <Box
+      className={ScopedCssBaselineContainerClassName}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
+    >
+      <Box sx={{ mb: 2 }}>
+        <Filters onChangeFilter={onChangeFilter} />
       </Box>
-    </>
+      <DataGrid
+        disableColumnFilter={true}
+        rowSelection={false}
+        sx={{
+          '&.MuiDataGrid-root--densityCompact .MuiDataGrid-cell': {
+            py: '8px',
+          },
+          '&.MuiDataGrid-root--densityStandard .MuiDataGrid-cell': {
+            py: '15px',
+          },
+          '&.MuiDataGrid-root--densityComfortable .MuiDataGrid-cell': {
+            py: '22px',
+          },
+          '& .MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+          '&.MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+        }}
+        loading={isLoading}
+        getRowHeight={() => 'auto'}
+        columns={[
+          {
+            field: 'name',
+            headerName: t(i18n)`Policy name`,
+            sortable: false,
+            flex: 1,
+          },
+          {
+            field: 'triggers',
+            headerName: t(i18n)`Triggers`,
+            sortable: false,
+            flex: 1,
+            renderCell: (params) => (
+              <ApprovalPoliciesTriggers approvalPolicyId={params.row.id} />
+            ),
+          },
+          {
+            field: 'rule',
+            headerName: t(i18n)`Rule`,
+            sortable: false,
+            flex: 1,
+            renderCell: (params) => (
+              <ApprovalPoliciesRules approvalPolicyId={params.row.id} />
+            ),
+          },
+          {
+            field: 'created_at',
+            headerName: t(i18n)`Created at`,
+            sortable: false,
+            flex: 0.7,
+            valueFormatter: (value) =>
+              i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+          },
+          {
+            field: 'created_by',
+            headerName: t(i18n)`Created by`,
+            sortable: false,
+            flex: 0.8,
+            renderCell: ({ value }) => (
+              <ApprovalPoliciesUser entityUserId={value} />
+            ),
+          },
+        ]}
+        rows={approvalPolicies?.data || []}
+        onRowClick={(params) => onRowClick?.(params.row)}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              nextPage={approvalPolicies?.next_pagination_token}
+              prevPage={approvalPolicies?.prev_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: currentPaginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setPageSize(pageSize);
+                setCurrentPaginationToken(page);
+              }}
+            />
+          ),
+        }}
+      />
+    </Box>
   );
 };
 

--- a/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.stories.tsx
+++ b/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.stories.tsx
@@ -21,7 +21,7 @@ export const FullPermissions: Story = {
     onRowClick: action('onRowClick'),
   },
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <ApprovalRequestsTable {...args} />
     </div>
   ),
@@ -47,7 +47,7 @@ export const ReadOnlyPermissions: Story = {
     }),
   ],
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <ApprovalRequestsTable {...args} />
     </div>
   ),
@@ -74,7 +74,7 @@ export const LowPermissions: Story = {
   ],
   render: (args) => {
     return (
-      <div style={{ height: 600 }}>
+      <div style={{ height: 600, padding: 20 }}>
         <ApprovalRequestsTable {...args} />
       </div>
     );

--- a/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx
+++ b/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx
@@ -179,10 +179,16 @@ const ApprovalRequestsTableBase = ({
 
   return (
     <Box
-      sx={{ padding: 2, width: '100%', height: '100%' }}
       className={ScopedCssBaselineContainerClassName}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
     >
-      <Box sx={{ marginBottom: 2 }}>
+      <Box sx={{ mb: 2 }}>
         <ApprovalRequestsFilter onChangeFilter={onChangeFilter} />
       </Box>
       <DataGrid

--- a/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx
+++ b/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx
@@ -192,7 +192,6 @@ const ApprovalRequestsTableBase = ({
         <ApprovalRequestsFilter onChangeFilter={onChangeFilter} />
       </Box>
       <DataGrid
-        autoHeight
         rowSelection={false}
         disableColumnFilter={true}
         initialState={{

--- a/packages/sdk-react/src/components/counterparts/CounterpartsTable/CounterpartsTable.stories.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartsTable/CounterpartsTable.stories.tsx
@@ -25,7 +25,7 @@ export const FullPermissions: Story = {
     showCategories: true,
   },
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <CounterpartsTable {...args} />
     </div>
   ),
@@ -55,7 +55,7 @@ export const WithReadOnlyPermissions: Story = {
     }),
   ],
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <CounterpartsTable {...args} />
     </div>
   ),
@@ -85,7 +85,7 @@ export const WithEmptyPermissions: Story = {
     }),
   ],
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <CounterpartsTable {...args} />
     </div>
   ),

--- a/packages/sdk-react/src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx
@@ -239,234 +239,232 @@ const CounterpartsTableBase = ({
   const className = 'Monite-CounterpartsTable';
 
   return (
-    <>
-      <Box
-        className={classNames(ScopedCssBaselineContainerClassName, className)}
-        sx={{
-          padding: 2,
-          width: '100%',
+    <Box
+      className={classNames(ScopedCssBaselineContainerClassName, className)}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
+    >
+      <Box sx={{ marginBottom: 2 }} className={className + '-FiltersContainer'}>
+        <FiltersComponent
+          onChangeFilter={onChangeFilter}
+          showCategories={showCategories}
+        />
+      </Box>
+      <DataGrid
+        rowSelection={false}
+        disableColumnFilter={true}
+        initialState={{
+          sorting: {
+            sortModel: sortModel && [sortModel],
+          },
+          columns: {
+            columnVisibilityModel: {
+              category: showCategories,
+            },
+          },
         }}
-      >
-        <Box
-          sx={{ marginBottom: 2 }}
-          className={className + '-FiltersContainer'}
-        >
-          <FiltersComponent
-            onChangeFilter={onChangeFilter}
-            showCategories={showCategories}
-          />
-        </Box>
-        <DataGrid
-          rowSelection={false}
-          disableColumnFilter={true}
-          initialState={{
-            sorting: {
-              sortModel: sortModel && [sortModel],
+        onSortModelChange={onChangeSort}
+        loading={isLoading}
+        onRowClick={(params) => onRowClick?.(params.row.id)}
+        columnVisibilityModel={{
+          category: showCategories,
+        }}
+        sx={{
+          '& .MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+          '&.MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+        }}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              prevPage={counterparts?.prev_pagination_token}
+              nextPage={counterparts?.next_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: currentPaginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setPageSize(pageSize);
+                setCurrentPaginationToken(page);
+              }}
+            />
+          ),
+        }}
+        columns={[
+          {
+            field: 'counterpart_name',
+            sortable: true,
+            headerName: t(i18n)`Name, country, city`,
+            display: 'flex',
+            flex: 1,
+            renderCell: (params) => {
+              const counterpart = params.row;
+
+              const name =
+                'organization' in counterpart
+                  ? counterpart.organization.legal_name
+                  : getIndividualName(counterpart.individual);
+
+              return (
+                <>
+                  <Avatar sx={{ marginRight: 2 }}>{name[0]}</Avatar>
+                  <Typography variant="caption">{name}</Typography>
+                </>
+              );
             },
-            columns: {
-              columnVisibilityModel: {
-                category: showCategories,
-              },
+          },
+          {
+            field: 'category',
+            sortable: false,
+            headerName: t(i18n)`Category`,
+            display: 'flex',
+            flex: 0.6,
+            renderCell: (params) => {
+              const counterpart = params.row;
+
+              const { is_customer, is_vendor } =
+                'organization' in counterpart
+                  ? counterpart.organization
+                  : counterpart.individual;
+
+              const items = [
+                {
+                  label: t(i18n)`Customer`,
+                  value: is_customer,
+                },
+                { label: t(i18n)`Vendor`, value: is_vendor },
+              ].map(
+                ({ label, value }) =>
+                  value && (
+                    <Chip
+                      key={label}
+                      label={label}
+                      variant="outlined"
+                      color="default"
+                    />
+                  )
+              );
+
+              return (
+                <Stack direction="row" spacing={1}>
+                  {items}
+                </Stack>
+              );
             },
-          }}
-          onSortModelChange={onChangeSort}
-          loading={isLoading}
-          onRowClick={(params) => onRowClick?.(params.row.id)}
-          columnVisibilityModel={{
-            category: showCategories,
-          }}
-          sx={{
-            '& .MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
+          },
+          {
+            field: 'contacts',
+            sortable: false,
+            flex: 1,
+            headerName: t(i18n)`Contact information`,
+            renderCell: (params) => {
+              const counterpart = params.row;
+
+              const { email, phone } =
+                'organization' in counterpart
+                  ? counterpart.organization
+                  : counterpart.individual;
+
+              return (
+                <Stack spacing={1} direction="column">
+                  {email && (
+                    <Styled.MuiColContacts>
+                      <MuiEnvelopeIcon fontSize="small" color="disabled" />
+                      <Typography variant="body2">{email}</Typography>
+                    </Styled.MuiColContacts>
+                  )}
+                  {phone && (
+                    <Styled.MuiColContacts>
+                      <MuiPhoneIcon fontSize="small" color="disabled" />
+                      <Typography variant="body2">{phone}</Typography>
+                    </Styled.MuiColContacts>
+                  )}
+                </Stack>
+              );
             },
-            '&.MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-          }}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                prevPage={counterparts?.prev_pagination_token}
-                nextPage={counterparts?.next_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: currentPaginationToken,
+          },
+          {
+            field: 'actions',
+            sortable: false,
+            headerName: '',
+            width: 70,
+            renderCell: (params) => (
+              <TableActions
+                permissions={{
+                  isUpdateAllowed: isUpdateSupported,
+                  isDeleteAllowed: isDeleteSupported,
                 }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setPageSize(pageSize);
-                  setCurrentPaginationToken(page);
+                onEdit={() => {
+                  onEdit?.(params.row.id);
+                }}
+                onDelete={() => {
+                  setSelectedCounterpart(params.row);
+                  setIsDeleteDialogOpen(true);
                 }}
               />
             ),
-          }}
-          columns={[
-            {
-              field: 'counterpart_name',
-              sortable: true,
-              headerName: t(i18n)`Name, country, city`,
-              display: 'flex',
-              flex: 1,
-              renderCell: (params) => {
-                const counterpart = params.row;
-
-                const name =
-                  'organization' in counterpart
-                    ? counterpart.organization.legal_name
-                    : getIndividualName(counterpart.individual);
-
-                return (
-                  <>
-                    <Avatar sx={{ marginRight: 2 }}>{name[0]}</Avatar>
-                    <Typography variant="caption">{name}</Typography>
-                  </>
-                );
-              },
-            },
-            {
-              field: 'category',
-              sortable: false,
-              headerName: t(i18n)`Category`,
-              display: 'flex',
-              flex: 0.6,
-              renderCell: (params) => {
-                const counterpart = params.row;
-
-                const { is_customer, is_vendor } =
-                  'organization' in counterpart
-                    ? counterpart.organization
-                    : counterpart.individual;
-
-                const items = [
-                  {
-                    label: t(i18n)`Customer`,
-                    value: is_customer,
-                  },
-                  { label: t(i18n)`Vendor`, value: is_vendor },
-                ].map(
-                  ({ label, value }) =>
-                    value && (
-                      <Chip
-                        key={label}
-                        label={label}
-                        variant="outlined"
-                        color="default"
-                      />
-                    )
-                );
-
-                return (
-                  <Stack direction="row" spacing={1}>
-                    {items}
-                  </Stack>
-                );
-              },
-            },
-            {
-              field: 'contacts',
-              sortable: false,
-              flex: 1,
-              headerName: t(i18n)`Contact information`,
-              renderCell: (params) => {
-                const counterpart = params.row;
-
-                const { email, phone } =
-                  'organization' in counterpart
-                    ? counterpart.organization
-                    : counterpart.individual;
-
-                return (
-                  <Stack spacing={1} direction="column">
-                    {email && (
-                      <Styled.MuiColContacts>
-                        <MuiEnvelopeIcon fontSize="small" color="disabled" />
-                        <Typography variant="body2">{email}</Typography>
-                      </Styled.MuiColContacts>
-                    )}
-                    {phone && (
-                      <Styled.MuiColContacts>
-                        <MuiPhoneIcon fontSize="small" color="disabled" />
-                        <Typography variant="body2">{phone}</Typography>
-                      </Styled.MuiColContacts>
-                    )}
-                  </Stack>
-                );
-              },
-            },
-            {
-              field: 'actions',
-              sortable: false,
-              headerName: '',
-              width: 70,
-              renderCell: (params) => (
-                <TableActions
-                  permissions={{
-                    isUpdateAllowed: isUpdateSupported,
-                    isDeleteAllowed: isDeleteSupported,
-                  }}
-                  onEdit={() => {
-                    onEdit?.(params.row.id);
-                  }}
-                  onDelete={() => {
-                    setSelectedCounterpart(params.row);
-                    setIsDeleteDialogOpen(true);
-                  }}
-                />
-              ),
-            },
-          ]}
-          rows={counterparts?.data || []}
-        />
-        <Dialog
-          className={className + 'Dialog-DeleteCounterpart'}
-          open={isDeleteDialogOpen && Boolean(selectedCounterpart)}
-          container={root}
-          onClose={closeDeleteCounterpartModal}
-          aria-label={t(i18n)`Delete confirmation`}
-          maxWidth="sm"
-          fullWidth
-          TransitionProps={{
-            onExited: closedDeleteCounterpartModal,
-          }}
+          },
+        ]}
+        rows={counterparts?.data || []}
+      />
+      <Dialog
+        className={className + 'Dialog-DeleteCounterpart'}
+        open={isDeleteDialogOpen && Boolean(selectedCounterpart)}
+        container={root}
+        onClose={closeDeleteCounterpartModal}
+        aria-label={t(i18n)`Delete confirmation`}
+        maxWidth="sm"
+        fullWidth
+        TransitionProps={{
+          onExited: closedDeleteCounterpartModal,
+        }}
+      >
+        <DialogTitle
+          variant="h3"
+          className={className + 'Dialog-DeleteCounterpart-Title'}
         >
-          <DialogTitle
-            variant="h3"
-            className={className + 'Dialog-DeleteCounterpart-Title'}
+          {t(i18n)`Delete Counterpart "${getCounterpartName(
+            selectedCounterpart!
+          )}"?`}
+        </DialogTitle>
+        <DialogContent
+          className={className + 'Dialog-DeleteCounterpart-Content'}
+        >
+          <DialogContentText>
+            {t(i18n)`This action can't be undone.`}
+          </DialogContentText>
+        </DialogContent>
+        <Divider className={className + 'Dialog-DeleteCounterpart-Divider'} />
+        <DialogActions
+          className={className + 'Dialog-DeleteCounterpart-Actions'}
+        >
+          <Button
+            variant="outlined"
+            onClick={closeDeleteCounterpartModal}
+            color="inherit"
+            className={className + 'Dialog-DeleteCounterpart-Actions-Cancel'}
           >
-            {t(i18n)`Delete Counterpart "${getCounterpartName(
-              selectedCounterpart!
-            )}"?`}
-          </DialogTitle>
-          <DialogContent
-            className={className + 'Dialog-DeleteCounterpart-Content'}
+            {t(i18n)`Cancel`}
+          </Button>
+          <Button
+            variant="outlined"
+            color="error"
+            onClick={deleteCounterpart}
+            autoFocus
+            className={className + 'Dialog-DeleteCounterpart-Actions-Delete'}
           >
-            <DialogContentText>
-              {t(i18n)`This action can't be undone.`}
-            </DialogContentText>
-          </DialogContent>
-          <Divider className={className + 'Dialog-DeleteCounterpart-Divider'} />
-          <DialogActions
-            className={className + 'Dialog-DeleteCounterpart-Actions'}
-          >
-            <Button
-              variant="outlined"
-              onClick={closeDeleteCounterpartModal}
-              color="inherit"
-              className={className + 'Dialog-DeleteCounterpart-Actions-Cancel'}
-            >
-              {t(i18n)`Cancel`}
-            </Button>
-            <Button
-              variant="outlined"
-              color="error"
-              onClick={deleteCounterpart}
-              autoFocus
-              className={className + 'Dialog-DeleteCounterpart-Actions-Delete'}
-            >
-              {t(i18n)`Delete`}
-            </Button>
-          </DialogActions>
-        </Dialog>
-      </Box>
-    </>
+            {t(i18n)`Delete`}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Box>
   );
 };

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.stories.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.stories.tsx
@@ -23,7 +23,7 @@ export const FullPermissions: Story = {
     onChangeSort: action('onChangeSort'),
   },
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <PayablesTable {...args} />
     </div>
   ),
@@ -45,6 +45,7 @@ export const AutoUpdatedTable: Story = {
         display: 'flex',
         height: 700,
         flexDirection: 'column',
+        padding: 20,
       }}
     >
       <>
@@ -92,6 +93,7 @@ export const WithLowPermissions: Story = {
           height: 500,
           flexDirection: 'column',
           justifyContent: 'center',
+          padding: 20,
         }}
       >
         <PayablesTable {...args} />

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
@@ -195,6 +195,7 @@ const PayablesTableBase = ({
         display: 'flex',
         flexDirection: 'column',
         overflow: 'hidden',
+        height: 'inherit',
         pt: 2,
       }}
     >
@@ -212,7 +213,6 @@ const PayablesTableBase = ({
           },
         }}
         apiRef={gridApiRef}
-        // autoHeight
         rowSelection={false}
         disableColumnFilter={true}
         loading={isLoading}

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
@@ -217,9 +217,6 @@ const PayablesTableBase = ({
           onRowClick?.(params.row.id);
         }}
         sx={{
-          display: 'flex',
-          flex: '1 1 auto',
-          minHeight: 0,
           '& .MuiDataGrid-withBorderColor': {
             borderColor: 'divider',
           },

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
@@ -199,11 +199,7 @@ const PayablesTableBase = ({
         pt: 2,
       }}
     >
-      <Box
-        sx={{
-          marginBottom: 2,
-        }}
-      >
+      <Box sx={{ mb: 2 }}>
         <FiltersComponent onChangeFilter={onChangeFilter} />
       </Box>
       <DataGrid

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
@@ -189,189 +189,192 @@ const PayablesTableBase = ({
 
   const className = 'Monite-PayablesTable';
   return (
-    <>
+    <Box
+      className={classNames(ScopedCssBaselineContainerClassName, className)}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        pt: 2,
+      }}
+    >
       <Box
-        className={classNames(ScopedCssBaselineContainerClassName, className)}
         sx={{
-          padding: 2,
+          marginBottom: 2,
         }}
       >
-        <Box
-          sx={{
-            marginBottom: 2,
-          }}
-        >
-          <FiltersComponent onChangeFilter={onChangeFilter} />
-        </Box>
-        <DataGrid
-          initialState={{
-            sorting: {
-              sortModel: [sortModel],
-            },
-          }}
-          apiRef={gridApiRef}
-          rowSelection={false}
-          disableColumnFilter={true}
-          loading={isLoading}
-          onSortModelChange={onChangeSort}
-          onRowClick={(params) => {
-            onRowClick?.(params.row.id);
-          }}
-          sx={{
-            '& .MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-            '&.MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-          }}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                nextPage={payables?.next_pagination_token}
-                prevPage={payables?.prev_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: currentPaginationToken,
-                }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setPageSize(pageSize);
-                  setCurrentPaginationToken(page);
-                }}
-              />
-            ),
-          }}
-          columns={[
-            {
-              field: 'document_id',
-              sortable: false,
-              headerName: t(i18n)`Invoice #`,
-              display: 'flex',
-              flex: 1.1,
-              colSpan: (_, row) => (isPayableInOCRProcessing(row) ? 2 : 1),
-              renderCell: (params) => {
-                const payable = params.row;
-
-                if (isPayableInOCRProcessing(payable)) {
-                  return (
-                    <>
-                      <FindInPageOutlinedIcon fontSize="small" />
-                      {payable.file?.name}
-                    </>
-                  );
-                }
-
-                return payable.document_id;
-              },
-            },
-            {
-              field: 'counterpart_id',
-              sortable: false,
-              headerName: t(i18n)`Counterpart`,
-              flex: 1.2,
-              renderCell: (params) => (
-                <CounterpartCell counterpartId={params.value} />
-              ),
-            },
-            {
-              field: 'created_at',
-              type: 'date',
-              headerName: t(i18n)`Invoice date`,
-              display: 'flex',
-              flex: 0.7,
-              colSpan: (_, row) => (isPayableInOCRProcessing(row) ? 3 : 1),
-              renderCell: ({ row, formattedValue }) => {
-                if (isPayableInOCRProcessing(row)) {
-                  return (
-                    <Stack direction="row">
-                      <CircularProgress size={22} sx={{ mr: 1 }} />
-                      {t(i18n)`Processing file…`}
-                    </Stack>
-                  );
-                }
-
-                return formattedValue;
-              },
-              valueFormatter: (
-                value: components['schemas']['PayableResponseSchema']['created_at']
-              ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-            },
-            {
-              field: 'issued_at',
-              sortable: false,
-              type: 'date',
-              headerName: t(i18n)({
-                id: 'Issue date Name',
-                message: 'Issue date',
-                comment: 'Payables Table "Issue date" heading title',
-              }),
-              flex: 0.7,
-              valueFormatter: (
-                value: components['schemas']['PayableResponseSchema']['issued_at']
-              ) =>
-                value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-            },
-            {
-              field: 'due_date',
-              sortable: false,
-              type: 'date',
-              headerName: t(i18n)({
-                id: 'Due date Name',
-                message: 'Due date',
-                comment: 'Payables Table "Due date" heading title',
-              }),
-              flex: 0.7,
-              valueFormatter: (
-                value: components['schemas']['PayableResponseSchema']['due_date']
-              ) =>
-                value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-            },
-            {
-              field: 'status',
-              sortable: false,
-              headerName: t(i18n)({
-                id: 'Status Name',
-                message: 'Status',
-                comment: 'Payables Table "Status" heading title',
-              }),
-              flex: 0.9,
-              renderCell: (params) => (
-                <PayableStatusChip status={params.value} />
-              ),
-            },
-            {
-              field: 'amount',
-              sortable: false,
-              headerName: t(i18n)({
-                id: 'Amount Name',
-                message: 'Amount',
-                comment: 'Payables Table "Amount" heading title',
-              }),
-              valueGetter: (_, row) => {
-                const payable = row;
-
-                return payable.amount_to_pay && payable.currency
-                  ? formatCurrencyToDisplay(
-                      payable.amount_to_pay,
-                      payable.currency
-                    )
-                  : '';
-              },
-            },
-            {
-              field: 'pay',
-              headerName: '',
-              sortable: false,
-              renderCell: (params) => {
-                const payable = params.row;
-
-                return <PayablesTableAction payable={payable} onPay={onPay} />;
-              },
-            },
-          ]}
-          rows={payables?.data || []}
-        />
+        <FiltersComponent onChangeFilter={onChangeFilter} />
       </Box>
-    </>
+      <DataGrid
+        initialState={{
+          sorting: {
+            sortModel: [sortModel],
+          },
+        }}
+        apiRef={gridApiRef}
+        // autoHeight
+        rowSelection={false}
+        disableColumnFilter={true}
+        loading={isLoading}
+        onSortModelChange={onChangeSort}
+        onRowClick={(params) => {
+          onRowClick?.(params.row.id);
+        }}
+        sx={{
+          display: 'flex',
+          flex: '1 1 auto',
+          minHeight: 0,
+          '& .MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+          '&.MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+        }}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              nextPage={payables?.next_pagination_token}
+              prevPage={payables?.prev_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: currentPaginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setPageSize(pageSize);
+                setCurrentPaginationToken(page);
+              }}
+            />
+          ),
+        }}
+        columns={[
+          {
+            field: 'document_id',
+            sortable: false,
+            headerName: t(i18n)`Invoice #`,
+            display: 'flex',
+            flex: 1.1,
+            colSpan: (_, row) => (isPayableInOCRProcessing(row) ? 2 : 1),
+            renderCell: (params) => {
+              const payable = params.row;
+
+              if (isPayableInOCRProcessing(payable)) {
+                return (
+                  <>
+                    <FindInPageOutlinedIcon fontSize="small" />
+                    {payable.file?.name}
+                  </>
+                );
+              }
+
+              return payable.document_id;
+            },
+          },
+          {
+            field: 'counterpart_id',
+            sortable: false,
+            headerName: t(i18n)`Counterpart`,
+            flex: 1.2,
+            renderCell: (params) => (
+              <CounterpartCell counterpartId={params.value} />
+            ),
+          },
+          {
+            field: 'created_at',
+            type: 'date',
+            headerName: t(i18n)`Invoice date`,
+            display: 'flex',
+            flex: 0.7,
+            colSpan: (_, row) => (isPayableInOCRProcessing(row) ? 3 : 1),
+            renderCell: ({ row, formattedValue }) => {
+              if (isPayableInOCRProcessing(row)) {
+                return (
+                  <Stack direction="row">
+                    <CircularProgress size={22} sx={{ mr: 1 }} />
+                    {t(i18n)`Processing file…`}
+                  </Stack>
+                );
+              }
+
+              return formattedValue;
+            },
+            valueFormatter: (
+              value: components['schemas']['PayableResponseSchema']['created_at']
+            ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+          },
+          {
+            field: 'issued_at',
+            sortable: false,
+            type: 'date',
+            headerName: t(i18n)({
+              id: 'Issue date Name',
+              message: 'Issue date',
+              comment: 'Payables Table "Issue date" heading title',
+            }),
+            flex: 0.7,
+            valueFormatter: (
+              value: components['schemas']['PayableResponseSchema']['issued_at']
+            ) =>
+              value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+          },
+          {
+            field: 'due_date',
+            sortable: false,
+            type: 'date',
+            headerName: t(i18n)({
+              id: 'Due date Name',
+              message: 'Due date',
+              comment: 'Payables Table "Due date" heading title',
+            }),
+            flex: 0.7,
+            valueFormatter: (
+              value: components['schemas']['PayableResponseSchema']['due_date']
+            ) =>
+              value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+          },
+          {
+            field: 'status',
+            sortable: false,
+            headerName: t(i18n)({
+              id: 'Status Name',
+              message: 'Status',
+              comment: 'Payables Table "Status" heading title',
+            }),
+            flex: 0.9,
+            renderCell: (params) => <PayableStatusChip status={params.value} />,
+          },
+          {
+            field: 'amount',
+            sortable: false,
+            headerName: t(i18n)({
+              id: 'Amount Name',
+              message: 'Amount',
+              comment: 'Payables Table "Amount" heading title',
+            }),
+            valueGetter: (_, row) => {
+              const payable = row;
+
+              return payable.amount_to_pay && payable.currency
+                ? formatCurrencyToDisplay(
+                    payable.amount_to_pay,
+                    payable.currency
+                  )
+                : '';
+            },
+          },
+          {
+            field: 'pay',
+            headerName: '',
+            sortable: false,
+            renderCell: (params) => {
+              const payable = params.row;
+
+              return <PayablesTableAction payable={payable} onPay={onPay} />;
+            },
+          },
+        ]}
+        rows={payables?.data || []}
+      />
+    </Box>
   );
 };

--- a/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.stories.tsx
+++ b/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof ProductsTable>;
 
 export const FullPermissions: Story = {
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <ProductsTable {...args} />
     </div>
   ),
@@ -40,7 +40,7 @@ export const ReadOnlyPermissions: Story = {
     }),
   ],
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <ProductsTable {...args} />
     </div>
   ),
@@ -64,7 +64,7 @@ export const LowPermissions: Story = {
   ],
   render: (args) => {
     return (
-      <div style={{ height: 600 }}>
+      <div style={{ height: 600, padding: 20 }}>
         <ProductsTable {...args} />
       </div>
     );

--- a/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.tsx
+++ b/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.tsx
@@ -178,150 +178,148 @@ const ProductsTableBase = ({
   }
 
   return (
-    <>
-      <Box
-        className={ScopedCssBaselineContainerClassName}
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          height: 'inherit',
-          pt: 2,
+    <Box
+      className={ScopedCssBaselineContainerClassName}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
+    >
+      <Box sx={{ mb: 2 }}>
+        <FiltersComponent onChangeFilter={onChangeFilter} />
+      </Box>
+      <DataGrid
+        initialState={{
+          sorting: {
+            sortModel: sortModel && [sortModel],
+          },
         }}
-      >
-        <Box sx={{ mb: 2 }}>
-          <FiltersComponent onChangeFilter={onChangeFilter} />
-        </Box>
-        <DataGrid
-          initialState={{
-            sorting: {
-              sortModel: sortModel && [sortModel],
+        rowSelection={false}
+        disableColumnFilter={true}
+        rows={products?.data || []}
+        onSortModelChange={onChangeSort}
+        onRowClick={(params) => {
+          onRowClick?.(params.row);
+        }}
+        columns={[
+          {
+            field: 'name',
+            headerName: t(i18n)`Name, description`,
+            display: 'flex',
+            flex: 3,
+            renderCell: (params) => (
+              <Stack spacing={1} width="100%">
+                <Typography variant="caption">{params.row.name}</Typography>
+                <Typography
+                  color="secondary"
+                  sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
+                >
+                  {params.row.description}
+                </Typography>
+              </Stack>
+            ),
+          },
+          {
+            field: 'type',
+            headerName: t(i18n)`Type`,
+            display: 'flex',
+            flex: 1,
+            sortable: false,
+            renderCell: (params) => {
+              return params.row.type ? (
+                <ProductType type={params.row.type} />
+              ) : null;
             },
-          }}
-          rowSelection={false}
-          disableColumnFilter={true}
-          rows={products?.data || []}
-          onSortModelChange={onChangeSort}
-          onRowClick={(params) => {
-            onRowClick?.(params.row);
-          }}
-          columns={[
-            {
-              field: 'name',
-              headerName: t(i18n)`Name, description`,
-              display: 'flex',
-              flex: 3,
-              renderCell: (params) => (
-                <Stack spacing={1} width="100%">
-                  <Typography variant="caption">{params.row.name}</Typography>
-                  <Typography
-                    color="secondary"
-                    sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-                  >
-                    {params.row.description}
-                  </Typography>
-                </Stack>
-              ),
-            },
-            {
-              field: 'type',
-              headerName: t(i18n)`Type`,
-              display: 'flex',
-              flex: 1,
-              sortable: false,
-              renderCell: (params) => {
-                return params.row.type ? (
-                  <ProductType type={params.row.type} />
-                ) : null;
-              },
-            },
-            {
-              field: 'price',
-              headerName: t(i18n)`Price per unit`,
-              flex: 1,
-              sortable: false,
-              align: 'right',
-              headerAlign: 'right',
-              valueGetter: (value: ProductServiceResponse['price']) => {
-                const price = value;
+          },
+          {
+            field: 'price',
+            headerName: t(i18n)`Price per unit`,
+            flex: 1,
+            sortable: false,
+            align: 'right',
+            headerAlign: 'right',
+            valueGetter: (value: ProductServiceResponse['price']) => {
+              const price = value;
 
-                return price
-                  ? formatCurrencyToDisplay(price.value, price.currency)
-                  : '';
-              },
+              return price
+                ? formatCurrencyToDisplay(price.value, price.currency)
+                : '';
             },
-            {
-              field: 'measure_unit_id',
-              headerName: t(i18n)`Units`,
-              flex: 1,
-              sortable: false,
-              renderCell: (params) => {
-                return <MeasureUnit unitId={params.value} />;
-              },
+          },
+          {
+            field: 'measure_unit_id',
+            headerName: t(i18n)`Units`,
+            flex: 1,
+            sortable: false,
+            renderCell: (params) => {
+              return <MeasureUnit unitId={params.value} />;
             },
-            {
-              field: 'actions',
-              sortable: false,
-              headerName: '',
-              width: 70,
-              renderCell: (params) => (
-                <TableActions
-                  permissions={{
-                    isUpdateAllowed: isUpdateSupported,
-                    isDeleteAllowed: isDeleteSupported,
-                  }}
-                  onEdit={() => onEdit?.(params.row)}
-                  onDelete={() => {
-                    setIsDeleteDialogOpen({
-                      id: params.row.id,
-                      open: true,
-                    });
-                  }}
-                />
-              ),
-            },
-          ]}
-          loading={isLoading}
-          sx={{
-            '& .MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-            '&.MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-          }}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                prevPage={products?.prev_pagination_token}
-                nextPage={products?.next_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: currentPaginationToken,
+          },
+          {
+            field: 'actions',
+            sortable: false,
+            headerName: '',
+            width: 70,
+            renderCell: (params) => (
+              <TableActions
+                permissions={{
+                  isUpdateAllowed: isUpdateSupported,
+                  isDeleteAllowed: isDeleteSupported,
                 }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setPageSize(pageSize);
-                  setCurrentPaginationToken(page);
+                onEdit={() => onEdit?.(params.row)}
+                onDelete={() => {
+                  setIsDeleteDialogOpen({
+                    id: params.row.id,
+                    open: true,
+                  });
                 }}
               />
             ),
-          }}
+          },
+        ]}
+        loading={isLoading}
+        sx={{
+          '& .MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+          '&.MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+        }}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              prevPage={products?.prev_pagination_token}
+              nextPage={products?.next_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: currentPaginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setPageSize(pageSize);
+                setCurrentPaginationToken(page);
+              }}
+            />
+          ),
+        }}
+      />
+      {isDeleteDialogOpen.id && (
+        <ProductDeleteModal
+          id={isDeleteDialogOpen.id}
+          open={isDeleteDialogOpen.open}
+          onDeleted={onDeleted}
+          onClose={() =>
+            setIsDeleteDialogOpen((prev) => ({
+              ...prev,
+              open: false,
+            }))
+          }
         />
-        {isDeleteDialogOpen.id && (
-          <ProductDeleteModal
-            id={isDeleteDialogOpen.id}
-            open={isDeleteDialogOpen.open}
-            onDeleted={onDeleted}
-            onClose={() =>
-              setIsDeleteDialogOpen((prev) => ({
-                ...prev,
-                open: false,
-              }))
-            }
-          />
-        )}
-      </Box>
-    </>
+      )}
+    </Box>
   );
 };
 

--- a/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.tsx
+++ b/packages/sdk-react/src/components/products/ProductsTable/ProductsTable.tsx
@@ -182,10 +182,14 @@ const ProductsTableBase = ({
       <Box
         className={ScopedCssBaselineContainerClassName}
         sx={{
-          padding: 2,
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          height: 'inherit',
+          pt: 2,
         }}
       >
-        <Box sx={{ marginBottom: 2 }}>
+        <Box sx={{ mb: 2 }}>
           <FiltersComponent onChangeFilter={onChangeFilter} />
         </Box>
         <DataGrid

--- a/packages/sdk-react/src/components/receivables/CreditNotesTable/CreditNotesTable.stories.tsx
+++ b/packages/sdk-react/src/components/receivables/CreditNotesTable/CreditNotesTable.stories.tsx
@@ -15,7 +15,7 @@ export const FullPermissions: Story = {
     onRowClick: action('onRowClick'),
   },
   render: (args) => (
-    <div style={{ height: 500 }}>
+    <div style={{ height: 500, padding: 20 }}>
       <CreditNotesTable {...args} />
     </div>
   ),

--- a/packages/sdk-react/src/components/receivables/CreditNotesTable/CreditNotesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/CreditNotesTable/CreditNotesTable.tsx
@@ -84,10 +84,16 @@ const CreditNotesTableBase = ({ onRowClick }: CreditNotesTableProps) => {
   return (
     <>
       <Box
-        sx={{ padding: 2, width: '100%' }}
         className={classNames(ScopedCssBaselineContainerClassName, className)}
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+          height: 'inherit',
+          pt: 2,
+        }}
       >
-        <Box sx={{ marginBottom: 2 }}>
+        <Box sx={{ mb: 2 }}>
           <ReceivableFilters
             onChange={onChangeFilter}
             filters={['document_id__contains', 'status', 'counterpart_id']}

--- a/packages/sdk-react/src/components/receivables/InvoicesTable/InvoicesTable.stories.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoicesTable/InvoicesTable.stories.tsx
@@ -15,7 +15,7 @@ export const FullPermissions: Story = {
     onRowClick: action('onRowClick'),
   },
   render: (args) => (
-    <div style={{ height: 500 }}>
+    <div style={{ height: 500, padding: 20 }}>
       <InvoicesTable {...args} />
     </div>
   ),
@@ -27,7 +27,7 @@ export const WithCustomActions: Story = {
     onRowActionClick: action('onRowActionClick'),
   },
   render: (args) => (
-    <div style={{ height: 500 }}>
+    <div style={{ height: 500, padding: 20 }}>
       <InvoicesTable
         {...args}
         rowActions={{

--- a/packages/sdk-react/src/components/receivables/InvoicesTable/InvoicesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoicesTable/InvoicesTable.tsx
@@ -103,149 +103,151 @@ const InvoicesTableBase = ({
   const className = 'Monite-InvoicesTable';
 
   return (
-    <>
-      <Box
-        sx={{ padding: 2, width: '100%' }}
-        className={classNames(ScopedCssBaselineContainerClassName, className)}
-      >
-        <Box sx={{ marginBottom: 2 }}>
-          <ReceivableFilters
-            onChange={(field, value) => {
-              setPaginationToken(undefined);
-              onChangeFilter(field, value);
-            }}
-            filters={[
-              'document_id__contains',
-              'status',
-              'counterpart_id',
-              'due_date__lte',
-            ]}
-          />
-        </Box>
-
-        <DataGrid<components['schemas']['ReceivableResponse']>
-          initialState={{
-            sorting: {
-              sortModel: sortModel && [sortModel],
-            },
+    <Box
+      className={classNames(ScopedCssBaselineContainerClassName, className)}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
+    >
+      <Box sx={{ mb: 2 }}>
+        <ReceivableFilters
+          onChange={(field, value) => {
+            setPaginationToken(undefined);
+            onChangeFilter(field, value);
           }}
-          apiRef={gridApiRef}
-          rowSelection={false}
-          disableColumnFilter={true}
-          loading={isLoading}
-          sx={{
-            '& .MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-            '&.MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-          }}
-          onSortModelChange={onChangeSort}
-          onRowClick={(params) => onRowClick?.(params.row.id)}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                nextPage={invoices?.next_pagination_token}
-                prevPage={invoices?.prev_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: paginationToken,
-                }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setPageSize(pageSize);
-                  setPaginationToken(page ?? undefined);
-                }}
-              />
-            ),
-          }}
-          columns={[
-            {
-              field: 'document_id',
-              headerName: t(i18n)`Number`,
-              sortable: false,
-              flex: 1,
-              renderCell: ({ value }) => {
-                if (!value) {
-                  return t(i18n)`INV-auto`;
-                }
-
-                return value;
-              },
-            },
-            {
-              field: 'counterpart_name',
-              headerName: t(i18n)`Customer`,
-              sortable: ReceivableCursorFields.includes('counterpart_name'),
-              display: 'flex',
-              flex: 1.3,
-              renderCell: (params) => (
-                <InvoiceCounterpartName
-                  counterpartId={params.row.counterpart_id}
-                />
-              ),
-            },
-            {
-              field: 'created_at',
-              headerName: t(i18n)`Created on`,
-              sortable: false,
-              valueFormatter: (value) =>
-                value
-                  ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
-                  : '—',
-              flex: 0.7,
-            },
-            {
-              field: 'issue_date',
-              headerName: t(i18n)`Issue date`,
-              sortable: false,
-              valueFormatter: (value) =>
-                value
-                  ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
-                  : '—',
-              flex: 0.7,
-            },
-            {
-              field: 'status',
-              headerName: t(i18n)`Status`,
-              sortable: ReceivableCursorFields.includes('status'),
-              renderCell: (
-                params: GridRenderCellParams<
-                  components['schemas']['ReceivableResponse']
-                >
-              ) => {
-                const status = params.value;
-                return <InvoiceStatusChip status={status} />;
-              },
-              flex: 1,
-            },
-            {
-              field: 'amount',
-              headerName: t(i18n)`Amount`,
-              sortable: ReceivableCursorFields.includes('amount'),
-              valueGetter: (_, row) => {
-                const value = row.total_amount;
-
-                return value
-                  ? formatCurrencyToDisplay(value, row.currency)
-                  : '';
-              },
-            },
-            {
-              field: 'due_date',
-              headerName: t(i18n)`Due date`,
-              sortable: false,
-              valueFormatter: (value) =>
-                value
-                  ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
-                  : '—',
-              flex: 0.7,
-            },
-            ...(invoiceActionCell ? [invoiceActionCell] : []),
+          filters={[
+            'document_id__contains',
+            'status',
+            'counterpart_id',
+            'due_date__lte',
           ]}
-          rows={invoices?.data ?? []}
         />
       </Box>
-    </>
+
+      <DataGrid<components['schemas']['ReceivableResponse']>
+        initialState={{
+          sorting: {
+            sortModel: sortModel && [sortModel],
+          },
+        }}
+        apiRef={gridApiRef}
+        rowSelection={false}
+        disableColumnFilter={true}
+        loading={isLoading}
+        sx={{
+          '& .MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+          '&.MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+        }}
+        onSortModelChange={onChangeSort}
+        onRowClick={(params) => onRowClick?.(params.row.id)}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              nextPage={invoices?.next_pagination_token}
+              prevPage={invoices?.prev_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: paginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setPageSize(pageSize);
+                setPaginationToken(page ?? undefined);
+              }}
+            />
+          ),
+        }}
+        columns={[
+          {
+            field: 'document_id',
+            headerName: t(i18n)`Number`,
+            sortable: false,
+            flex: 1,
+            renderCell: ({ value }) => {
+              if (!value) {
+                return t(i18n)`INV-auto`;
+              }
+
+              return value;
+            },
+          },
+          {
+            field: 'counterpart_name',
+            headerName: t(i18n)`Customer`,
+            sortable: ReceivableCursorFields.includes('counterpart_name'),
+            display: 'flex',
+            flex: 1.3,
+            renderCell: (params) => (
+              <InvoiceCounterpartName
+                counterpartId={params.row.counterpart_id}
+              />
+            ),
+          },
+          {
+            field: 'created_at',
+            headerName: t(i18n)`Created on`,
+            sortable: false,
+            valueFormatter: (value) =>
+              value
+                ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
+                : '—',
+            flex: 0.7,
+          },
+          {
+            field: 'issue_date',
+            headerName: t(i18n)`Issue date`,
+            sortable: false,
+            valueFormatter: (value) =>
+              value
+                ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
+                : '—',
+            flex: 0.7,
+          },
+          {
+            field: 'status',
+            headerName: t(i18n)`Status`,
+            sortable: ReceivableCursorFields.includes('status'),
+            renderCell: (
+              params: GridRenderCellParams<
+                components['schemas']['ReceivableResponse']
+              >
+            ) => {
+              const status = params.value;
+              return <InvoiceStatusChip status={status} />;
+            },
+            flex: 1,
+          },
+          {
+            field: 'amount',
+            headerName: t(i18n)`Amount`,
+            sortable: ReceivableCursorFields.includes('amount'),
+            valueGetter: (_, row) => {
+              const value = row.total_amount;
+
+              return value ? formatCurrencyToDisplay(value, row.currency) : '';
+            },
+          },
+          {
+            field: 'due_date',
+            headerName: t(i18n)`Due date`,
+            sortable: false,
+            valueFormatter: (value) =>
+              value
+                ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
+                : '—',
+            flex: 0.7,
+          },
+          ...(invoiceActionCell ? [invoiceActionCell] : []),
+        ]}
+        rows={invoices?.data ?? []}
+      />
+    </Box>
   );
 };

--- a/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.stories.tsx
+++ b/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.stories.tsx
@@ -16,7 +16,7 @@ export const FullPermissions: Story = {
     onChangeSort: action('onChangeSort'),
   },
   render: (args) => (
-    <div style={{ height: 500 }}>
+    <div style={{ height: 500, padding: 20 }}>
       <QuotesTable {...args} />
     </div>
   ),

--- a/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.tsx
@@ -96,123 +96,125 @@ const QuotesTableBase = ({
   const className = 'Monite-QuotesTable';
 
   return (
-    <>
-      <Box
-        sx={{ padding: 2, width: '100%' }}
-        className={classNames(ScopedCssBaselineContainerClassName, className)}
-      >
-        <Box sx={{ marginBottom: 2 }}>
-          <ReceivableFilters
-            onChange={onChangeFilter}
-            filters={['document_id__contains', 'status', 'counterpart_id']}
-          />
-        </Box>
-        <DataGrid
-          initialState={{
-            sorting: {
-              sortModel: [sortModel],
-            },
-          }}
-          apiRef={gridApiRef}
-          rowSelection={false}
-          disableColumnFilter={true}
-          loading={isLoading}
-          onSortModelChange={onChangeSort}
-          sx={{
-            '& .MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-            '&.MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-          }}
-          onRowClick={(params) => onRowClick?.(params.row.id)}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                nextPage={quotes?.next_pagination_token}
-                prevPage={quotes?.prev_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: paginationToken,
-                }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setPageSize(pageSize);
-                  setPaginationToken(page ?? undefined);
-                }}
-              />
-            ),
-          }}
-          columns={[
-            {
-              field: 'document_id',
-              headerName: t(i18n)`Number`,
-              flex: 1.2,
-            },
-            {
-              field: 'created_at',
-              headerName: t(i18n)`Created on`,
-              valueFormatter: (value) =>
-                value
-                  ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
-                  : '—',
-              flex: 1,
-            },
-            {
-              field: 'issue_date',
-              headerName: t(i18n)`Issue Date`,
-              valueFormatter: (value) =>
-                value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-              flex: 1,
-            },
-            {
-              field: 'counterpart_name',
-              sortable: ReceivableCursorFields.includes('counterpart_name'),
-              headerName: t(i18n)`Customer`,
-              display: 'flex',
-              flex: 1,
-              renderCell: (params) => (
-                <InvoiceCounterpartName
-                  counterpartId={params.row.counterpart_id}
-                />
-              ),
-            },
-            {
-              field: 'expiry_date',
-              sortable: false,
-              headerName: t(i18n)`Due date`,
-              valueFormatter: (value) =>
-                value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-              flex: 1,
-            },
-            {
-              field: 'status',
-              sortable: ReceivableCursorFields.includes('status'),
-              headerName: t(i18n)`Status`,
-              renderCell: (params) => {
-                const status = params.value;
-
-                return <InvoiceStatusChip status={status} />;
-              },
-              flex: 1,
-            },
-            {
-              field: 'amount',
-              headerName: t(i18n)`Amount`,
-              sortable: ReceivableCursorFields.includes('amount'),
-              valueGetter: (_, row) => {
-                const value = row.total_amount;
-
-                return value
-                  ? formatCurrencyToDisplay(value, row.currency)
-                  : '';
-              },
-              flex: 0.8,
-            },
-          ]}
-          rows={quotes?.data || []}
+    <Box
+      className={classNames(ScopedCssBaselineContainerClassName, className)}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
+    >
+      <Box sx={{ mb: 2 }}>
+        <ReceivableFilters
+          onChange={onChangeFilter}
+          filters={['document_id__contains', 'status', 'counterpart_id']}
         />
       </Box>
-    </>
+      <DataGrid
+        initialState={{
+          sorting: {
+            sortModel: [sortModel],
+          },
+        }}
+        apiRef={gridApiRef}
+        rowSelection={false}
+        disableColumnFilter={true}
+        loading={isLoading}
+        onSortModelChange={onChangeSort}
+        sx={{
+          '& .MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+          '&.MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+        }}
+        onRowClick={(params) => onRowClick?.(params.row.id)}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              nextPage={quotes?.next_pagination_token}
+              prevPage={quotes?.prev_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: paginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setPageSize(pageSize);
+                setPaginationToken(page ?? undefined);
+              }}
+            />
+          ),
+        }}
+        columns={[
+          {
+            field: 'document_id',
+            headerName: t(i18n)`Number`,
+            flex: 1.2,
+          },
+          {
+            field: 'created_at',
+            headerName: t(i18n)`Created on`,
+            valueFormatter: (value) =>
+              value
+                ? i18n.date(value, DateTimeFormatOptions.EightDigitDate)
+                : '—',
+            flex: 1,
+          },
+          {
+            field: 'issue_date',
+            headerName: t(i18n)`Issue Date`,
+            valueFormatter: (value) =>
+              value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+            flex: 1,
+          },
+          {
+            field: 'counterpart_name',
+            sortable: ReceivableCursorFields.includes('counterpart_name'),
+            headerName: t(i18n)`Customer`,
+            display: 'flex',
+            flex: 1,
+            renderCell: (params) => (
+              <InvoiceCounterpartName
+                counterpartId={params.row.counterpart_id}
+              />
+            ),
+          },
+          {
+            field: 'expiry_date',
+            sortable: false,
+            headerName: t(i18n)`Due date`,
+            valueFormatter: (value) =>
+              value && i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+            flex: 1,
+          },
+          {
+            field: 'status',
+            sortable: ReceivableCursorFields.includes('status'),
+            headerName: t(i18n)`Status`,
+            renderCell: (params) => {
+              const status = params.value;
+
+              return <InvoiceStatusChip status={status} />;
+            },
+            flex: 1,
+          },
+          {
+            field: 'amount',
+            headerName: t(i18n)`Amount`,
+            sortable: ReceivableCursorFields.includes('amount'),
+            valueGetter: (_, row) => {
+              const value = row.total_amount;
+
+              return value ? formatCurrencyToDisplay(value, row.currency) : '';
+            },
+            flex: 0.8,
+          },
+        ]}
+        rows={quotes?.data || []}
+      />
+    </Box>
   );
 };

--- a/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.stories.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.stories.tsx
@@ -15,7 +15,7 @@ export const FullPermissions: Story = {
     onRowClick: action('onRowClick'),
   },
   render: (args) => (
-    <div style={{ height: 500 }}>
+    <div style={{ height: 500, padding: 20 }}>
       <ReceivablesTable {...args} />
     </div>
   ),

--- a/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.tsx
@@ -60,7 +60,7 @@ const ReceivablesTableBase = ({
   return (
     <>
       <Box
-        sx={{ paddingLeft: 2, paddingRight: 2 }}
+        sx={{ pl: 2, pr: 2 }}
         className={classNames(ScopedCssBaselineContainerClassName, className)}
       >
         <Tabs
@@ -97,6 +97,12 @@ const ReceivablesTableBase = ({
           role="tabpanel"
           id={`${tabPanelIdPrefix}-${ReceivablesTableTabEnum.Quotes}`}
           aria-labelledby={`${tabIdPrefix}-${ReceivablesTableTabEnum.Quotes}`}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: 'inherit',
+            minHeight: '0',
+          }}
         >
           <QuotesTable onRowClick={onRowClick} />
         </Box>
@@ -107,6 +113,12 @@ const ReceivablesTableBase = ({
           role="tabpanel"
           id={`${tabPanelIdPrefix}-${ReceivablesTableTabEnum.Invoices}`}
           aria-labelledby={`${tabIdPrefix}-${ReceivablesTableTabEnum.Invoices}`}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: 'inherit',
+            minHeight: '0',
+          }}
         >
           <InvoicesTable onRowClick={onRowClick} />
         </Box>
@@ -117,6 +129,12 @@ const ReceivablesTableBase = ({
           role="tabpanel"
           id={`${tabPanelIdPrefix}-${ReceivablesTableTabEnum.CreditNotes}`}
           aria-labelledby={`${tabIdPrefix}-${ReceivablesTableTabEnum.CreditNotes}`}
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: 'inherit',
+            minHeight: '0',
+          }}
         >
           <CreditNotesTable onRowClick={onRowClick} />
         </Box>

--- a/packages/sdk-react/src/components/tags/Tags.stories.tsx
+++ b/packages/sdk-react/src/components/tags/Tags.stories.tsx
@@ -20,7 +20,7 @@ export const Tags: Story = {
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
-        height: 600px;
+        height: 100vh;
         padding: 20px;
       `}
     >

--- a/packages/sdk-react/src/components/tags/TagsTable/TagsTable.stories.tsx
+++ b/packages/sdk-react/src/components/tags/TagsTable/TagsTable.stories.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof TagsTable>;
 
 export const FullPermissions: Story = {
   render: (args) => (
-    <div style={{ height: 600 }}>
+    <div style={{ height: 600, padding: 20 }}>
       <TagsTable {...args} />
     </div>
   ),

--- a/packages/sdk-react/src/components/tags/TagsTable/TagsTable.tsx
+++ b/packages/sdk-react/src/components/tags/TagsTable/TagsTable.tsx
@@ -124,117 +124,121 @@ const TagsTableBase = ({
   });
 
   return (
-    <>
-      <Box
-        sx={{ padding: 2, width: '100%', height: '100%' }}
-        className={ScopedCssBaselineContainerClassName}
-      >
-        <DataGrid
-          initialState={{
-            sorting: {
-              sortModel: [sortModel],
-            },
-          }}
-          autoHeight
-          rowSelection={false}
-          disableColumnFilter={true}
-          loading={isLoading}
-          onSortModelChange={onChangeSort}
-          sx={{
-            '& .MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-            '&.MuiDataGrid-withBorderColor': {
-              borderColor: 'divider',
-            },
-          }}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                prevPage={tags?.prev_pagination_token}
-                nextPage={tags?.next_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: currentPaginationToken,
+    <Box
+      className={ScopedCssBaselineContainerClassName}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
+    >
+      <DataGrid
+        initialState={{
+          sorting: {
+            sortModel: [sortModel],
+          },
+        }}
+        autoHeight
+        rowSelection={false}
+        disableColumnFilter={true}
+        loading={isLoading}
+        onSortModelChange={onChangeSort}
+        sx={{
+          '& .MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+          '&.MuiDataGrid-withBorderColor': {
+            borderColor: 'divider',
+          },
+        }}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              prevPage={tags?.prev_pagination_token}
+              nextPage={tags?.next_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: currentPaginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setPageSize(pageSize);
+                setCurrentPaginationToken(page);
+              }}
+            />
+          ),
+        }}
+        columns={[
+          {
+            field: 'name',
+            headerName: t(i18n)`Name`,
+            sortable: false,
+            flex: 1,
+          },
+          {
+            field: 'created_at',
+            headerName: t(i18n)`Created at`,
+            flex: 0.5,
+            valueFormatter: (
+              value: components['schemas']['TagReadSchema']['created_at']
+            ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+          },
+          {
+            field: 'updated_at',
+            headerName: t(i18n)`Updated at`,
+            flex: 0.5,
+            valueFormatter: (
+              value: components['schemas']['TagReadSchema']['updated_at']
+            ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+          },
+          {
+            field: 'created_by_entity_user_id',
+            headerName: t(i18n)`Created by`,
+            flex: 0.6,
+            sortable: false,
+            renderCell: (params) =>
+              params.value ? <UserCell id={params.value} /> : null,
+          },
+          {
+            field: 'actions',
+            type: 'actions',
+            getActions: (params) => [
+              <GridActionsCellItem
+                onClick={() => {
+                  setSelectedTag(params.row);
+                  openEditModal();
                 }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setPageSize(pageSize);
-                  setCurrentPaginationToken(page);
+                icon={<EditIcon />}
+                disabled={!isUpdateAllowed}
+                label={t(i18n)`Edit`}
+              />,
+              <GridActionsCellItem
+                onClick={() => {
+                  setSelectedTag(params.row);
+                  openDeleteModal();
                 }}
-              />
-            ),
-          }}
-          columns={[
-            {
-              field: 'name',
-              headerName: t(i18n)`Name`,
-              sortable: false,
-              flex: 1,
-            },
-            {
-              field: 'created_at',
-              headerName: t(i18n)`Created at`,
-              flex: 0.5,
-              valueFormatter: (
-                value: components['schemas']['TagReadSchema']['created_at']
-              ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-            },
-            {
-              field: 'updated_at',
-              headerName: t(i18n)`Updated at`,
-              flex: 0.5,
-              valueFormatter: (
-                value: components['schemas']['TagReadSchema']['updated_at']
-              ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-            },
-            {
-              field: 'created_by_entity_user_id',
-              headerName: t(i18n)`Created by`,
-              flex: 0.6,
-              sortable: false,
-              renderCell: (params) =>
-                params.value ? <UserCell id={params.value} /> : null,
-            },
-            {
-              field: 'actions',
-              type: 'actions',
-              getActions: (params) => [
-                <GridActionsCellItem
-                  onClick={() => {
-                    setSelectedTag(params.row);
-                    openEditModal();
-                  }}
-                  icon={<EditIcon />}
-                  disabled={!isUpdateAllowed}
-                  label={t(i18n)`Edit`}
-                />,
-                <GridActionsCellItem
-                  onClick={() => {
-                    setSelectedTag(params.row);
-                    openDeleteModal();
-                  }}
-                  disabled={!isDeleteAllowed}
-                  icon={<DeleteIcon />}
-                  label={t(i18n)`Delete`}
-                />,
-              ],
-            },
-          ]}
-          rows={tags?.data ?? []}
-        />
-        <TagFormModal
+                disabled={!isDeleteAllowed}
+                icon={<DeleteIcon />}
+                label={t(i18n)`Delete`}
+              />,
+            ],
+          },
+        ]}
+        rows={tags?.data ?? []}
+      />
+      <TagFormModal
+        tag={selectedTag}
+        open={editModalOpened}
+        onClose={closeEditModal}
+      />
+      {selectedTag && (
+        <ConfirmDeleteModal
           tag={selectedTag}
-          open={editModalOpened}
-          onClose={closeEditModal}
+          modalOpened={deleteModalOpened}
+          onClose={closeDeleteModal}
         />
-        {selectedTag && (
-          <ConfirmDeleteModal
-            tag={selectedTag}
-            modalOpened={deleteModalOpened}
-            onClose={closeDeleteModal}
-          />
-        )}
-      </Box>
-    </>
+      )}
+    </Box>
   );
 };

--- a/packages/sdk-react/src/components/tags/TagsTable/TagsTable.tsx
+++ b/packages/sdk-react/src/components/tags/TagsTable/TagsTable.tsx
@@ -140,7 +140,6 @@ const TagsTableBase = ({
             sortModel: [sortModel],
           },
         }}
-        autoHeight
         rowSelection={false}
         disableColumnFilter={true}
         loading={isLoading}

--- a/packages/sdk-react/src/components/userRoles/UserRolesTable/UserRolesTable.tsx
+++ b/packages/sdk-react/src/components/userRoles/UserRolesTable/UserRolesTable.tsx
@@ -138,83 +138,84 @@ const UserRolesTableBase = ({
   }
 
   return (
-    <>
-      <Box
-        className={ScopedCssBaselineContainerClassName}
-        sx={{
-          padding: 2,
+    <Box
+      className={ScopedCssBaselineContainerClassName}
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        height: 'inherit',
+        pt: 2,
+      }}
+    >
+      <Box sx={{ mb: 2 }}>
+        <Filters onChangeFilter={onChangeFilter} />
+      </Box>
+      <DataGrid
+        initialState={{
+          sorting: {
+            sortModel: [sortModel],
+          },
         }}
-      >
-        <Box sx={{ marginBottom: 2 }}>
-          <Filters onChangeFilter={onChangeFilter} />
-        </Box>
-        <DataGrid
-          initialState={{
-            sorting: {
-              sortModel: [sortModel],
-            },
-          }}
-          autoHeight
-          rowSelection={false}
-          disableColumnFilter={true}
-          loading={isLoading}
-          columns={[
-            {
-              field: 'name',
-              headerName: t(i18n)`Name`,
-              sortable: false,
-              flex: 1,
-            },
-            {
-              field: 'permissions',
-              headerName: t(i18n)`Permissions`,
-              sortable: false,
-              flex: 2,
-              renderCell: (params) => (
-                <PermissionsCell
-                  permissions={params.value}
-                  onCLickSeeAll={() => onRowClick?.(params.row.id)}
-                />
-              ),
-            },
-            {
-              field: 'created_at',
-              headerName: t(i18n)`Created on`,
-              sortable: true,
-              type: 'date',
-              flex: 1,
-              valueFormatter: (
-                value: components['schemas']['PayableResponseSchema']['created_at']
-              ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
-            },
-          ]}
-          rows={roles?.data || []}
-          onSortModelChange={onChangeSort}
-          onRowClick={(params) => onRowClick?.(params.row.id)}
-          getRowHeight={() => 'auto'}
-          sx={{
-            [`& .${gridClasses.cell}`]: {
-              py: 1,
-            },
-          }}
-          slots={{
-            pagination: () => (
-              <TablePagination
-                prevPage={roles?.prev_pagination_token}
-                nextPage={roles?.next_pagination_token}
-                paginationModel={{
-                  pageSize,
-                  page: currentPaginationToken,
-                }}
-                onPaginationModelChange={({ page, pageSize }) => {
-                  setCurrentPaginationToken(page);
-                  setPageSize(pageSize);
-                }}
+        rowSelection={false}
+        disableColumnFilter={true}
+        loading={isLoading}
+        columns={[
+          {
+            field: 'name',
+            headerName: t(i18n)`Name`,
+            sortable: false,
+            flex: 1,
+          },
+          {
+            field: 'permissions',
+            headerName: t(i18n)`Permissions`,
+            sortable: false,
+            flex: 2,
+            renderCell: (params) => (
+              <PermissionsCell
+                permissions={params.value}
+                onCLickSeeAll={() => onRowClick?.(params.row.id)}
               />
             ),
-          }}
-        />
-      </Box>
-    </>
+          },
+          {
+            field: 'created_at',
+            headerName: t(i18n)`Created on`,
+            sortable: true,
+            type: 'date',
+            flex: 1,
+            valueFormatter: (
+              value: components['schemas']['PayableResponseSchema']['created_at']
+            ) => i18n.date(value, DateTimeFormatOptions.EightDigitDate),
+          },
+        ]}
+        rows={roles?.data || []}
+        onSortModelChange={onChangeSort}
+        onRowClick={(params) => onRowClick?.(params.row.id)}
+        getRowHeight={() => 'auto'}
+        sx={{
+          [`& .${gridClasses.cell}`]: {
+            py: 1,
+          },
+        }}
+        slots={{
+          pagination: () => (
+            <TablePagination
+              prevPage={roles?.prev_pagination_token}
+              nextPage={roles?.next_pagination_token}
+              paginationModel={{
+                pageSize,
+                page: currentPaginationToken,
+              }}
+              onPaginationModelChange={({ page, pageSize }) => {
+                setCurrentPaginationToken(page);
+                setPageSize(pageSize);
+              }}
+            />
+          ),
+        }}
+      />
+    </Box>
   );
 };


### PR DESCRIPTION
Styles for table components were updated and autoHeight property was removed.
Now all tables reproduce the default MUI DataGrid behavior, they require a parent container with intrinsic dimensions.
Advantages:

- we don't force extra property (autoHeight). This property is not recommended in some cases
- the table component could be embedded in a parent block with absolute or dynamic height. It will grow till the bottom of the parent container and leave the content area scrollable. Examples are in the Storybook and Demo project.