### PR TITLE
feat(DEV-12231): custom Tabs for Receivables 🎲

### DIFF
--- a/.changeset/odd-horses-rest.md
+++ b/.changeset/odd-horses-rest.md
@@ -1,0 +1,23 @@
+---
+'@monite/sdk-react': minor
+---
+
+introduce Custom Tabs for `<ReceivablesTable/>`
+
+### Description
+
+Implemented the ability to configure custom tabs for Receivables using MUI. Users can now select the specific tabs they
+need, while backward compatibility is maintained. By default, the standard tabs Invoices, Quotes, and Credit Notes are
+displayed.
+
+### Breaking Changes
+
+The `<ReceivablesTable/>` component interface has changed. Instead of using `ReceivablesTableTabEnum` for the active
+tab, you now need to pass a `number` representing the tab index. Additionally, the default tab indices have been
+updated:
+
+- **Invoices**: 0 (previously 1)
+- **Quotes**: 1 (previously 0)
+- **Credit Notes**: 2 (unchanged)
+
+Please update any existing integrations to reflect these changes.

--- a/packages/sdk-react/mui-styles.d.ts
+++ b/packages/sdk-react/mui-styles.d.ts
@@ -1,9 +1,9 @@
-import { ReceivablesTableProps } from '@/components';
 import { type MoniteApprovalRequestStatusChipProps } from '@/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip';
 import { type PayableStatusChipProps } from '@/components/payables/PayableStatusChip/PayableStatusChip';
 import { InvoiceRecurrenceIterationStatusChipProps } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip';
 import { InvoiceRecurrenceStatusChipProps } from '@/components/receivables/InvoiceRecurrenceStatusChip/InvoiceRecurrenceStatusChip';
 import { type InvoiceStatusChipProps } from '@/components/receivables/InvoiceStatusChip';
