### PR TITLE
fix(DEV-11981): do not display empty `<Alert/>` if there is no error in the reminder form

### DIFF
--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/OverdueReminderForm.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/OverdueReminderForm.tsx
@@ -274,9 +274,9 @@ const CreateOverdueReminderComponent = ({
               </>
             )}
           </Stack>
-          {formState.errors.terms && (
+          {formState.errors.terms?.message && (
             <Alert severity="error" sx={{ mt: 2 }}>
-              {formState.errors.terms?.message}
+              {formState.errors.terms.message}
             </Alert>
           )}
         </form>


### PR DESCRIPTION
Do not display empty `<Alert/>` if there is no error in the reminder form