### PR TITLE
feat(DEV-12499): use tax value for us entity during invoice creation

### DIFF
--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
@@ -88,6 +88,11 @@ const CreateReceivablesBase = ({
 
   const createReceivable = useCreateReceivable();
   const { api, monite } = useMoniteContext();
+  const { data: entity, isLoading: isEntityLoading } =
+    api.entityUsers.getEntityUsersMyEntity.useQuery();
+
+  const isUSEntity = entity?.address.country === 'US';
+
   const { data: settings, isLoading: isSettingsLoading } =
     api.entities.getEntitiesIdSettings.useQuery({
       path: { entity_id: monite.entityId },
@@ -111,7 +116,7 @@ const CreateReceivablesBase = ({
 
   const theme = useTheme();
 
-  if (isSettingsLoading) {
+  if (isSettingsLoading || isEntityLoading) {
     return <LoadingPage />;
   }
 
@@ -191,7 +196,9 @@ const CreateReceivablesBase = ({
                   line_items: values.line_items.map((item) => ({
                     quantity: item.quantity,
                     product_id: item.product_id,
-                    vat_rate_id: item.vat_rate_id,
+                    ...(isUSEntity
+                      ? { tax_rate_value: item.tax_rate_value * 100 }
+                      : { vat_rate_id: item.vat_rate_id }),
                   })),
                   vat_exemption_rationale: values.vat_exemption_rationale,
                   entity_vat_id_id: values.entity_vat_id_id || undefined,
@@ -228,6 +235,7 @@ const CreateReceivablesBase = ({
                 defaultCurrency={settings?.currency?.default}
                 actualCurrency={actualCurrency}
                 onCurrencyChanged={setActualCurrency}
+                isUSEntity={isUSEntity}
               />
               <PaymentSection disabled={createReceivable.isPending} />
               <ReminderSection

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
@@ -91,6 +91,7 @@ const CreateReceivablesBase = ({
   const { data: entity, isLoading: isEntityLoading } =
     api.entityUsers.getEntityUsersMyEntity.useQuery();
 
+  // TODO: This can be moved up to a context and shared
   const isUSEntity = entity?.address.country === 'US';
 
   const { data: settings, isLoading: isSettingsLoading } =

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
@@ -12,6 +12,7 @@ import { useMoniteContext } from '@/core/context/MoniteContext';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useCounterpartAddresses } from '@/core/queries';
 import { useCreateReceivable } from '@/core/queries/useReceivables';
+import { checkIfUSEntity } from '@/core/utils';
 import { LoadingPage } from '@/ui/loadingPage';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { t } from '@lingui/macro';
@@ -92,7 +93,9 @@ const CreateReceivablesBase = ({
     api.entityUsers.getEntityUsersMyEntity.useQuery();
 
   // TODO: This can be moved up to a context and shared
-  const isUSEntity = entity?.address.country === 'US';
+  const isUSEntity = Boolean(
+    entity?.address && checkIfUSEntity(entity.address.country)
+  );
 
   const { data: settings, isLoading: isSettingsLoading } =
     api.entities.getEntitiesIdSettings.useQuery({
@@ -202,7 +205,9 @@ const CreateReceivablesBase = ({
                       : { vat_rate_id: item.vat_rate_id }),
                   })),
                   vat_exemption_rationale: values.vat_exemption_rationale,
-                  entity_vat_id_id: values.entity_vat_id_id || undefined,
+                  ...(!isUSEntity && values.entity_vat_id_id
+                    ? { entity_vat_id_id: values.entity_vat_id_id }
+                    : {}),
                   fulfillment_date: values.fulfillment_date
                     ? /**
                        * We have to change the date as Backend accepts it.

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/useCreateInvoiceProductsTable.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/useCreateInvoiceProductsTable.ts
@@ -56,13 +56,9 @@ export const useCreateInvoiceProductsTable = ({
       const quantity = field.quantity;
       const subtotalPrice = price * quantity;
 
-      let taxRate: number | undefined = 0;
-
-      if (isUSEntity) {
-        taxRate = (field?.tax_rate_value ?? 0) * 100;
-      } else {
-        taxRate = field.vat_rate_value;
-      }
+      const taxRate = isUSEntity
+        ? (field?.tax_rate_value ?? 0) * 100
+        : field.vat_rate_value;
 
       if (!taxRate) {
         return acc;

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx
@@ -5,6 +5,7 @@ import { CountryInvoiceOption } from '@/components/receivables/InvoiceDetails/Cr
 import { CreateReceivablesFormProps } from '@/components/receivables/InvoiceDetails/CreateReceivable/validation';
 import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useRootElements } from '@/core/context/RootElementsProvider';
+import { checkIfUSEntity } from '@/core/utils';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import {
@@ -87,6 +88,10 @@ export const EntitySection = ({ disabled, hidden }: EntitySectionProps) => {
   }, [visibleFields]);
 
   const className = 'Monite-CreateReceivable-EntitySection';
+  // TODO: This can be moved up to a context and shared
+  const isUSEntity = Boolean(
+    entity?.address && checkIfUSEntity(entity.address.country)
+  );
 
   return (
     <Stack spacing={1} className={className}>
@@ -94,45 +99,51 @@ export const EntitySection = ({ disabled, hidden }: EntitySectionProps) => {
       <Card variant="outlined">
         <CardContent>
           <Grid container spacing={3}>
-            <Grid item {...gridItemProps}>
-              <Controller
-                name="entity_vat_id_id"
-                control={control}
-                render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    variant="outlined"
-                    fullWidth
-                    required
-                    disabled={isEntityVatIdsLoading || disabled}
-                    error={Boolean(error)}
-                  >
-                    <InputLabel id={field.name}>{t(
-                      i18n
-                    )`Your VAT ID`}</InputLabel>
-                    <Select
-                      {...field}
-                      labelId={field.name}
-                      label={t(i18n)`Your VAT ID`}
-                      MenuProps={{ container: root }}
-                      startAdornment={
-                        isEntityVatIdsLoading ? (
-                          <CircularProgress size={20} />
-                        ) : entity?.address.country ? (
-                          <CountryInvoiceOption code={entity.address.country} />
-                        ) : null
-                      }
+            {!isUSEntity && (
+              <Grid item {...gridItemProps}>
+                <Controller
+                  name="entity_vat_id_id"
+                  control={control}
+                  render={({ field, fieldState: { error } }) => (
+                    <FormControl
+                      variant="outlined"
+                      fullWidth
+                      required
+                      disabled={isEntityVatIdsLoading || disabled}
+                      error={Boolean(error)}
                     >
-                      {entityVatIds?.data.map((vatId) => (
-                        <MenuItem key={vatId.id} value={vatId.id}>
-                          {vatId.value}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                    {error && <FormHelperText>{error.message}</FormHelperText>}
-                  </FormControl>
-                )}
-              />
-            </Grid>
+                      <InputLabel id={field.name}>{t(
+                        i18n
+                      )`Your VAT ID`}</InputLabel>
+                      <Select
+                        {...field}
+                        labelId={field.name}
+                        label={t(i18n)`Your VAT ID`}
+                        MenuProps={{ container: root }}
+                        startAdornment={
+                          isEntityVatIdsLoading ? (
+                            <CircularProgress size={20} />
+                          ) : entity?.address.country ? (
+                            <CountryInvoiceOption
+                              code={entity.address.country}
+                            />
+                          ) : null
+                        }
+                      >
+                        {entityVatIds?.data.map((vatId) => (
+                          <MenuItem key={vatId.id} value={vatId.id}>
+                            {vatId.value}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                      {error && (
+                        <FormHelperText>{error.message}</FormHelperText>
+                      )}
+                    </FormControl>
+                  )}
+                />
+              </Grid>
+            )}
             <Grid item {...gridItemProps}>
               <TextField
                 disabled

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts
@@ -56,6 +56,12 @@ const getLineItemsSchema = (i18n: I18n) =>
           .number()
           .label(t(i18n)`VAT`)
           .required(),
+        tax_rate_value: yup
+          .number()
+          .label(t(i18n)`TAX`)
+          .min(0)
+          .max(100)
+          .required(),
         name: yup
           .string()
           .label(t(i18n)`Name`)
@@ -175,6 +181,7 @@ export interface CreateReceivablesFormBeforeValidationLineItemProps {
   product_id: string;
   vat_rate_id?: string;
   vat_rate_value?: number;
+  tax_rate_value?: number;
   smallest_amount?: number;
   name: string;
   price?: components['schemas']['Price'];

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts
@@ -99,10 +99,7 @@ export const getCreateInvoiceValidationSchema = (i18n: I18n) =>
       .label(t(i18n)`Counterpart`)
       .required(),
     entity_bank_account_id: yup.string().label(t(i18n)`Bank account`),
-    entity_vat_id_id: yup
-      .string()
-      .label(t(i18n)`VAT ID`)
-      .required(),
+    entity_vat_id_id: yup.string().label(t(i18n)`VAT ID`),
     counterpart_vat_id_id: yup.string().label(t(i18n)`Counterpart VAT ID`),
     fulfillment_date: yup
       .date()
@@ -141,10 +138,7 @@ export const getUpdateInvoiceValidationSchema = (i18n: I18n) =>
       .label(t(i18n)`Counterpart`)
       .required(),
     entity_bank_account_id: yup.string().label(t(i18n)`Bank account`),
-    entity_vat_id_id: yup
-      .string()
-      .label(t(i18n)`VAT ID`)
-      .required(),
+    entity_vat_id_id: yup.string().label(t(i18n)`VAT ID`),
     counterpart_vat_id_id: yup.string().label(t(i18n)`Counterpart VAT ID`),
     fulfillment_date: yup
       .date()

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
@@ -18,6 +18,7 @@ import {
   useUpdateReceivable,
   useUpdateReceivableLineItems,
 } from '@/core/queries/useReceivables';
+import { checkIfUSEntity } from '@/core/utils';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
@@ -133,7 +134,9 @@ const EditInvoiceDetailsContent = ({
     api.entityUsers.getEntityUsersMyEntity.useQuery();
 
   // TODO: This can be moved up to a context and shared
-  const isUSEntity = entity?.address.country === 'US';
+  const isUSEntity = Boolean(
+    entity?.address && checkIfUSEntity(entity.address.country)
+  );
 
   const isLoading =
     updateReceivableLineItems.isPending ||

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
@@ -12,6 +12,7 @@ import { PaymentSection } from '@/components/receivables/InvoiceDetails/CreateRe
 import { getUpdateInvoiceValidationSchema } from '@/components/receivables/InvoiceDetails/CreateReceivable/validation';
 import { EditInvoiceReminderDialog } from '@/components/receivables/InvoiceDetails/EditInvoiceReminderDialog';
 import { useInvoiceReminderDialogs } from '@/components/receivables/InvoiceDetails/useInvoiceReminderDialogs';
+import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useRootElements } from '@/core/context/RootElementsProvider';
 import {
   useUpdateReceivable,
@@ -127,8 +128,17 @@ const EditInvoiceDetailsContent = ({
   const updateReceivableLineItems = useUpdateReceivableLineItems(invoice.id);
   const updateReceivable = useUpdateReceivable(invoice.id);
 
+  const { api } = useMoniteContext();
+  const { data: entity, isLoading: isEntityLoading } =
+    api.entityUsers.getEntityUsersMyEntity.useQuery();
+
+  // TODO: This can be moved up to a context and shared
+  const isUSEntity = entity?.address.country === 'US';
+
   const isLoading =
-    updateReceivableLineItems.isPending || updateReceivable.isPending;
+    updateReceivableLineItems.isPending ||
+    updateReceivable.isPending ||
+    isEntityLoading;
 
   const formName = `Monite-Form-receivablesDetailsForm-${useId()}`;
 
@@ -243,6 +253,7 @@ const EditInvoiceDetailsContent = ({
               <CustomerSection disabled={isLoading} />
               <EntitySection disabled={isLoading} hidden={['purchase_order']} />
               <ItemsSection
+                isUSEntity={isUSEntity}
                 actualCurrency={actualCurrency}
                 onCurrencyChanged={setActualCurrency}
               />

--- a/packages/sdk-react/src/core/utils/countries.ts
+++ b/packages/sdk-react/src/core/utils/countries.ts
@@ -9,6 +9,8 @@ export type CountryType = {
   label: string;
 };
 
+export const checkIfUSEntity = (country: AllowedCountries) => country === 'US';
+
 export const getCountriesArray = (i18n: I18n): CountryType[] =>
   Object.entries(getCountries(i18n)).map(([code, label]) => ({
     code: code as AllowedCountries,


### PR DESCRIPTION
- Use tax value for US entities during invoice creation.
- Don't require counterpart vat id on create receivable for US based counterparts