### PR TITLE
fix(DEV-12351): hide cell selection indicator

### DIFF
--- a/.changeset/small-dryers-happen.md
+++ b/.changeset/small-dryers-happen.md
@@ -1,0 +1,5 @@
+---
+'@team-monite/sdk-themes': minor
+---
+
+Hide focused cell indicator on click - only the whole row should be selected

--- a/packages/sdk-themes/src/themes/monite.ts
+++ b/packages/sdk-themes/src/themes/monite.ts
@@ -550,6 +550,9 @@ export const defaultMoniteComponents: Components<Omit<Theme, 'components'>> = {
           overflow: 'hidden',
           textOverflow: 'ellipsis',
         },
+        '&:focus': {
+          outline: 'none',
+        },
       },
       footerContainer: {
         '& .Monite-RowsPerPageSelector div[role="combobox"]': {


### PR DESCRIPTION
This PR hides cell selection indicator that appears on cell click, but it doesn't gives any value.