### PR TITLE
chore(DEV-11417): refine status icons 🤌

### DIFF
--- a/.changeset/funny-apples-tell.md
+++ b/.changeset/funny-apples-tell.md
@@ -1,0 +1,7 @@
+---
+'@monite/sdk-react': patch
+---
+
+chore(DEV-11417): unify custom status chip interfaces
+
+Removed forced small size for status chips, allowing backward compatibility.

--- a/packages/sdk-demo/src/hooks/useThemeConfig.tsx
+++ b/packages/sdk-demo/src/hooks/useThemeConfig.tsx
@@ -16,53 +16,47 @@ import {
 export const getThemeOptions = (themeConfig: ThemeConfig) => {
   const { variant, mode } = themeConfig;
 
-  const defaultThemeOptions: ThemeOptions = {
-    components: {
-      MoniteInvoiceStatusChip: {
-        defaultProps: {
-          icon: true,
-          size: 'small',
-        },
-      },
-      MonitePayableStatusChip: {
-        defaultProps: {
-          icon: true,
-        },
-      },
-      MoniteApprovalRequestStatusChip: {
-        defaultProps: {
-          icon: true,
-        },
-      },
-      MoniteInvoiceRecurrenceStatusChip: {
-        defaultProps: {
-          icon: true,
-        },
-      },
-      MoniteInvoiceRecurrenceIterationStatusChip: {
-        defaultProps: {
-          icon: true,
-        },
-      },
-      MoniteTablePagination: {
-        defaultProps: {
-          pageSizeOptions: [10, 15, 20],
-        },
-      },
-    },
-  };
-
   if (variant === 'material') {
     return deepmerge(
       mode === 'light' ? themeMaterialLight : themeMaterialDark,
-      defaultThemeOptions
+      {
+        components: {
+          MoniteInvoiceStatusChip: {
+            defaultProps: {
+              icon: true,
+            },
+          },
+          MonitePayableStatusChip: {
+            defaultProps: {
+              icon: true,
+            },
+          },
+          MoniteApprovalRequestStatusChip: {
+            defaultProps: {
+              icon: true,
+            },
+          },
+          MoniteInvoiceRecurrenceStatusChip: {
+            defaultProps: {
+              icon: true,
+            },
+          },
+          MoniteInvoiceRecurrenceIterationStatusChip: {
+            defaultProps: {
+              icon: true,
+            },
+          },
+          MoniteTablePagination: {
+            defaultProps: {
+              pageSizeOptions: [10, 15, 20],
+            },
+          },
+        },
+      } satisfies ThemeOptions
     );
   }
 
-  return deepmerge(
-    mode === 'light' ? themeMoniteLight : themeMoniteDark,
-    defaultThemeOptions
-  );
+  return mode === 'light' ? themeMoniteLight : themeMoniteDark;
 };
 
 export const useThemeConfig = () => {

--- a/packages/sdk-react/mui-styles.d.ts
+++ b/packages/sdk-react/mui-styles.d.ts
@@ -1,8 +1,8 @@
-import { type MoniteApprovalRequestStatusChipProps } from '@/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip';
-import { type PayableStatusChipProps } from '@/components/payables/PayableStatusChip/PayableStatusChip';
-import { InvoiceRecurrenceIterationStatusChipProps } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip';
-import { InvoiceRecurrenceStatusChipProps } from '@/components/receivables/InvoiceRecurrenceStatusChip/InvoiceRecurrenceStatusChip';
-import { type InvoiceStatusChipProps } from '@/components/receivables/InvoiceStatusChip';
+import { type MoniteApprovalRequestStatusChipProps } from '@/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip/ApprovalRequestStatusChip';
+import { type MonitePayableStatusChipProps } from '@/components/payables/PayableStatusChip/PayableStatusChip';
+import { type MoniteInvoiceRecurrenceIterationStatusChipProps } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip';
+import { type MoniteInvoiceRecurrenceStatusChipProps } from '@/components/receivables/InvoiceRecurrenceStatusChip/InvoiceRecurrenceStatusChip';
+import { type MoniteInvoiceStatusChipProps } from '@/components/receivables/InvoiceStatusChip/InvoiceStatusChip';
 import { MoniteTablePaginationProps } from '@/ui/table/TablePagination';
 import {
   ComponentsOverrides,
@@ -41,12 +41,12 @@ declare module '@mui/material/styles' {
    * Extends MUI component list
    */
   interface ComponentsPropsList {
-    MoniteInvoiceStatusChip: Partial<InvoiceStatusChipProps>;
-    MonitePayableStatusChip: Partial<PayableStatusChipProps>;
+    MoniteInvoiceStatusChip: Partial<MoniteInvoiceStatusChipProps>;
+    MonitePayableStatusChip: Partial<MonitePayableStatusChipProps>;
     MoniteApprovalRequestStatusChip: Partial<MoniteApprovalRequestStatusChipProps>;
     MoniteTablePagination: Partial<MoniteTablePaginationProps>;
-    MoniteInvoiceRecurrenceStatusChip: Partial<InvoiceRecurrenceStatusChipProps>;
-    MoniteInvoiceRecurrenceIterationStatusChip: Partial<InvoiceRecurrenceIterationStatusChipProps>;
+    MoniteInvoiceRecurrenceStatusChip: Partial<MoniteInvoiceRecurrenceStatusChipProps>;
+    MoniteInvoiceRecurrenceIterationStatusChip: Partial<MoniteInvoiceRecurrenceIterationStatusChipProps>;
   }
 
   /**

--- a/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip/ApprovalRequestStatusChip.tsx
+++ b/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip/ApprovalRequestStatusChip.tsx
@@ -13,17 +13,15 @@ import { getRowToStatusTextMap } from '../../helpers';
 
 type ApprovalRequestStatus = components['schemas']['ApprovalRequestStatus'];
 
-interface ApprovalRequestStatusChipRootProps {
+export interface MoniteApprovalRequestStatusChipProps {
   /** The status of the approval request. */
   status: ApprovalRequestStatus;
-  /** The variant of the Chip. */
-  variant?: ChipProps['variant'];
-}
-
-export interface ApprovalRequestStatusChipProps
-  extends ApprovalRequestStatusChipRootProps {
-  /** Display status icon? */
+  /** The size of the Chip. */
   icon?: boolean;
+  /** Display status icon? */
+  variant?: ChipProps['variant'];
+  /** The variant of the Chip. */
+  size?: ChipProps['size'];
 }
 
 /**
@@ -54,7 +52,7 @@ export interface ApprovalRequestStatusChipProps
 
 export const ApprovalRequestStatusChip = forwardRef<
   HTMLDivElement,
-  ApprovalRequestStatusChipProps
+  MoniteApprovalRequestStatusChipProps
 >((inProps, ref) => {
   const props = useThemeProps({
     props: inProps,
@@ -72,30 +70,20 @@ export const ApprovalRequestStatusChip = forwardRef<
       color={ROW_TO_STATUS_MUI_MAP[props.status]}
       icon={props.icon && Icon ? <Icon fontSize="small" /> : undefined}
       label={getRowToStatusTextMap(i18n)[props.status]}
-      status={props.status}
+      size={props.size}
       variant={props.variant ?? 'filled'}
     />
   );
 });
 
 const StyledChip = styled(
-  forwardRef<HTMLDivElement, ChipProps & ApprovalRequestStatusChipRootProps>(
-    (props, ref) => <Chip ref={ref} {...props} />
-  ),
+  forwardRef<HTMLDivElement, ChipProps>((props, ref) => (
+    <Chip ref={ref} {...props} />
+  )),
   {
     // eslint-disable-next-line lingui/no-unlocalized-strings
     name: 'MoniteApprovalRequestStatusChip',
     slot: 'root',
-    shouldForwardProp: (prop) => {
-      switch (prop) {
-        case 'variant':
-        case 'label':
-        case 'color':
-        case 'icon':
-          return true;
-        default:
-          return false;
-      }
-    },
+    shouldForwardProp: () => true,
   }
 )({});

--- a/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip/index.ts
+++ b/packages/sdk-react/src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip/index.ts
@@ -1,4 +1,1 @@
-export {
-  ApprovalRequestStatusChip,
-  type ApprovalRequestStatusChipProps,
-} from './ApprovalRequestStatusChip';
+export { ApprovalRequestStatusChip } from './ApprovalRequestStatusChip';

--- a/packages/sdk-react/src/components/payables/PayableStatusChip/PayableStatusChip.tsx
+++ b/packages/sdk-react/src/components/payables/PayableStatusChip/PayableStatusChip.tsx
@@ -10,18 +10,15 @@ import { useLingui } from '@lingui/react';
 import { Chip, ChipProps } from '@mui/material';
 import { styled, useThemeProps } from '@mui/material/styles';
 
-interface PayableStatusChipRootProps {
+export interface MonitePayableStatusChipProps {
   /** The status of the payable. */
   status: components['schemas']['PayableStateEnum'];
+  /** Display status icon? */
+  icon?: boolean;
   /** The variant of the Chip. */
   variant?: ChipProps['variant'];
   /** The size of the Chip. */
   size?: ChipProps['size'];
-}
-
-export interface PayableStatusChipProps extends PayableStatusChipRootProps {
-  /** Display status icon? */
-  icon?: boolean;
 }
 
 /**
@@ -52,7 +49,7 @@ export interface PayableStatusChipProps extends PayableStatusChipRootProps {
  */
 export const PayableStatusChip = forwardRef<
   HTMLDivElement,
-  PayableStatusChipProps
+  MonitePayableStatusChipProps
 >((inProps, ref) => {
   const props = useThemeProps({
     props: inProps,
@@ -70,31 +67,19 @@ export const PayableStatusChip = forwardRef<
       color={ROW_TO_STATUS_MUI_MAP[props.status]}
       icon={props.icon && Icon ? <Icon fontSize="small" /> : undefined}
       label={getRowToStatusTextMap(i18n)[props.status]}
-      status={props.status}
-      size={props.size ?? 'small'}
+      size={props.size}
       variant={props.variant ?? 'filled'}
     />
   );
 });
 
 const StyledChip = styled(
-  forwardRef<HTMLDivElement, ChipProps & PayableStatusChipRootProps>(
-    (props, ref) => <Chip ref={ref} {...props} />
-  ),
+  forwardRef<HTMLDivElement, ChipProps>((props, ref) => (
+    <Chip ref={ref} {...props} />
+  )),
   {
     name: 'MonitePayableStatusChip',
     slot: 'root',
-    shouldForwardProp: (prop) => {
-      switch (prop) {
-        case 'variant':
-        case 'label':
-        case 'color':
-        case 'icon':
-        case 'size':
-          return true;
-        default:
-          return false;
-      }
-    },
+    shouldForwardProp: () => true,
   }
 )({});

--- a/packages/sdk-react/src/components/payables/PayableStatusChip/index.ts
+++ b/packages/sdk-react/src/components/payables/PayableStatusChip/index.ts
@@ -1,4 +1,1 @@
-export {
-  PayableStatusChip,
-  type PayableStatusChipProps,
-} from './PayableStatusChip';
+export { PayableStatusChip } from './PayableStatusChip';

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx
@@ -149,7 +149,10 @@ export const OverviewTabPanel = ({
             ? {
                 label: t(i18n)`Current status`,
                 value: recurrence ? (
-                  <InvoiceRecurrenceStatusChip status={recurrence?.status} />
+                  <InvoiceRecurrenceStatusChip
+                    status={recurrence?.status}
+                    size="small"
+                  />
                 ) : (
                   <Skeleton variant="text" width="50%" />
                 ),

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceIterations.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceIterations.tsx
@@ -1,7 +1,7 @@
 import { components } from '@/api';
 import { INVOICE_DOCUMENT_AUTO_ID } from '@/components/receivables/consts';
 import { InvoiceRecurrenceIterationStatusChip } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip';
-import { InvoiceRecurrenceIterationStatusChipProps } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip';
+import { MoniteInvoiceRecurrenceIterationStatusChipProps } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip';
 import { InvoiceStatusChip } from '@/components/receivables/InvoiceStatusChip';
 import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useCurrencies } from '@/core/hooks';
@@ -41,7 +41,7 @@ export const InvoiceRecurrenceIterations = ({
     );
 
   const { size: unifiedChipSize = 'small' } = useThemeProps({
-    props: {} as Pick<InvoiceRecurrenceIterationStatusChipProps, 'size'>,
+    props: {} as Pick<MoniteInvoiceRecurrenceIterationStatusChipProps, 'size'>,
     name: 'MoniteInvoiceRecurrenceIterationStatusChip',
   });
 

--- a/packages/sdk-react/src/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip.tsx
@@ -13,7 +13,7 @@ import {
 import { Chip, ChipProps } from '@mui/material';
 import { styled, useThemeProps } from '@mui/material/styles';
 
-export interface InvoiceRecurrenceIterationStatusChipProps {
+export interface MoniteInvoiceRecurrenceIterationStatusChipProps {
   /** The status of the iteration. */
   status: components['schemas']['IterationStatus'];
   /** The variant of the Chip. */
@@ -53,7 +53,7 @@ export interface InvoiceRecurrenceIterationStatusChipProps {
  */
 export const InvoiceRecurrenceIterationStatusChip = forwardRef<
   HTMLDivElement,
-  InvoiceRecurrenceIterationStatusChipProps
+  MoniteInvoiceRecurrenceIterationStatusChipProps
 >((inProps, ref) => {
   const { status, variant, icon, size } = useThemeProps({
     props: inProps,
@@ -71,7 +71,7 @@ export const InvoiceRecurrenceIterationStatusChip = forwardRef<
       icon={icon && Icon ? <Icon fontSize="small" /> : undefined}
       label={getIterationStatusLabel(i18n, status)}
       status={status}
-      size={size ?? 'small'}
+      size={size}
       variant={variant ?? 'filled'}
     />
   );
@@ -80,23 +80,12 @@ export const InvoiceRecurrenceIterationStatusChip = forwardRef<
 const StyledChip = styled(
   forwardRef<
     HTMLDivElement,
-    ChipProps & Omit<InvoiceRecurrenceIterationStatusChipProps, 'icon'>
+    ChipProps & Omit<MoniteInvoiceRecurrenceIterationStatusChipProps, 'icon'>
   >((props, ref) => <Chip ref={ref} {...props} />),
   {
     name: 'MoniteInvoiceRecurrenceIterationStatusChip',
     slot: 'root',
-    shouldForwardProp: (prop) => {
-      switch (prop) {
-        case 'variant':
-        case 'label':
-        case 'color':
-        case 'icon':
-        case 'size':
-          return true;
-        default:
-          return false;
-      }
-    },
+    shouldForwardProp: () => true,
   }
 )({});
 

--- a/packages/sdk-react/src/components/receivables/InvoiceRecurrenceStatusChip/InvoiceRecurrenceStatusChip.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceRecurrenceStatusChip/InvoiceRecurrenceStatusChip.tsx
@@ -12,7 +12,7 @@ import {
 import { Chip, ChipProps } from '@mui/material';
 import { styled, useThemeProps } from '@mui/material/styles';
 
-export interface InvoiceRecurrenceStatusChipProps {
+export interface MoniteInvoiceRecurrenceStatusChipProps {
   /** The status of the recurrence. */
   status: components['schemas']['RecurrenceStatus'];
   /** The variant of the Chip. */
@@ -63,7 +63,7 @@ export interface InvoiceRecurrenceStatusChipProps {
  */
 export const InvoiceRecurrenceStatusChip = forwardRef<
   HTMLDivElement,
-  InvoiceRecurrenceStatusChipProps
+  MoniteInvoiceRecurrenceStatusChipProps
 >((inProps, ref) => {
   const { status, variant, icon, size } = useThemeProps({
     props: inProps,
@@ -81,34 +81,21 @@ export const InvoiceRecurrenceStatusChip = forwardRef<
       color={INVOICE_RECURRENCE_STATUS_TO_MUI_COLOR_MAP[status]}
       icon={icon && Icon ? <Icon /> : undefined}
       label={getInvoiceRecurrenceStatusLabel(i18n, status)}
-      status={status}
-      size={size ?? 'small'}
+      size={size}
       variant={variant ?? 'filled'}
     />
   );
 });
 
 const StyledChip = styled(
-  forwardRef<
-    HTMLDivElement,
-    ChipProps & Omit<InvoiceRecurrenceStatusChipProps, 'icon'>
-  >((props, ref) => <Chip ref={ref} {...props} />),
+  forwardRef<HTMLDivElement, ChipProps>((props, ref) => (
+    <Chip ref={ref} {...props} />
+  )),
   {
     // eslint-disable-next-line lingui/no-unlocalized-strings
     name: 'MoniteInvoiceRecurrenceStatusChip',
     slot: 'root',
-    shouldForwardProp: (prop) => {
-      switch (prop) {
-        case 'variant':
-        case 'label':
-        case 'color':
-        case 'icon':
-        case 'size':
-          return true;
-        default:
-          return false;
-      }
-    },
+    shouldForwardProp: () => true,
   }
 )({});
 

--- a/packages/sdk-react/src/components/receivables/InvoiceStatusChip/InvoiceStatusChip.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceStatusChip/InvoiceStatusChip.tsx
@@ -10,18 +10,16 @@ import { useLingui } from '@lingui/react';
 import { Chip, ChipProps } from '@mui/material';
 import { styled, useThemeProps } from '@mui/material/styles';
 
-interface InvoiceStatusChipRootProps {
-  /** The status of the invoice. */
-  status: components['schemas']['ReceivablesStatusEnum'];
+export interface MoniteInvoiceStatusChipProps {
+  icon?: boolean;
   /** The variant of the Chip. */
   variant?: ChipProps['variant'];
   /** The size of the Chip. */
   size?: ChipProps['size'];
-}
-
-export interface InvoiceStatusChipProps extends InvoiceStatusChipRootProps {
   /** Display status icon? */
-  icon?: boolean;
+  /** The status of the invoice. */
+  status: components['schemas']['ReceivablesStatusEnum'];
+  /** The variant of the Chip. */
 }
 
 /**
@@ -59,7 +57,7 @@ export interface InvoiceStatusChipProps extends InvoiceStatusChipRootProps {
 
 export const InvoiceStatusChip = forwardRef<
   HTMLDivElement,
-  InvoiceStatusChipProps
+  MoniteInvoiceStatusChipProps
 >((inProps, ref) => {
   const { status, variant, icon, size } = useThemeProps({
     props: inProps,
@@ -76,31 +74,19 @@ export const InvoiceStatusChip = forwardRef<
       color={ROW_TO_TAG_STATUS_MUI_MAP[status]}
       icon={icon && Icon ? <Icon fontSize="small" /> : undefined}
       label={getCommonStatusLabel(i18n, status)}
-      status={status}
-      size={size ?? 'small'}
+      size={size}
       variant={variant ?? 'filled'}
     />
   );
 });
 
 const StyledChip = styled(
-  forwardRef<HTMLDivElement, ChipProps & InvoiceStatusChipRootProps>(
-    (props, ref) => <Chip ref={ref} {...props} />
-  ),
+  forwardRef<HTMLDivElement, ChipProps>((props, ref) => (
+    <Chip ref={ref} {...props} />
+  )),
   {
     name: 'MoniteInvoiceStatusChip',
     slot: 'root',
-    shouldForwardProp: (prop) => {
-      switch (prop) {
-        case 'variant':
-        case 'label':
-        case 'color':
-        case 'icon':
-        case 'size':
-          return true;
-        default:
-          return false;
-      }
-    },
+    shouldForwardProp: () => true,
   }
 )({});

--- a/packages/sdk-react/src/components/receivables/InvoiceStatusChip/index.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceStatusChip/index.ts
@@ -1,4 +1,1 @@
-export {
-  InvoiceStatusChip,
-  type InvoiceStatusChipProps,
-} from './InvoiceStatusChip';
+export { InvoiceStatusChip } from './InvoiceStatusChip';


### PR DESCRIPTION
- Unified status chip interfaces and removed unnecessary properties from styling components.
- Restored status chip size control to customer configuration(_no default size as previously_).
- Disabled icon displaying for the SDK Demo Monite Theme

<details>
  <summary>Screenshots</summary>
  
  <img width="1715" src="https://github.com/user-attachments/assets/37d206f2-724c-47c2-bf69-2fc56bf35734">
  <img width="1725" src="https://github.com/user-attachments/assets/6a9f2e30-5a9e-4a59-981a-d511a916dd30">

  
</details>