+import { MoniteReceivablesTableProps } from '@/components/receivables/ReceivablesTable/ReceivablesTable';
 import { MoniteTablePaginationProps } from '@/ui/table/TablePagination';
 import {
   ComponentsOverrides,
@@ -49,7 +49,7 @@ declare module '@mui/material/styles' {
     MoniteTablePagination: Partial<MoniteTablePaginationProps>;
     MoniteInvoiceRecurrenceStatusChip: Partial<InvoiceRecurrenceStatusChipProps>;
     MoniteInvoiceRecurrenceIterationStatusChip: Partial<InvoiceRecurrenceIterationStatusChipProps>;
-    MoniteReceivablesTable: Partial<ReceivablesTableProps>;
+    MoniteReceivablesTable: Partial<MoniteReceivablesTableProps>;
   }
 
   /**

--- a/packages/sdk-react/mui-styles.d.ts
+++ b/packages/sdk-react/mui-styles.d.ts
@@ -1,3 +1,4 @@
+import { ReceivablesTableProps } from '@/components';
 import { type MoniteApprovalRequestStatusChipProps } from '@/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip';
 import { type PayableStatusChipProps } from '@/components/payables/PayableStatusChip/PayableStatusChip';
 import { InvoiceRecurrenceIterationStatusChipProps } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip';
@@ -35,6 +36,7 @@ declare module '@mui/material/styles' {
     MoniteTablePagination: 'root' | 'menu';
     MoniteInvoiceRecurrenceStatusChip: 'root';
     MoniteInvoiceRecurrenceIterationStatusChip: 'root';
+    MoniteReceivablesTable: never; // no slots available
   }
 
   /**
@@ -47,6 +49,7 @@ declare module '@mui/material/styles' {
     MoniteTablePagination: Partial<MoniteTablePaginationProps>;
     MoniteInvoiceRecurrenceStatusChip: Partial<InvoiceRecurrenceStatusChipProps>;
     MoniteInvoiceRecurrenceIterationStatusChip: Partial<InvoiceRecurrenceIterationStatusChipProps>;
+    MoniteReceivablesTable: Partial<ReceivablesTableProps>;
   }
 
   /**
@@ -59,5 +62,6 @@ declare module '@mui/material/styles' {
     MoniteTablePagination?: ComponentType<'MoniteTablePagination'>;
     MoniteInvoiceRecurrenceStatusChip?: ComponentType<'MoniteInvoiceRecurrenceStatusChip'>;
     MoniteInvoiceRecurrenceIterationStatusChip?: ComponentType<'MoniteInvoiceRecurrenceIterationStatusChip'>;
+    MoniteReceivablesTable?: ComponentType<'MoniteReceivablesTable'>;
   }
 }

--- a/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/QuotesTable/QuotesTable.tsx
@@ -4,6 +4,11 @@ import { components } from '@/api';
 import { ScopedCssBaselineContainerClassName } from '@/components/ContainerCssBaseline';
 import { InvoiceCounterpartName } from '@/components/receivables/InvoiceCounterpartName';
 import { InvoiceStatusChip } from '@/components/receivables/InvoiceStatusChip';
+import { ReceivableFilters } from '@/components/receivables/ReceivableFilters/ReceivableFilters';
+import {
+  ReceivableFilterType,
+  ReceivablesTabFilter,
+} from '@/components/receivables/ReceivablesTable/types';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useCurrencies } from '@/core/hooks/useCurrencies';
 import { useReceivables } from '@/core/queries/useReceivables';
@@ -20,7 +25,6 @@ import { Box } from '@mui/material';
 import { DataGrid, GridColDef, GridSortModel } from '@mui/x-data-grid';
 import { GridSortDirection } from '@mui/x-data-grid/models/gridSortModel';
 
-import { ReceivableFilters } from '../ReceivableFilters';
 import { useReceivablesFilters } from '../ReceivableFilters/useReceivablesFilters';
 
 export interface QuotesTableSortModel {
@@ -42,6 +46,14 @@ type QuotesTableProps = {
    * @param {QuotesTableSortModel} params - The sort model.
    */
   onChangeSort?: (params: QuotesTableSortModel) => void;
+
+  /**
+   * The query to be used for the Table
+   */
+  query?: ReceivablesTabFilter;
+
+  /** Filters to be applied to the table */
+  filters?: Array<keyof ReceivableFilterType>;
 };
 
 export const QuotesTable = (props: QuotesTableProps) => (
@@ -53,6 +65,8 @@ export const QuotesTable = (props: QuotesTableProps) => (
 const QuotesTableBase = ({
   onRowClick,
   onChangeSort: onChangeSortCallback,
+  query,
+  filters: filtersProp,
 }: QuotesTableProps) => {
   const { i18n } = useLingui();
 
@@ -65,15 +79,20 @@ const QuotesTableBase = ({
   );
 
   const [sortModel, setSortModel] = useState<QuotesTableSortModel>({
-    field: 'created_at',
-    sort: 'desc',
+    field: query?.sort ?? 'created_at',
+    sort: query?.order ?? 'desc',
   });
 
   const { formatCurrencyToDisplay } = useCurrencies();
-  const { onChangeFilter, filters } = useReceivablesFilters();
+  const { onChangeFilter, filters, filtersQuery } = useReceivablesFilters(
+    (['document_id__contains', 'status', 'counterpart_id'] as const).filter(
+      (filter) => filtersProp?.includes(filter) ?? true
+    ),
+    query
+  );
 
   const { data: quotes, isLoading } = useReceivables({
-    ...filters,
+    ...filtersQuery,
     sort: sortModel?.field,
     order: sortModel?.sort,
     limit: pageSize,
@@ -167,10 +186,7 @@ const QuotesTableBase = ({
       }}
     >
       <Box sx={{ mb: 2 }}>
-        <ReceivableFilters
-          onChange={onChangeFilter}
-          filters={['document_id__contains', 'status', 'counterpart_id']}
-        />
+        <ReceivableFilters onChange={onChangeFilter} filters={filters} />
       </Box>
       <DataGrid
         initialState={{

--- a/packages/sdk-react/src/components/receivables/ReceivableFilters/index.ts
+++ b/packages/sdk-react/src/components/receivables/ReceivableFilters/index.ts
@@ -1,1 +1,1 @@
-export { ReceivableFilters } from './ReceivableFilters';
+export { ReceivableFilter } from './ReceivableFilters';

--- a/packages/sdk-react/src/components/receivables/ReceivableFilters/useReceivablesFilters.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivableFilters/useReceivablesFilters.tsx
@@ -1,23 +1,106 @@
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
-import { ReceivableFilterType } from '@/components/receivables/ReceivablesTable/types';
+import { components } from '@/api';
+import { ReceivableFilter } from '@/components/receivables/ReceivableFilters/ReceivableFilters';
+import {
+  ReceivableFilterType,
+  ReceivablesTabFilter,
+} from '@/components/receivables/ReceivablesTable/types';
 
-export const useReceivablesFilters = () => {
-  const [filters, setFilters] = useState<ReceivableFilterType>({});
+export const useReceivablesFilters = <T extends keyof ReceivableFilterType>(
+  availableFilters: Array<T>,
+  predefinedQuery?: ReceivablesTabFilter
+) => {
+  const [filtersQuery, setFiltersQuery] = useState<ReceivablesTabFilter>(
+    predefinedQuery ?? {}
+  );
 
-  const onChangeFilter: ReceivablesFilterHandler = (field, value) => {
-    setFilters((prevFilters) => ({
-      ...prevFilters,
-      [field]: value,
-    }));
+  const onChangeFilter = useCallback(
+    (field: T, value: ReceivableFilterType[T]) => {
+      setFiltersQuery((prevFilters) => ({
+        ...prevFilters,
+        [field]: value,
+      }));
+    },
+    []
+  );
+
+  return {
+    filtersQuery,
+    filters: useMemo(
+      () =>
+        availableFilters.map((field) => {
+          return (
+            field === 'status'
+              ? {
+                  field,
+                  value: filtersQuery[field],
+                  options: predefinedQuery?.type
+                    ? filterStatusesByReceivableType(
+                        predefinedQuery.type,
+                        predefinedQuery?.status__in
+                      )
+                    : [],
+                }
+              : {
+                  field,
+                  value: filtersQuery[field],
+                }
+          ) satisfies ReceivableFilter<keyof ReceivableFilterType>;
+        }) as ReceivableFilter<T>[],
+      [availableFilters, filtersQuery, predefinedQuery]
+    ),
+    onChangeFilter,
   };
-
-  return { filters, onChangeFilter };
 };
 
-export type ReceivablesFilterHandler = <
-  Filter extends keyof ReceivableFilterType
->(
-  filter: Filter,
-  value: ReceivableFilterType[Filter]
-) => void;
+const filterStatusesByReceivableType = (
+  receivableType: components['schemas']['ReceivableType'],
+  inStatuses: Array<ReceivablesStatusEnum> | undefined
+) => {
+  if (receivableType === 'invoice') {
+    const invoiceStatuses = [
+      'recurring',
+      'draft',
+      'issued',
+      'partially_paid',
+      'paid',
+      'overdue',
+      'canceled',
+      'uncollectible',
+    ] satisfies Array<ReceivablesStatusEnum>;
+
+    if (!inStatuses) return invoiceStatuses;
+
+    return invoiceStatuses.filter((status) => inStatuses.includes(status));
+  }
+
+  if (receivableType === 'quote') {
+    const quoteStatuses = [
+      'draft',
+      'issued',
+      'accepted',
+      'expired',
+      'declined',
+    ] satisfies Array<ReceivablesStatusEnum>;
+
+    if (!inStatuses) return quoteStatuses;
+
+    return quoteStatuses.filter((status) => inStatuses.includes(status));
+  }
+
+  if (receivableType === 'credit_note') {
+    const creditNoteStatuses = [
+      'draft',
+      'issued',
+    ] satisfies Array<ReceivablesStatusEnum>;
+
+    if (!inStatuses) return creditNoteStatuses;
+
+    return creditNoteStatuses.filter((status) => inStatuses.includes(status));
+  }
+
+  throw new Error(`Unknown receivable type: ${receivableType}`);
+};
+
+type ReceivablesStatusEnum = components['schemas']['ReceivablesStatusEnum'];

--- a/packages/sdk-react/src/components/receivables/Receivables.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.tsx
@@ -4,7 +4,10 @@ import { Dialog } from '@/components/Dialog';
 import { PageHeader } from '@/components/PageHeader';
 import { InvoiceDetails } from '@/components/receivables/InvoiceDetails';
 import { ReceivablesTable } from '@/components/receivables/ReceivablesTable';
-import { useReceivablesTableProps } from '@/components/receivables/ReceivablesTable/ReceivablesTable';
+import {
+  useControlledTab,
+  useReceivablesTableProps,
+} from '@/components/receivables/ReceivablesTable/ReceivablesTable';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useRootElements } from '@/core/context/RootElementsProvider';
 import { useEntityUserByAuthToken } from '@/core/queries';
@@ -27,8 +30,13 @@ const ReceivablesBase = () => {
   const [openDetails, setOpenDetails] = useState<boolean>(false);
   const [isCreateInvoiceDialogOpen, setIsCreateInvoiceDialogOpen] =
     useState<boolean>(false);
-  const { tabs: receivablesTable } = useReceivablesTableProps({});
-  const [activeTabIndex, setActiveTabIndex] = useState(0);
+
+  const { tabs: receivablesTabs, tab: inReceivablesTab } =
+    useReceivablesTableProps();
+
+  const [activeTabIndex, setActiveTabIndex] = useControlledTab({
+    tab: inReceivablesTab ?? 0,
+  });
 
   useEffect(() => {
     if (!invoiceId) {
@@ -133,7 +141,7 @@ const ReceivablesBase = () => {
             setActiveTabIndex(
               Math.max(
                 0,
-                receivablesTable?.findIndex(
+                receivablesTabs?.findIndex(
                   (tab) => tab.query?.type === 'invoice'
                 ) ?? 0
               )

--- a/packages/sdk-react/src/components/receivables/Receivables.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.tsx
@@ -4,7 +4,7 @@ import { Dialog } from '@/components/Dialog';
 import { PageHeader } from '@/components/PageHeader';
 import { InvoiceDetails } from '@/components/receivables/InvoiceDetails';
 import { ReceivablesTable } from '@/components/receivables/ReceivablesTable';
-import { ReceivablesTableTabEnum } from '@/components/receivables/ReceivablesTable/ReceivablesTable';
+import { useReceivablesTableProps } from '@/components/receivables/ReceivablesTable/ReceivablesTable';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useRootElements } from '@/core/context/RootElementsProvider';
 import { useEntityUserByAuthToken } from '@/core/queries';
@@ -27,9 +27,8 @@ const ReceivablesBase = () => {
   const [openDetails, setOpenDetails] = useState<boolean>(false);
   const [isCreateInvoiceDialogOpen, setIsCreateInvoiceDialogOpen] =
     useState<boolean>(false);
-  const [activeTab, setActiveTab] = useState<ReceivablesTableTabEnum>(
-    ReceivablesTableTabEnum.Invoices
-  );
+  const { tabs: receivablesTable } = useReceivablesTableProps({});
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
 
   useEffect(() => {
     if (!invoiceId) {
@@ -103,8 +102,8 @@ const ReceivablesBase = () => {
       {!isReadAllowed && !isReadAllowedLoading && <AccessRestriction />}
       {isReadAllowed && (
         <ReceivablesTable
-          tab={activeTab}
-          onTabChange={setActiveTab}
+          tab={activeTabIndex}
+          onTabChange={setActiveTabIndex}
           onRowClick={onRowClick}
         />
       )}
@@ -131,7 +130,14 @@ const ReceivablesBase = () => {
           type={'invoice'}
           onCreate={() => {
             setIsCreateInvoiceDialogOpen(false);
-            setActiveTab(ReceivablesTableTabEnum.Invoices);
+            setActiveTabIndex(
+              Math.max(
+                0,
+                receivablesTable?.findIndex(
+                  (tab) => tab.query?.type === 'invoice'
+                ) ?? 0
+              )
+            );
           }}
         />
       </Dialog>

--- a/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.stories.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.stories.tsx
@@ -1,3 +1,4 @@
+import { ExtendThemeProvider } from '@/utils/ExtendThemeProvider';
 import { action } from '@storybook/addon-actions';
 import type { Meta, StoryObj } from '@storybook/react';
 
@@ -16,7 +17,75 @@ export const FullPermissions: Story = {
   },
   render: (args) => (
     <div style={{ height: 500, padding: 20 }}>
-      <ReceivablesTable {...args} />
+      <ReceivablesTable {...args} onTabChange={undefined} tab={undefined} />
+    </div>
+  ),
+};
+
+export const WithCustomTabs: Story = {
+  args: {
+    onRowClick: action('onRowClick'),
+  },
+  render: (args) => (
+    <div style={{ height: 500, padding: 20 }}>
+      <ExtendThemeProvider
+        theme={{
+          components: {
+            MoniteReceivablesTable: {
+              defaultProps: {
+                tabs: [
+                  {
+                    label: 'Draft Invoices',
+                    query: {
+                      type: 'invoice',
+                      sort: 'created_at',
+                      order: 'desc',
+                      status__in: ['draft'],
+                    },
+                    filters: [
+                      'document_id__contains',
+                      'counterpart_id',
+                      'due_date__lte',
+                    ],
+                  },
+                  {
+                    label: 'Recurring invoices',
+                    query: {
+                      type: 'invoice',
+                      status__in: ['recurring'],
+                    },
+                    filters: ['document_id__contains', 'counterpart_id'],
+                  },
+                  {
+                    label: 'Other Invoices',
+                    query: {
+                      type: 'invoice',
+                      sort: 'created_at',
+                      order: 'desc',
+                      status__in: [
+                        'issued',
+                        'overdue',
+                        'partially_paid',
+                        'paid',
+                        'uncollectible',
+                        'canceled',
+                      ],
+                    },
+                  },
+                  {
+                    label: 'Credit notes',
+                    query: {
+                      type: 'credit_note',
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }}
+      >
+        <ReceivablesTable {...args} onTabChange={undefined} tab={undefined} />
+      </ExtendThemeProvider>
     </div>
   ),
 };

--- a/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.test.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.test.tsx
@@ -1,65 +1,52 @@
-import { renderWithClient, waitUntilTableIsLoaded } from '@/utils/test-utils';
+import { renderWithClient } from '@/utils/test-utils';
 import { fireEvent, screen } from '@testing-library/react';
 
-import { ReceivablesTable, ReceivablesTableTabEnum } from './ReceivablesTable';
+import { ReceivablesTable } from './ReceivablesTable';
 
 describe('ReceivablesTable', () => {
-  test('should render the list of invoices by default', async () => {
+  test('renders "Invoices" tab by default', async () => {
     renderWithClient(<ReceivablesTable />);
+    const invoicesTab = screen.findByRole('tab', { name: 'Invoices' });
 
-    await waitUntilTableIsLoaded();
+    await expect(invoicesTab).resolves.toHaveAttribute('aria-selected', 'true');
 
     const documents = await screen.findAllByText(/INV-/);
 
     expect(documents[0]).toBeInTheDocument();
   });
 
-  test('should render the list of quotes by default when the customer provides it', async () => {
-    renderWithClient(
-      <ReceivablesTable
-        tab={ReceivablesTableTabEnum.Quotes}
-        onTabChange={jest.fn()}
-      />
-    );
+  test('renders the list of "Quotes" if tab specified', async () => {
+    renderWithClient(<ReceivablesTable tab={1} onTabChange={jest.fn()} />);
+
+    await expect(
+      screen.findByRole('tab', { name: 'Quotes' })
+    ).resolves.toHaveAttribute('aria-selected', 'true');
 
     const documents = await screen.findAllByText(/quote-/);
 
     expect(documents[0]).toBeInTheDocument();
   });
 
-  test('should render the list of invoices when click on tab "Invoices"', async () => {
+  test('renders "Quotes" tab panel when click on tab "Quotes"', async () => {
     renderWithClient(<ReceivablesTable />);
 
-    const invoicesTab = screen.getByText('Invoices');
-    fireEvent.click(invoicesTab);
+    const quotesTab = screen.findByRole('tab', { name: 'Quotes' });
 
-    await waitUntilTableIsLoaded();
+    fireEvent.click(await quotesTab);
 
-    const documents = await screen.findAllByText(/INV-/);
-
-    expect(documents[0]).toBeInTheDocument();
-  });
-
-  test('should render the list of quotes when click on tab "Quotes"', async () => {
-    renderWithClient(<ReceivablesTable />);
-
-    const quotesTab = screen.getByText('Quotes');
-    fireEvent.click(quotesTab);
-
-    await waitUntilTableIsLoaded();
+    await expect(quotesTab).resolves.toHaveAttribute('aria-selected', 'true');
 
     const documents = await screen.findAllByText(/quote--/);
 
     expect(documents[0]).toBeInTheDocument();
   });
 
-  test('should render the list of credit notes when click on tab "Credit notes"', async () => {
-    renderWithClient(<ReceivablesTable />);
+  test('renders the list of "Credit notes" if tab specified', async () => {
+    renderWithClient(<ReceivablesTable tab={2} onTabChange={jest.fn()} />);
 
-    const creditNotesTab = screen.getByText('Credit notes');
-    fireEvent.click(creditNotesTab);
-
-    await waitUntilTableIsLoaded();
+    await expect(
+      screen.findByRole('tab', { name: 'Credit notes' })
+    ).resolves.toHaveAttribute('aria-selected', 'true');
 
     const documents = await screen.findAllByText(/credit_note--/);
 

--- a/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.tsx
@@ -67,6 +67,7 @@ export type ReceivablesTableProps =
  *   components: {
  *     MoniteReceivablesTable: {
  *       defaultProps: {
+ *         tab: 0,                      // The default tab index to display
  *         tabs: [
  *           {
  *             label: 'Draft Invoices', // The label of the Tab
@@ -241,19 +242,33 @@ const ReceivablesTableBase = ({
 
 /**
  * Manages the active tab state for controlled mode and uncontrolled modes.
- * If the `tab` or `onTabChange` prop is provided (not `undefined`), the hook is not controlled.
+ *
+ * - If the `tab === undefined || onTabChange === undefined`, the hook behaves uncontrolled hook;
+ *   that means it handles the internal state.
+ *   - Whenever `tab` is updated, the hook updates the internal state.
+ * - If the `tab !== undefined` and `onTabChange !== undefined`, the hook behaves controlled hook;
+ *   that means it just returns the original state.
  */
-const useControlledTab = ({
-  tab,
-  onTabChange,
+export const useControlledTab = ({
+  tab: controlledTab,
+  onTabChange: setControlledTab,
 }: Pick<ReceivablesTableProps, 'tab' | 'onTabChange'>) => {
-  const [tabControlled, onTabChangeControlled] = useState(0);
+  const [uncontrolledTab, setUncontrolledTab] = useState(controlledTab ?? 0);
 
-  return [tab ?? tabControlled, onTabChange ?? onTabChangeControlled] as const;
+  useEffect(() => {
+    if (controlledTab === undefined) return;
+    if (setControlledTab === undefined) setUncontrolledTab(controlledTab);
+  }, [setControlledTab, controlledTab]);
+
+  if (controlledTab !== undefined && setControlledTab !== undefined) {
+    return [controlledTab, setControlledTab] as const;
+  }
+
+  return [uncontrolledTab, setUncontrolledTab] as const;
 };
 
 export const useReceivablesTableProps = (
-  inProps: Partial<ReceivablesTableProps>
+  inProps?: Partial<MoniteReceivablesTableProps>
 ) => {
   return useThemeProps({
     props: inProps,

--- a/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.tsx
+++ b/packages/sdk-react/src/components/receivables/ReceivablesTable/ReceivablesTable.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 import { CreditNotesTable } from '@/components';
 import { InvoicesTable } from '@/components';
@@ -15,33 +15,46 @@ import { useLingui } from '@lingui/react';
 import { Box, Tab, Tabs } from '@mui/material';
 import { useThemeProps } from '@mui/material/styles';
 
-interface ReceivablesTableUncontrolledProps {
-  tab?: undefined;
-  onTabChange?: undefined;
-}
-
 interface ReceivablesTableControlledProps {
-  /** Active-selected tab */
-  tab: number;
-
   /** Event handler for tab change */
   onTabChange: (tab: number) => void;
+
+  /** Active-selected tab */
+  tab: number;
 }
 
-export type ReceivablesTableProps = {
-  /**
-   * The event handler for a row click.
-   *
-   * @param id - The identifier of the clicked row, a string.
-   */
-  onRowClick?: (id: string) => void;
+interface ReceivablesTableUncontrolledProps {
+  /** Active-selected tab */
+  tab?: number;
+  onTabChange?: never;
+}
+
+/**
+ * Receivables Table props for MUI theming
+ */
+export interface MoniteReceivablesTableProps {
+  /** Active-selected tab */
+  tab?: number;
 
   /**
    * The tabs to display in the ReceivablesTable.
    * By default, the component will display tabs for Invoices, Quotes, and Credit Notes.
    */
   tabs?: Array<MoniteReceivablesTab>;
-} & (ReceivablesTableUncontrolledProps | ReceivablesTableControlledProps);
+}
+
+interface ReceivablesTableBaseProps {
+  /**
+   * The event handler for a row click.
+   *
+   * @param id - The identifier of the clicked row, a string.
+   */
+  onRowClick?: (id: string) => void;
+}
+
+export type ReceivablesTableProps =
+  | (ReceivablesTableControlledProps & ReceivablesTableBaseProps)
+  | (ReceivablesTableUncontrolledProps & ReceivablesTableBaseProps);
 
 /**
  * ReceivablesTable component
@@ -119,9 +132,12 @@ type MoniteReceivablesTab = {
   filters?: Array<keyof ReceivableFilterType>;
 };
 
-const ReceivablesTableBase = (inProps: ReceivablesTableProps) => {
-  const { tab, onTabChange, onRowClick, tabs } =
-    useReceivablesTableProps(inProps);
+const ReceivablesTableBase = ({
+  onRowClick,
+  onTabChange,
+  ...inProps
+}: ReceivablesTableProps) => {
+  const { tab, tabs } = useReceivablesTableProps(inProps);
 
   const { i18n } = useLingui();
   const [activeTabIndex, setActiveTabIndex] = useControlledTab({

--- a/packages/sdk-react/src/components/receivables/ReceivablesTable/types.ts
+++ b/packages/sdk-react/src/components/receivables/ReceivablesTable/types.ts
@@ -1,4 +1,5 @@
 import { components, Services } from '@/api';
+import { API } from '@/api/client';
 
 export type ReceivableFilterType = Pick<
   NonNullable<
@@ -16,3 +17,7 @@ export type FilterValue =
   | components['schemas']['ReceivablesStatusEnum']
   | string
   | null;
+
+export type ReceivablesTabFilter = NonNullable<
+  API['receivables']['getReceivables']['types']['parameters']['query']
+>;

--- a/packages/sdk-react/src/core/context/MoniteContext.tsx
+++ b/packages/sdk-react/src/core/context/MoniteContext.tsx
@@ -16,9 +16,10 @@ import {
   type MoniteLocale,
 } from '@/core/context/MoniteI18nProvider';
 import { SentryFactory } from '@/core/services';
+import { createThemeWithDefaults } from '@/core/utils/createThemeWithDefaults';
 import type { I18n } from '@lingui/core';
 import type { MoniteSDK } from '@monite/sdk-api';
-import type { Theme } from '@mui/material';
+import type { Theme, ThemeOptions } from '@mui/material';
 import type { Hub } from '@sentry/react';
 import type { QueryClient } from '@tanstack/react-query';
 
@@ -29,7 +30,6 @@ interface MoniteContextBaseValue {
   locale: MoniteLocaleWithRequired;
   i18n: I18n;
   dateFnsLocale: DateFnsLocale;
-  theme: Theme;
 }
 
 export interface MoniteContextValue
@@ -38,6 +38,7 @@ export interface MoniteContextValue
   sentryHub: Hub | undefined;
   queryClient: QueryClient;
   apiUrl: string;
+  theme: Theme;
   fetchToken: () => Promise<{
     access_token: string;
     expires_in: number;
@@ -68,7 +69,7 @@ export function useMoniteContext() {
 interface MoniteContextProviderProps {
   monite: MoniteSDK;
   locale: Partial<MoniteLocale> | undefined;
-  theme: Theme;
+  theme: Theme | ThemeOptions | undefined;
   children: ReactNode;
 }
 
@@ -100,6 +101,7 @@ export const MoniteContextProvider = ({
 
 interface ContextProviderProps extends MoniteContextBaseValue {
   children: ReactNode;
+  theme: Theme | ThemeOptions | undefined;
 }
 
 const ContextProvider = ({
@@ -107,7 +109,7 @@ const ContextProvider = ({
   locale,
   i18n,
   dateFnsLocale,
-  theme,
+  theme: userTheme,
   children,
 }: ContextProviderProps) => {
   const sentryHub = useMemo(() => {
@@ -131,6 +133,11 @@ const ContextProvider = ({
         context: MoniteQraftContext,
       }),
     [monite.entityId]
+  );
+
+  const theme = useMemo(
+    () => createThemeWithDefaults(i18n, userTheme),
+    [i18n, userTheme]
   );
 
   useEffect(() => {

--- a/packages/sdk-react/src/core/context/MoniteProvider.tsx
+++ b/packages/sdk-react/src/core/context/MoniteProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo } from 'react';
+import { ReactNode } from 'react';
 
 import { ContainerCssBaseline } from '@/components/ContainerCssBaseline';
 import { EmotionCacheProvider } from '@/core/context/EmotionCacheProvider';
@@ -7,13 +7,12 @@ import {
   MoniteQraftContext,
 } from '@/core/context/MoniteAPIProvider';
 import { MoniteLocale } from '@/core/context/MoniteI18nProvider';
-import { createThemeWithDefaults } from '@/core/utils/createThemeWithDefaults';
 import { MoniteSDK } from '@monite/sdk-api';
 import { Theme, ThemeOptions } from '@mui/material';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
 
 import { GlobalToast } from '../GlobalToast';
-import { MoniteContextProvider } from './MoniteContext';
+import { MoniteContextProvider, useMoniteContext } from './MoniteContext';
 
 export interface MoniteProviderProps {
   children?: ReactNode;
@@ -44,19 +43,22 @@ export const MoniteProvider = ({
   children,
   locale,
 }: MoniteProviderProps) => {
-  const muiTheme = useMemo(() => createThemeWithDefaults(theme), [theme]);
-
   return (
-    <MoniteContextProvider monite={monite} locale={locale} theme={muiTheme}>
+    <MoniteContextProvider monite={monite} locale={locale} theme={theme}>
       <EmotionCacheProvider cacheKey="monite-css-baseline">
-        <MuiThemeProvider theme={muiTheme}>
+        <MoniteMuiThemeProvider>
           <ContainerCssBaseline enableColorScheme />
           <GlobalToast />
-        </MuiThemeProvider>
+        </MoniteMuiThemeProvider>
       </EmotionCacheProvider>
       <MoniteAPIProvider APIContext={MoniteQraftContext}>
         {children}
       </MoniteAPIProvider>
     </MoniteContextProvider>
   );
+};
+
+const MoniteMuiThemeProvider = ({ children }: { children: ReactNode }) => {
+  const { theme } = useMoniteContext();
+  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
 };

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -353,7 +353,7 @@ msgstr "Algerian Dinar"
 msgid "All"
 msgstr "All"
 
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:113
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:140
 msgid "All customers"
 msgstr "All customers"
 
@@ -374,7 +374,7 @@ msgstr "All future iterations of this invoice will be canceled."
 msgid "All invoices"
 msgstr "All invoices"
 
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:82
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:103
 msgid "All statuses"
 msgstr "All statuses"
 
@@ -398,11 +398,11 @@ msgstr "American Samoa"
 #: src/components/approvalPolicies/ApprovalPoliciesTable/components/ApprovalPoliciesTriggers.tsx:80
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:216
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:218
-#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:121
+#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:142
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:242
 #: src/components/receivables/InvoiceDetails/InvoiceItems/InvoiceItems.tsx:35
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:173
-#: src/components/receivables/QuotesTable/QuotesTable.tsx:144
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:197
+#: src/components/receivables/QuotesTable/QuotesTable.tsx:163
 msgid "Amount"
 msgstr "Amount"
 
@@ -1672,7 +1672,7 @@ msgstr "Create from mail"
 #: src/components/receivables/Receivables.test.tsx:35
 #: src/components/receivables/Receivables.test.tsx:72
 #: src/components/receivables/Receivables.test.tsx:110
-#: src/components/receivables/Receivables.tsx:99
+#: src/components/receivables/Receivables.tsx:98
 msgid "Create Invoice"
 msgstr "Create Invoice"
 
@@ -1746,15 +1746,15 @@ msgstr "Created by"
 msgid "Created by user"
 msgstr "Created by user"
 
-#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:88
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:140
-#: src/components/receivables/QuotesTable/QuotesTable.tsx:102
+#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:109
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:164
+#: src/components/receivables/QuotesTable/QuotesTable.tsx:121
 #: src/components/userRoles/UserRolesTable/Filters/Filters.tsx:34
 #: src/components/userRoles/UserRolesTable/UserRolesTable.tsx:159
 msgid "Created on"
 msgstr "Created on"
 
-#: src/components/receivables/ReceivablesTable/ReceivablesTable.tsx:91
+#: src/core/utils/createThemeWithDefaults.ts:33
 msgid "Credit notes"
 msgstr "Credit notes"
 
@@ -1802,14 +1802,14 @@ msgstr "Current status"
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartIndividualView/CounterpartIndividualView.tsx:47
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartOrganizationView/CounterpartOrganizationView.tsx:73
 #: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:271
-#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:102
+#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:123
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx:143
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:138
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewCustomerSection.tsx:56
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:130
-#: src/components/receivables/QuotesTable/QuotesTable.tsx:117
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:101
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:106
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:154
+#: src/components/receivables/QuotesTable/QuotesTable.tsx:136
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:122
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:127
 msgid "Customer"
 msgstr "Customer"
 
@@ -2178,9 +2178,9 @@ msgstr "Dry Cleaners"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:235
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:420
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/reminderCardTermsHelpers.tsx:45
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:184
-#: src/components/receivables/QuotesTable/QuotesTable.tsx:126
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:131
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:208
+#: src/components/receivables/QuotesTable/QuotesTable.tsx:145
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:158
 msgid "Due date"
 msgstr "Due date"
 
@@ -3067,7 +3067,7 @@ msgstr "Insurance Underwriting, Premiums"
 msgid "Intra-Company Purchases"
 msgstr "Intra-Company Purchases"
 
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:121
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:145
 msgid "INV-auto"
 msgstr "INV-auto"
 
@@ -3151,7 +3151,7 @@ msgstr "Invoice to “{0}” was created"
 msgid "Invoice total"
 msgstr "Invoice total"
 
-#: src/components/receivables/ReceivablesTable/ReceivablesTable.tsx:77
+#: src/core/utils/createThemeWithDefaults.ts:25
 msgid "Invoices"
 msgstr "Invoices"
 
@@ -3202,8 +3202,8 @@ msgstr "Issue at"
 
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:188
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:191
-#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:95
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:148
+#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:116
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:172
 msgid "Issue date"
 msgstr "Issue date"
 
@@ -3213,7 +3213,7 @@ msgstr "Issue date"
 msgid "Issue date Name"
 msgstr "Issue date"
 
-#: src/components/receivables/QuotesTable/QuotesTable.tsx:109
+#: src/components/receivables/QuotesTable/QuotesTable.tsx:128
 msgid "Issue Date"
 msgstr "Issue Date"
 
@@ -4053,9 +4053,9 @@ msgstr "Norwegian Krone"
 msgid "NOT allowed"
 msgstr "NOT allowed"
 
-#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:83
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:109
-#: src/components/receivables/QuotesTable/QuotesTable.tsx:97
+#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:104
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:133
+#: src/components/receivables/QuotesTable/QuotesTable.tsx:116
 msgid "Number"
 msgstr "Number"
 
@@ -4712,7 +4712,7 @@ msgstr "Quebec Sales Tax (Canada)"
 msgid "Quick Copy, Repro, and Blueprint"
 msgstr "Quick Copy, Repro, and Blueprint"
 
-#: src/components/receivables/ReceivablesTable/ReceivablesTable.tsx:84
+#: src/core/utils/createThemeWithDefaults.ts:29
 msgid "Quotes"
 msgstr "Quotes"
 
@@ -4745,7 +4745,7 @@ msgstr "Receivable type {0} is not supported. Only invoice is supported."
 msgid "Receivable type not supported"
 msgstr "Receivable type not supported"
 
-#: src/components/receivables/ReceivablesTable/ReceivablesTable.tsx:71
+#: src/components/receivables/ReceivablesTable/ReceivablesTable.tsx:147
 msgid "Receivables tabs"
 msgstr "Receivables tabs"
 
@@ -4786,7 +4786,7 @@ msgid "Recurrence was completed, all invoices were issued"
 msgstr "Recurrence was completed, all invoices were issued"
 
 #: src/components/receivables/getCommonStatusLabel.ts:21
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:113
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:137
 msgid "Recurring"
 msgstr "Recurring"
 
@@ -5019,7 +5019,7 @@ msgstr "Saint Pierre And Miquelon"
 msgid "Saint Vincent And Grenadines"
 msgstr "Saint Vincent And Grenadines"
 
-#: src/components/receivables/Receivables.tsx:84
+#: src/components/receivables/Receivables.tsx:83
 msgid "Sales"
 msgstr "Sales"
 
@@ -5094,7 +5094,7 @@ msgstr "Script in Monite Script"
 #: src/components/products/ProductsTable/components/Filters/Filters.tsx:38
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTableFilters.tsx:38
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTableFilters.tsx:41
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:52
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:63
 #: src/components/userRoles/UserRolesTable/Filters/Filters.tsx:25
 msgid "Search"
 msgstr "Search"
@@ -5379,12 +5379,12 @@ msgstr "Stationery Stores, Office, and School Supply Stores"
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:207
 #: src/components/payables/PayablesTable/Filters/Filters.tsx:48
 #: src/components/payables/PayablesTable/Filters/Filters.tsx:51
-#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:111
+#: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:132
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceIterations.tsx:57
-#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:156
-#: src/components/receivables/QuotesTable/QuotesTable.tsx:134
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:67
-#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:70
+#: src/components/receivables/InvoicesTable/InvoicesTable.tsx:180
+#: src/components/receivables/QuotesTable/QuotesTable.tsx:153
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:87
+#: src/components/receivables/ReceivableFilters/ReceivableFilters.tsx:90
 msgid "Status"
 msgstr "Status"
 

--- a/packages/sdk-react/src/core/utils/createThemeWithDefaults.ts
+++ b/packages/sdk-react/src/core/utils/createThemeWithDefaults.ts
@@ -1,4 +1,6 @@
 import { ScopedCssBaselineContainerClassName } from '@/components/ContainerCssBaseline';
+import type { I18n } from '@lingui/core';
+import { t } from '@lingui/macro';
 import {
   createTheme,
   type Theme,
@@ -7,44 +9,70 @@ import {
 } from '@mui/material';
 
 /**
- * Create a theme with default component's `defaultProps`
+ * Create a theme with the default component's `defaultProps`
  */
 export const createThemeWithDefaults = (
+  i18n: I18n,
   theme: Theme | ThemeOptions | undefined
 ) =>
-  createTheme(theme, {
-    components: {
-      ...createComponentsThemeDefaultProps(
-        [
-          'MuiMenu',
-          'MuiModal',
-          'MuiPopper',
-          'MuiDialogTitle',
-          'MuiDialogContent',
-          'MuiDialogActions',
-          'MuiDivider',
-        ],
-        {
-          classes: {
-            root: ScopedCssBaselineContainerClassName,
+  createTheme(
+    {
+      components: {
+        MoniteReceivablesTable: {
+          defaultProps: {
+            tabs: [
+              {
+                label: t(i18n)`Invoices`,
+                query: { type: 'invoice' },
+              },
+              {
+                label: t(i18n)`Quotes`,
+                query: { type: 'quote' },
+              },
+              {
+                label: t(i18n)`Credit notes`,
+                query: { type: 'credit_note' },
+              },
+            ],
           },
-        }
-      ),
-      ...createComponentsThemeDefaultProps(['MuiGrid', 'MuiDialog'], {
-        classes: { container: ScopedCssBaselineContainerClassName },
-      }),
-      MuiStack: {
-        defaultProps: {
-          className: ScopedCssBaselineContainerClassName,
         },
       },
-      MuiAutocomplete: {
-        defaultProps: {
-          classes: { popper: ScopedCssBaselineContainerClassName },
+    } satisfies ThemeOptions,
+    theme ?? {},
+    {
+      components: {
+        ...createComponentsThemeDefaultProps(
+          [
+            'MuiMenu',
+            'MuiModal',
+            'MuiPopper',
+            'MuiDialogTitle',
+            'MuiDialogContent',
+            'MuiDialogActions',
+            'MuiDivider',
+          ],
+          {
+            classes: {
+              root: ScopedCssBaselineContainerClassName,
+            },
+          }
+        ),
+        ...createComponentsThemeDefaultProps(['MuiGrid', 'MuiDialog'], {
+          classes: { container: ScopedCssBaselineContainerClassName },
+        }),
+        MuiStack: {
+          defaultProps: {
+            className: ScopedCssBaselineContainerClassName,
+          },
+        },
+        MuiAutocomplete: {
+          defaultProps: {
+            classes: { popper: ScopedCssBaselineContainerClassName },
+          },
         },
       },
-    },
-  });
+    } satisfies ThemeOptions
+  );
 
 /**
  * Create a `defaultProps` for the given MUI component list

--- a/packages/sdk-react/src/ui/SearchField/SearchField.tsx
+++ b/packages/sdk-react/src/ui/SearchField/SearchField.tsx
@@ -25,6 +25,7 @@ export const DEBOUNCE_SEARCH_TIMEOUT: number = 500;
 interface Props {
   label: string;
   onChange: (value: string | null) => void;
+  value?: string;
 }
 
 /**
@@ -35,6 +36,7 @@ interface Props {
  * @component
  * @param {object} props - The properties that define the `SearchField` component.
  * @param {string} props.label - The label for the search field.
+ * @param {string} props.value - The initial value of the search field.
  * @param {(value: string | null) => void} props.onChange - The function to be called when the input value changes.
  *
  * @example
@@ -43,7 +45,7 @@ interface Props {
  * @returns {React.ReactElement} Returns a `FormControl` element that contains the search field.
  */
 
-export const SearchField = ({ label, onChange }: Props) => {
+export const SearchField = ({ label, onChange, value }: Props) => {
   const debouncedOnChange = useMemo(
     () => debounce(onChange, DEBOUNCE_SEARCH_TIMEOUT),
     [onChange]
@@ -68,6 +70,7 @@ export const SearchField = ({ label, onChange }: Props) => {
         name="search-by-name"
         aria-label="search-by-name"
         label={label}
+        value={value}
         onChange={(search) => {
           debouncedOnChange(search.target.value || null);
         }}

--- a/packages/sdk-react/src/utils/ExtendThemeProvider.tsx
+++ b/packages/sdk-react/src/utils/ExtendThemeProvider.tsx
@@ -1,11 +1,7 @@
 import { ReactNode } from 'react';
 
-import {
-  createTheme,
-  ThemeOptions,
-  ThemeProvider,
-  useTheme,
-} from '@mui/material';
+import { MoniteContext, useMoniteContext } from '@/core/context/MoniteContext';
+import { createTheme, ThemeOptions, ThemeProvider } from '@mui/material';
 
 /**
  * Extends the current theme with the provided theme options.
@@ -19,10 +15,18 @@ export function ExtendThemeProvider({
   theme: ThemeOptions;
   children: ReactNode;
 }) {
-  const mainTheme = useTheme();
+  const moniteContext = useMoniteContext();
+  const extendedTheme = createTheme(moniteContext.theme, theme);
   return (
-    <ThemeProvider theme={createTheme(mainTheme, theme)}>
-      {children}
+    <ThemeProvider theme={extendedTheme}>
+      <MoniteContext.Provider
+        value={{
+          ...moniteContext,
+          theme: extendedTheme,
+        }}
+      >
+        {children}
+      </MoniteContext.Provider>
     </ThemeProvider>
   );
 }

--- a/packages/sdk-react/src/utils/test-utils.tsx
+++ b/packages/sdk-react/src/utils/test-utils.tsx
@@ -111,7 +111,7 @@ export const Provider = ({
         i18n,
         sentryHub,
         queryClient: client,
-        theme: createThemeWithDefaults(moniteProviderProps?.theme),
+        theme: createThemeWithDefaults(i18n, moniteProviderProps?.theme),
         dateFnsLocale,
         apiUrl: monite.baseUrl,
         fetchToken: monite.fetchToken,


### PR DESCRIPTION
- Added support for configuring custom tabs in Receivables Tables using MUI Theming.
- Maintained backward compatibility with default tabs: Invoices, Quotes, and Credit Notes.
- Updated the `<ReceivablesTable/>` component to use numeric tab indices instead of `ReceivablesTableTabEnum`.
- Changed default tab indices:
  - **Invoices**: 0
  - **Quotes**: 1
  - **Credit Notes**: 2