### PR TITLE
feat(DEV-12593): Merge create/preview steps of invoice creation into a single flow

### DIFF
--- a/.changeset/neat-dolls-push.md
+++ b/.changeset/neat-dolls-push.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': minor
+---
+
+Open newly created invoice for preview immediately after creation.

--- a/examples/with-nextjs-and-clerk-auth/package.json
+++ b/examples/with-nextjs-and-clerk-auth/package.json
@@ -55,7 +55,7 @@
     "@lingui/swc-plugin": "4.0.4",
     "@openapi-qraft/cli": "1.14.0",
     "@testing-library/jest-dom": "~6.1.4",
-    "@testing-library/react": "~16.0.1",
+    "@testing-library/react": "~14.1.0",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "chalk": "~5.3.0",
     "dotenv": "^16.3.0",

--- a/examples/with-nextjs-and-clerk-auth/package.json
+++ b/examples/with-nextjs-and-clerk-auth/package.json
@@ -55,7 +55,7 @@
     "@lingui/swc-plugin": "4.0.4",
     "@openapi-qraft/cli": "1.14.0",
     "@testing-library/jest-dom": "~6.1.4",
-    "@testing-library/react": "~14.1.0",
+    "@testing-library/react": "~16.0.1",
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "chalk": "~5.3.0",
     "dotenv": "^16.3.0",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -83,7 +83,7 @@
     "@team-monite/sdk-themes": "workspace:~",
     "@testing-library/dom": "~9.3.1",
     "@testing-library/jest-dom": "~5.16.5",
-    "@testing-library/react": "~16.0.1",
+    "@testing-library/react": "~14.1.0",
     "@testing-library/user-event": "~14.4.3",
     "@types/deep-eql": "~4.0.2",
     "@types/jest": "~29.5.11",

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -83,7 +83,7 @@
     "@team-monite/sdk-themes": "workspace:~",
     "@testing-library/dom": "~9.3.1",
     "@testing-library/jest-dom": "~5.16.5",
-    "@testing-library/react": "~14.0.0",
+    "@testing-library/react": "~16.0.1",
     "@testing-library/user-event": "~14.4.3",
     "@types/deep-eql": "~4.0.2",
     "@types/jest": "~29.5.11",

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
@@ -1,17 +1,30 @@
+import { VirtuosoMockContext } from 'react-virtuoso';
+
+import { Receivables } from '@/components';
 import { CounterpartDataTestId } from '@/components/counterparts/Counterpart.types';
-import { getCounterpartName } from '@/components/counterparts/helpers';
 import { CreateCounterpartDialogTestEnum } from '@/components/receivables/InvoiceDetails/CreateReceivable/sections/components/CreateCounterpartDialog.types';
-import { counterpartListFixture } from '@/mocks';
 import { entityIds, entityVatIdList } from '@/mocks/entities';
 import { paymentTermsFixtures } from '@/mocks/paymentTerms';
 import { DateTimeFormatOptions } from '@/utils/DateTimeFormatOptions';
 import {
+  findParentElement,
+  Provider,
   renderWithClient,
   triggerClickOnAutocompleteOption,
+  triggerClickOnFirstAutocompleteOption,
   triggerClickOnSelectOption,
+  waitForCondition,
   waitUntilTableIsLoaded,
 } from '@/utils/test-utils';
-import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { t } from '@lingui/macro';
+import { QueryClient } from '@tanstack/react-query';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 
 import { CreateReceivables } from './CreateReceivables';
 
@@ -35,7 +48,7 @@ describe('CreateReceivables', () => {
 
     await waitUntilTableIsLoaded();
 
-    const submitButton = screen.getByRole('button', { name: /create/i });
+    const submitButton = screen.getByRole('button', { name: /Next/i });
 
     fireEvent.click(submitButton);
 
@@ -44,37 +57,96 @@ describe('CreateReceivables', () => {
     expect(error).toBeInTheDocument();
   });
 
-  test.skip('should create receivable when the form is valid', async () => {
-    const onCreateMock = jest.fn();
+  test('newly created invoice should be opened after creation', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+      },
+    });
 
-    renderWithClient(
-      <CreateReceivables type={'invoice'} onCreate={onCreateMock} />
-    );
+    render(<Receivables />, {
+      wrapper: ({ children }) => (
+        <VirtuosoMockContext.Provider
+          value={{ viewportHeight: 1000, itemHeight: 50 }}
+        >
+          <Provider client={queryClient} children={children} />
+        </VirtuosoMockContext.Provider>
+      ),
+    });
 
     await waitUntilTableIsLoaded();
 
-    const firstCounterpart = counterpartListFixture[0];
+    const createInvoiceButton = await screen.findByRole('button', {
+      name: t`Create Invoice`,
+    });
 
-    // Select first counterpart
-    triggerClickOnSelectOption(
-      /Bill to/i,
-      getCounterpartName(firstCounterpart)
+    fireEvent.click(createInvoiceButton);
+
+    const nextPageButtonPromise = screen.findByRole('button', {
+      name: t`Next page`,
+    });
+    await expect(nextPageButtonPromise).resolves.toBeInTheDocument();
+    await expect(nextPageButtonPromise).resolves.toBeEnabled();
+
+    // No contact progress indicator should be visible at this moment
+    const contactPersonPromise = screen.findByLabelText<HTMLInputElement>(
+      t`Contact person`
+    );
+    await expect(contactPersonPromise).resolves.toBeInTheDocument();
+    const contactPersonInput = await contactPersonPromise;
+    expect(
+      contactPersonInput.parentElement!.querySelector(
+        '.MuiCircularProgress-root'
+      )
+    ).toBeNull();
+
+    await triggerClickOnFirstAutocompleteOption(/Bill to/i);
+    await triggerClickOnFirstAutocompleteOption(/Billing address/i);
+    await triggerClickOnFirstAutocompleteOption(/Your VAT ID/i);
+    await triggerClickOnFirstAutocompleteOption(/Payment terms/i);
+
+    // Add item to invoice
+    const itemsHeader = screen.getByText(t`Items`);
+    // Use querySelector to find the 'Add Item' button.
+    // Due to the button icon, the screen.getByText won't find it
+    const addItemButton = itemsHeader.parentElement!.querySelector('button')!;
+    fireEvent.click(addItemButton);
+    // Wait for Products dialog to open
+    await waitForCondition(
+      () => !!screen.queryByText(`Available items`),
+      3_000
     );
 
-    // Select the first two items
-    fireEvent.click(screen.getByRole('button', { name: 'Add item' }));
-    const checkboxes = await screen.findAllByRole('checkbox');
-    fireEvent.click(checkboxes[1]);
-    fireEvent.click(checkboxes[2]);
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    const availableItems = screen.getByText(t`Available items`);
+    const rightSideForm = findParentElement(
+      availableItems,
+      ({ tagName }) => tagName == 'FORM'
+    )!;
+    // Wait for products to load
+    await waitForCondition(
+      () => !!rightSideForm.querySelector('tbody tr input'),
+      3_000
+    );
+    const productCheckbox = rightSideForm.querySelector('tbody tr input')!;
+    fireEvent.click(productCheckbox);
 
-    await waitFor(() => {
-      const submitButton = screen.getByRole('button', { name: /create/i });
-      fireEvent.click(submitButton);
-
-      expect(onCreateMock).toHaveBeenCalled();
+    const addProductsButton = screen.getByRole('button', { name: t`Add` });
+    fireEvent.click(addProductsButton);
+    // Wait for Products dialog to close
+    await waitForElementToBeRemoved(addProductsButton, {
+      timeout: 3_000,
     });
-  });
+
+    // Create invoice
+    const nextPageButton = await nextPageButtonPromise;
+    fireEvent.click(nextPageButton);
+
+    // Compose email dialog opens
+    await waitForCondition(
+      () => !!screen.queryByRole('button', { name: t`Compose email` }),
+      3_000
+    );
+  }, 30_000);
 
   describe('# Select Counterpart', () => {
     test('should show "Create counterpart" dialog when the user clicks on "Bill to" select and "Create new counterpart" button', async () => {
@@ -223,7 +295,7 @@ describe('CreateReceivables', () => {
       const errorMessage = 'VAT ID is a required field';
 
       /** We should have an error if we do not fill entity vat id */
-      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
       expect(await screen.findByText(errorMessage)).toBeInTheDocument();
 
       const vatIdByEntity = entityVatIdList[entityIds[0]];
@@ -250,7 +322,7 @@ describe('CreateReceivables', () => {
       const errorMessage = 'Payment terms is a required field';
 
       /** We should have an error if we do not fill entity vat id */
-      fireEvent.click(screen.getByRole('button', { name: /create/i }));
+      fireEvent.click(screen.getByRole('button', { name: /next/i }));
       expect(await screen.findByText(errorMessage)).toBeInTheDocument();
 
       const firstPaymentTerm = paymentTermsFixtures.data?.[0];

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
@@ -21,7 +21,7 @@ describe('CreateReceivables', () => {
 
     await waitUntilTableIsLoaded();
 
-    const submitButton = screen.getByRole('button', { name: /create/i });
+    const submitButton = screen.getByRole('button', { name: /Next page/i });
 
     fireEvent.click(submitButton);
 

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
@@ -79,13 +79,17 @@ describe('CreateReceivables', () => {
     const createInvoiceButton = await screen.findByRole('button', {
       name: t`Create Invoice`,
     });
-
     fireEvent.click(createInvoiceButton);
 
+    await waitForCondition(
+      () =>
+        !!screen.queryByRole('button', {
+          name: t`Next page`,
+        })
+    );
     const nextPageButtonPromise = screen.findByRole('button', {
       name: t`Next page`,
     });
-    await expect(nextPageButtonPromise).resolves.toBeInTheDocument();
     await expect(nextPageButtonPromise).resolves.toBeEnabled();
 
     // No contact progress indicator should be visible at this moment

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx
@@ -92,7 +92,6 @@ describe('CreateReceivables', () => {
     });
     await expect(nextPageButtonPromise).resolves.toBeEnabled();
 
-    // No contact progress indicator should be visible at this moment
     const contactPersonPromise = screen.findByLabelText<HTMLInputElement>(
       t`Contact person`
     );
@@ -109,13 +108,11 @@ describe('CreateReceivables', () => {
     await triggerClickOnFirstAutocompleteOption(/Your VAT ID/i);
     await triggerClickOnFirstAutocompleteOption(/Payment terms/i);
 
-    // Add item to invoice
     const itemsHeader = screen.getByText(t`Items`);
     // Use querySelector to find the 'Add Item' button.
     // Due to the button icon, the screen.getByText won't find it
     const addItemButton = itemsHeader.parentElement!.querySelector('button')!;
     fireEvent.click(addItemButton);
-    // Wait for Products dialog to open
     await waitForCondition(
       () => !!screen.queryByText(`Available items`),
       3_000
@@ -126,7 +123,6 @@ describe('CreateReceivables', () => {
       availableItems,
       ({ tagName }) => tagName == 'FORM'
     )!;
-    // Wait for products to load
     await waitForCondition(
       () => !!rightSideForm.querySelector('tbody tr input'),
       3_000
@@ -136,16 +132,13 @@ describe('CreateReceivables', () => {
 
     const addProductsButton = screen.getByRole('button', { name: t`Add` });
     fireEvent.click(addProductsButton);
-    // Wait for Products dialog to close
     await waitForElementToBeRemoved(addProductsButton, {
       timeout: 3_000,
     });
 
-    // Create invoice
     const nextPageButton = await nextPageButtonPromise;
     fireEvent.click(nextPageButton);
 
-    // Compose email dialog opens
     await waitForCondition(
       () => !!screen.queryByRole('button', { name: t`Compose email` }),
       3_000

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
@@ -139,7 +139,7 @@ const CreateReceivablesBase = ({
               type="submit"
               form={formName}
               disabled={createReceivable.isPending}
-            >{t(i18n)`Create`}</Button>
+            >{t(i18n)`Next page`}</Button>
           </Box>
         </Toolbar>
       </DialogTitle>

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx
@@ -108,9 +108,9 @@ const VirtuosoTableComponents: TableComponents<ProductServiceResponse> = {
   TableBody: forwardRef<HTMLTableSectionElement>((props, ref) => (
     <TableBody {...props} ref={ref} />
   )),
-  TableFoot: ({ children }) => {
-    return <>{children}</>;
-  },
+  TableFoot: forwardRef<HTMLTableSectionElement>((props, ref) => (
+    <tfoot {...props} ref={ref} />
+  )),
 };
 
 const getTableHeadCells = (i18n: I18n) => [
@@ -419,33 +419,42 @@ export const ProductsTable = ({
                     EmptyPlaceholder: () => {
                       if (isLoading) {
                         return (
-                          <TableCell colSpan={3}>
-                            <CenteredContentBox>
-                              <CircularProgress />
-                            </CenteredContentBox>
-                          </TableCell>
+                          <TableBody>
+                            <TableRow>
+                              <TableCell colSpan={3}>
+                                <CenteredContentBox>
+                                  <CircularProgress />
+                                </CenteredContentBox>
+                              </TableCell>
+                            </TableRow>
+                          </TableBody>
                         );
                       }
 
                       return (
-                        <TableCell colSpan={3}>
-                          <CenteredContentBox>
-                            <Stack alignItems="center" sx={{ p: 4 }}>
-                              <FileIcon color="primary" sx={{ mb: 2 }} />
-                              <Typography variant="body1" sx={{ mb: 0.5 }}>{t(
-                                i18n
-                              )`No items yet`}</Typography>
-                              <Typography variant="body2" sx={{ mb: 2 }}>{t(
-                                i18n
-                              )`Create an item with this currency to add it`}</Typography>
-                              <Button
-                                variant="contained"
-                                onClick={handleCreateNewProduct}
-                                size="small"
-                              >{t(i18n)`Create product or service`}</Button>
-                            </Stack>
-                          </CenteredContentBox>
-                        </TableCell>
+                        <TableBody>
+                          <TableRow>
+                            <TableCell colSpan={3}>
+                              <CenteredContentBox>
+                                <Stack alignItems="center" sx={{ p: 4 }}>
+                                  <FileIcon color="primary" sx={{ mb: 2 }} />
+                                  <Typography
+                                    variant="body1"
+                                    sx={{ mb: 0.5 }}
+                                  >{t(i18n)`No items yet`}</Typography>
+                                  <Typography variant="body2" sx={{ mb: 2 }}>{t(
+                                    i18n
+                                  )`Create an item with this currency to add it`}</Typography>
+                                  <Button
+                                    variant="contained"
+                                    onClick={handleCreateNewProduct}
+                                    size="small"
+                                  >{t(i18n)`Create product or service`}</Button>
+                                </Stack>
+                              </CenteredContentBox>
+                            </TableCell>
+                          </TableRow>
+                        </TableBody>
                       );
                     },
                   }}
@@ -485,7 +494,7 @@ export const ProductsTable = ({
                     );
                   }}
                   fixedFooterContent={() => {
-                    if (isLoading) {
+                    if (!isLoading) {
                       return null;
                     }
 
@@ -498,17 +507,19 @@ export const ProductsTable = ({
                     }
 
                     return (
-                      <TableCell colSpan={3}>
-                        <Box
-                          sx={{
-                            p: 2,
-                            display: 'flex',
-                            justifyContent: 'center',
-                          }}
-                        >
-                          <CircularProgress size={30} />
-                        </Box>
-                      </TableCell>
+                      <TableRow>
+                        <TableCell colSpan={3}>
+                          <Box
+                            sx={{
+                              p: 2,
+                              display: 'flex',
+                              justifyContent: 'center',
+                            }}
+                          >
+                            <CircularProgress size={30} />
+                          </Box>
+                        </TableCell>
+                      </TableRow>
                     );
                   }}
                   itemContent={(_index, row) => (

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx
@@ -208,8 +208,6 @@ export const ProductsTable = ({
     [productsInfinity]
   );
 
-  console.log(`flattenProducts: ${flattenProducts.length}`);
-
   const { formatCurrencyToDisplay } = useCurrencies();
 
   const formName = `Monite-Form-productsTable-${useId()}`;

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx
@@ -208,6 +208,8 @@ export const ProductsTable = ({
     [productsInfinity]
   );
 
+  console.log(`flattenProducts: ${flattenProducts.length}`);
+
   const { formatCurrencyToDisplay } = useCurrencies();
 
   const formName = `Monite-Form-productsTable-${useId()}`;

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
@@ -105,6 +105,11 @@ export const CustomerSection = ({ disabled }: SectionGeneralProps) => {
   // _isCounterpartAddressesLoading will be true if counterpartId isn't set
   const isCounterpartAddressesLoading =
     counterpartId && _isCounterpartAddressesLoading;
+  console.log(
+    `counterpartAddresses: ${
+      counterpartAddresses?.data?.length ?? 0
+    }, isCounterpartAddressesLoading: ${isCounterpartAddressesLoading}`
+  );
 
   const [isCreateCounterpartOpened, setIsCreateCounterpartOpened] =
     useState<boolean>(false);

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
@@ -259,9 +259,10 @@ export const CustomerSection = ({ disabled }: SectionGeneralProps) => {
                     : ''
                 }
                 InputProps={{
-                  startAdornment: isContactPersonsLoading ? (
-                    <CircularProgress size={20} />
-                  ) : null,
+                  startAdornment:
+                    counterpartId && isContactPersonsLoading ? (
+                      <CircularProgress size={20} />
+                    ) : null,
                 }}
               />
               <Collapse in={Boolean(contactPersonError)}>

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
@@ -100,8 +100,11 @@ export const CustomerSection = ({ disabled }: SectionGeneralProps) => {
     useCounterpartById(counterpartId);
   const {
     data: counterpartAddresses,
-    isLoading: isCounterpartAddressesLoading,
+    isLoading: _isCounterpartAddressesLoading,
   } = useCounterpartAddresses(counterpartId);
+  // _isCounterpartAddressesLoading will be true if counterpartId isn't set
+  const isCounterpartAddressesLoading =
+    counterpartId && _isCounterpartAddressesLoading;
 
   const [isCreateCounterpartOpened, setIsCreateCounterpartOpened] =
     useState<boolean>(false);

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
@@ -105,11 +105,6 @@ export const CustomerSection = ({ disabled }: SectionGeneralProps) => {
   // _isCounterpartAddressesLoading will be true if counterpartId isn't set
   const isCounterpartAddressesLoading =
     counterpartId && _isCounterpartAddressesLoading;
-  console.log(
-    `counterpartAddresses: ${
-      counterpartAddresses?.data?.length ?? 0
-    }, isCounterpartAddressesLoading: ${isCounterpartAddressesLoading}`
-  );
 
   const [isCreateCounterpartOpened, setIsCreateCounterpartOpened] =
     useState<boolean>(false);

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
@@ -105,6 +105,11 @@ export const CustomerSection = ({ disabled }: SectionGeneralProps) => {
   // _isCounterpartAddressesLoading will be true if counterpartId isn't set
   const isCounterpartAddressesLoading =
     counterpartId && _isCounterpartAddressesLoading;
+  // console.log(
+  //   `counterpartAddresses: ${
+  //     counterpartAddresses?.data.length ?? 0
+  //   }, counterpartId: ${counterpartId}`
+  // );
 
   const [isCreateCounterpartOpened, setIsCreateCounterpartOpened] =
     useState<boolean>(false);

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/CustomerSection.tsx
@@ -105,11 +105,6 @@ export const CustomerSection = ({ disabled }: SectionGeneralProps) => {
   // _isCounterpartAddressesLoading will be true if counterpartId isn't set
   const isCounterpartAddressesLoading =
     counterpartId && _isCounterpartAddressesLoading;
-  // console.log(
-  //   `counterpartAddresses: ${
-  //     counterpartAddresses?.data.length ?? 0
-  //   }, counterpartId: ${counterpartId}`
-  // );
 
   const [isCreateCounterpartOpened, setIsCreateCounterpartOpened] =
     useState<boolean>(false);

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx
@@ -14,6 +14,7 @@ import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useRootElements } from '@/core/context/RootElementsProvider';
 import { useCurrencies } from '@/core/hooks';
 import { Price } from '@/core/utils/price';
+import { classNames } from '@/utils/css-utils';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import AddIcon from '@mui/icons-material/Add';
@@ -83,24 +84,36 @@ const CardTableItem = ({
   variant = 'body1',
   sx,
   className,
-}: CardTableItemProps) => (
-  <Grid container direction="row" alignItems="center" className={className}>
-    <Grid item xs={4}>
-      {typeof label === 'string' ? (
-        <Typography variant="body1">{label}</Typography>
-      ) : (
-        label
+}: CardTableItemProps) => {
+  const componentClassName = 'Monite-CreateReceivable-CardTableItem';
+  return (
+    <Grid
+      container
+      direction="row"
+      alignItems="center"
+      className={classNames(componentClassName, className)}
+    >
+      <Grid item xs={4}>
+        {typeof label === 'string' ? (
+          <Typography variant="body1">{label}</Typography>
+        ) : (
+          label
+        )}
+      </Grid>
+      {value && (
+        <Grid item xs={8} display="flex" justifyContent="end">
+          <Typography
+            variant={variant}
+            sx={sx}
+            className={componentClassName + '-Value'}
+          >
+            {value.toString()}
+          </Typography>
+        </Grid>
       )}
     </Grid>
-    {value && (
-      <Grid item xs={8} display="flex" justifyContent="end">
-        <Typography variant={variant} sx={sx}>
-          {value.toString()}
-        </Typography>
-      </Grid>
-    )}
-  </Grid>
-);
+  );
+};
 
 const TotalCell = ({
   item,
@@ -379,9 +392,17 @@ export const ItemsSection = ({
       <Card className={className + '-Totals'} variant="outlined">
         <CardContent>
           <Stack>
-            <CardTableItem label={t(i18n)`Subtotal`} value={subtotalPrice} />
+            <CardTableItem
+              label={t(i18n)`Subtotal`}
+              value={subtotalPrice}
+              className="Monite-Subtotal"
+            />
             <Divider sx={{ my: 1.5 }} />
-            <CardTableItem label={t(i18n)`Taxes total`} value={totalTaxes} />
+            <CardTableItem
+              label={t(i18n)`Taxes total`}
+              value={totalTaxes}
+              className="Monite-TaxesTotal"
+            />
             <Divider sx={{ my: 1.5 }} />
             <CardTableItem
               label={
@@ -389,6 +410,7 @@ export const ItemsSection = ({
               }
               value={totalPrice}
               variant="subtitle1"
+              className="Monite-Total"
             />
           </Stack>
         </CardContent>

--- a/packages/sdk-react/src/components/receivables/Receivables.test.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.test.tsx
@@ -1,18 +1,25 @@
+import { Receivables } from '@/components';
 import {
   ENTITY_ID_FOR_EMPTY_PERMISSIONS,
   ENTITY_ID_FOR_OWNER_PERMISSIONS,
 } from '@/mocks';
 import {
   checkPermissionQueriesLoaded,
+  findParentElement,
   Provider,
+  triggerClickOnFirstAutocompleteOption,
   waitUntilTableIsLoaded,
 } from '@/utils/test-utils';
 import { t } from '@lingui/macro';
 import { MoniteSDK } from '@monite/sdk-api';
 import { QueryClient } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
-
-import { Receivables } from './Receivables';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 
 describe('Receivables', () => {
   describe('# Permissions', () => {
@@ -104,7 +111,6 @@ describe('Receivables', () => {
       });
 
       await waitUntilTableIsLoaded();
-      await waitUntilTableIsLoaded();
 
       const createInvoiceButton = screen.findByRole('button', {
         name: t`Create Invoice`,
@@ -116,6 +122,100 @@ describe('Receivables', () => {
       const invoiceCells = screen.findAllByText(/INV-/);
 
       await expect(invoiceCells).resolves.toBeDefined();
+    });
+
+    test('newly created invoice should be opened after creation', async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+        },
+      });
+
+      render(<Receivables />, {
+        wrapper: ({ children }) => (
+          <Provider client={queryClient} children={children} />
+        ),
+      });
+
+      await waitUntilTableIsLoaded();
+
+      const createInvoiceButton = await screen.findByRole('button', {
+        name: t`Create Invoice`,
+      });
+
+      act(() => fireEvent.click(createInvoiceButton));
+
+      const nextPageButton = screen.findByRole('button', {
+        name: t`Next page`,
+      });
+      await expect(nextPageButton).resolves.toBeInTheDocument();
+      await expect(nextPageButton).resolves.toBeEnabled();
+
+      // No contact progress indicator should be visible at this moment
+      const contactPersonPromise = screen.findByLabelText<HTMLInputElement>(
+        t`Contact person`
+      );
+      await expect(contactPersonPromise).resolves.toBeInTheDocument();
+      const contactPersonInput = await contactPersonPromise;
+      expect(
+        contactPersonInput.parentElement!.querySelector(
+          '.MuiCircularProgress-root'
+        )
+      ).toBeNull();
+
+      // Choose counterpart and billing address
+      await triggerClickOnFirstAutocompleteOption(/Bill to/i);
+      await triggerClickOnFirstAutocompleteOption(/Billing address/i);
+      await triggerClickOnFirstAutocompleteOption(/Your VAT ID/i);
+
+      // Add item to invoice
+      const itemsHeader = screen.getByText(t`Items`);
+      // Use querySelector to find the 'Add Item' button.
+      // Due to the button icon, the screen.getByText won't find it
+      const addItemButton = itemsHeader.parentElement!.querySelector('button')!;
+      act(() => fireEvent.click(addItemButton));
+
+      await waitFor(() => !!screen.queryByText(t`Available items`), {
+        timeout: 30_000,
+      });
+
+      // Find product in 'Add Item' dialog
+      await expect(
+        screen.findByText(t`Available items`)
+      ).resolves.toBeInTheDocument();
+      await waitUntilTableIsLoaded();
+
+      const availableItems = screen.getByText(t`Available items`);
+      const rightSideForm = findParentElement(
+        availableItems,
+        ({ tagName }) => tagName == 'FORM'
+      )!;
+      await waitFor(() => !!rightSideForm.querySelector('tbody tr'), {
+        timeout: 30_000,
+      });
+      const productRow = rightSideForm.querySelector('tbody tr')!;
+      const availableItems2 = screen.getByText(t`Available items`);
+      console.log(availableItems == availableItems2);
+      console.log(rightSideForm.innerHTML);
+      console.log(productRow.outerHTML);
+      const productCheckbox = productRow.querySelector('input')!;
+      act(() => fireEvent.click(productCheckbox));
+      const addProductsButton = screen.getByText(t`Add`);
+      act(() => fireEvent.click(addProductsButton));
+
+      // Check Subtotal got updated
+      const subtotalLabel = screen.getByText(t`Subtotal`);
+      const subtotalCardTableItem = findParentElement(
+        subtotalLabel,
+        ({ classList }) =>
+          classList.contains('Monite-CreateReceivable-CardTableItem')
+      )!;
+      const subtotalCardValue: HTMLElement =
+        subtotalCardTableItem.querySelector(
+          '.Monite-CreateReceivable-CardTableItem-Value'
+        )!;
+      expect(parseFloat(subtotalCardValue.innerText)).toBeGreaterThan(0);
+      // subtotalLabel;
     });
   });
 });

--- a/packages/sdk-react/src/components/receivables/Receivables.test.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.test.tsx
@@ -164,8 +164,11 @@ describe('Receivables', () => {
       ).toBeNull();
 
       // Choose counterpart and billing address
+      console.log('bill to');
       await triggerClickOnFirstAutocompleteOption(/Bill to/i);
+      console.log('billing address');
       await triggerClickOnFirstAutocompleteOption(/Billing address/i);
+      console.log('vat id');
       await triggerClickOnFirstAutocompleteOption(/Your VAT ID/i);
 
       // Add item to invoice
@@ -175,6 +178,7 @@ describe('Receivables', () => {
       const addItemButton = itemsHeader.parentElement!.querySelector('button')!;
       act(() => fireEvent.click(addItemButton));
 
+      console.log('available items');
       await waitFor(() => !!screen.queryByText(t`Available items`), {
         timeout: 30_000,
       });
@@ -190,6 +194,7 @@ describe('Receivables', () => {
         availableItems,
         ({ tagName }) => tagName == 'FORM'
       )!;
+      console.log('tbody tr');
       await waitFor(() => !!rightSideForm.querySelector('tbody tr'), {
         timeout: 30_000,
       });

--- a/packages/sdk-react/src/components/receivables/Receivables.test.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.test.tsx
@@ -1,5 +1,3 @@
-import { VirtuosoMockContext } from 'react-virtuoso';
-
 import { Receivables } from '@/components';
 import {
   ENTITY_ID_FOR_EMPTY_PERMISSIONS,
@@ -7,23 +5,13 @@ import {
 } from '@/mocks';
 import {
   checkPermissionQueriesLoaded,
-  findParentElement,
   Provider,
-  triggerClickOnFirstAutocompleteOption,
-  waitForCondition,
   waitUntilTableIsLoaded,
 } from '@/utils/test-utils';
 import { t } from '@lingui/macro';
 import { MoniteSDK } from '@monite/sdk-api';
 import { QueryClient } from '@tanstack/react-query';
-import {
-  act,
-  fireEvent,
-  render,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 describe('Receivables', () => {
   describe('# Permissions', () => {
@@ -127,97 +115,5 @@ describe('Receivables', () => {
 
       await expect(invoiceCells).resolves.toBeDefined();
     });
-
-    test('newly created invoice should be opened after creation', async () => {
-      const queryClient = new QueryClient({
-        defaultOptions: {
-          queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
-        },
-      });
-
-      render(<Receivables />, {
-        wrapper: ({ children }) => (
-          <VirtuosoMockContext.Provider
-            value={{ viewportHeight: 1000, itemHeight: 50 }}
-          >
-            <Provider client={queryClient} children={children} />
-          </VirtuosoMockContext.Provider>
-        ),
-      });
-
-      await waitUntilTableIsLoaded();
-
-      const createInvoiceButton = await screen.findByRole('button', {
-        name: t`Create Invoice`,
-      });
-
-      act(() => fireEvent.click(createInvoiceButton));
-
-      const nextPageButtonPromise = screen.findByRole('button', {
-        name: t`Next page`,
-      });
-      await expect(nextPageButtonPromise).resolves.toBeInTheDocument();
-      await expect(nextPageButtonPromise).resolves.toBeEnabled();
-
-      // No contact progress indicator should be visible at this moment
-      const contactPersonPromise = screen.findByLabelText<HTMLInputElement>(
-        t`Contact person`
-      );
-      await expect(contactPersonPromise).resolves.toBeInTheDocument();
-      const contactPersonInput = await contactPersonPromise;
-      expect(
-        contactPersonInput.parentElement!.querySelector(
-          '.MuiCircularProgress-root'
-        )
-      ).toBeNull();
-
-      // Fill required fields
-      await triggerClickOnFirstAutocompleteOption(/Bill to/i);
-      await triggerClickOnFirstAutocompleteOption(/Billing address/i);
-      await triggerClickOnFirstAutocompleteOption(/Your VAT ID/i);
-      await triggerClickOnFirstAutocompleteOption(/Payment terms/i);
-
-      // Add item to invoice
-      const itemsHeader = screen.getByText(t`Items`);
-      // Use querySelector to find the 'Add Item' button.
-      // Due to the button icon, the screen.getByText won't find it
-      const addItemButton = itemsHeader.parentElement!.querySelector('button')!;
-      act(() => fireEvent.click(addItemButton));
-      // Wait for Products dialog to open
-      await waitForCondition(
-        () => !!screen.queryByText(`Available items`),
-        3_000
-      );
-
-      const availableItems = screen.getByText(t`Available items`);
-      const rightSideForm = findParentElement(
-        availableItems,
-        ({ tagName }) => tagName == 'FORM'
-      )!;
-      // Wait for products to load
-      await waitForCondition(
-        () => !!rightSideForm.querySelector('tbody tr input'),
-        3_000
-      );
-      const productCheckbox = rightSideForm.querySelector('tbody tr input')!;
-      act(() => fireEvent.click(productCheckbox));
-
-      const addProductsButton = screen.getByRole('button', { name: t`Add` });
-      act(() => fireEvent.click(addProductsButton));
-      // Wait for Products dialog to close
-      await waitForElementToBeRemoved(addProductsButton, {
-        timeout: 3_000,
-      });
-
-      // Create invoice
-      const nextPageButton = await nextPageButtonPromise;
-      act(() => fireEvent.click(nextPageButton));
-
-      // Compose email dialog opens
-      await waitForCondition(
-        () => !!screen.queryByRole('button', { name: t`Compose email` }),
-        3_000
-      );
-    }, 30_000);
   });
 });

--- a/packages/sdk-react/src/components/receivables/Receivables.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { Dialog } from '@/components/Dialog';
 import { PageHeader } from '@/components/PageHeader';
@@ -24,36 +24,23 @@ const ReceivablesBase = () => {
   const { i18n } = useLingui();
 
   const [invoiceId, setInvoiceId] = useState<string>('');
-  const [openDetails, setOpenDetails] = useState<boolean>(false);
   const [isCreateInvoiceDialogOpen, setIsCreateInvoiceDialogOpen] =
     useState<boolean>(false);
   const [activeTab, setActiveTab] = useState<ReceivablesTableTabEnum>(
     ReceivablesTableTabEnum.Invoices
   );
 
-  useEffect(() => {
-    if (!invoiceId) {
-      setOpenDetails(false);
-
-      return;
-    }
-
-    if (invoiceId) {
-      setOpenDetails(true);
-    }
-  }, [invoiceId]);
-
-  const onRowClick = (id: string) => {
+  const openInvoiceModal = (id: string) => {
     setInvoiceId(id);
   };
 
-  const closeModal = () => {
-    setOpenDetails(false);
+  const onRowClick = (id: string) => {
+    openInvoiceModal(id);
   };
 
-  const closedModal = useCallback(() => {
+  const closeModal = () => {
     setInvoiceId('');
-  }, []);
+  };
 
   const { root } = useRootElements();
 
@@ -111,11 +98,10 @@ const ReceivablesBase = () => {
       )}
       <Dialog
         className={className + '-Dialog-ReceivableDetails'}
-        open={openDetails}
+        open={!!invoiceId}
         fullScreen
         container={root}
         onClose={closeModal}
-        onClosed={closedModal}
       >
         <InvoiceDetails id={invoiceId} />
       </Dialog>
@@ -133,7 +119,7 @@ const ReceivablesBase = () => {
           onCreate={(receivableId: string) => {
             setIsCreateInvoiceDialogOpen(false);
             setActiveTab(ReceivablesTableTabEnum.Invoices);
-            setInvoiceId(receivableId);
+            openInvoiceModal(receivableId);
           }}
         />
       </Dialog>

--- a/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
+++ b/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
@@ -1,8 +1,7 @@
 import { components } from '@/api';
+import { counterpartsAddressesFixture } from '@/mocks';
 
 import { http, HttpResponse, delay } from 'msw';
-
-import { counterpartsAddressesFixture } from './counterpartsAddressesFixture';
 
 const counterpartsAddressesPath = `*/counterparts/:counterpartId/addresses`;
 const counterpartAddressPath = `${counterpartsAddressesPath}/:addressId`;
@@ -19,6 +18,7 @@ export const counterpartsAddressesHandlers = [
     const address = counterpartsAddressesFixture.find((address) =>
       address.data.find((addr) => addr.counterpart_id === counterpartId)
     );
+    // console.log(`/addresses: ${counterpartId}, ${address}`);
 
     if (!address) {
       await delay();

--- a/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
+++ b/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
@@ -24,6 +24,7 @@ export const counterpartsAddressesHandlers = [
     const address = counterpartsAddressesFixture.find((address) =>
       address.data.find((addr) => addr.counterpart_id === counterpartId)
     );
+    console.log(`/addresses: ${counterpartId}, ${address}`);
 
     if (!address) {
       await delay();
@@ -40,7 +41,7 @@ export const counterpartsAddressesHandlers = [
       );
     }
 
-    await delay();
+    // await delay();
 
     return HttpResponse.json(address);
   }),

--- a/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
+++ b/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
@@ -1,7 +1,9 @@
 import { components } from '@/api';
-import { counterpartsAddressesFixture } from '@/mocks';
 
-import { http, HttpResponse, delay } from 'msw';
+import { delay, http, HttpResponse } from 'msw';
+
+// noinspection ES6PreferShortImport
+import { counterpartsAddressesFixture } from './counterpartsAddressesFixture';
 
 const counterpartsAddressesPath = `*/counterparts/:counterpartId/addresses`;
 const counterpartAddressPath = `${counterpartsAddressesPath}/:addressId`;
@@ -15,10 +17,13 @@ export const counterpartsAddressesHandlers = [
     | components['schemas']['ErrorSchemaResponse']
   >(counterpartsAddressesPath, async ({ params }) => {
     const { counterpartId } = params;
+    // Imports may silently fail if imported as import { counterpartsAddressesFixture } from '@/mocks';
+    // Since mock handlers do not print exception, make sure the file was imported properly
+    if (!counterpartsAddressesFixture)
+      console.error(`counterpartsAddressesFixture is undefined`);
     const address = counterpartsAddressesFixture.find((address) =>
       address.data.find((addr) => addr.counterpart_id === counterpartId)
     );
-    // console.log(`/addresses: ${counterpartId}, ${address}`);
 
     if (!address) {
       await delay();

--- a/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
+++ b/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
@@ -24,7 +24,6 @@ export const counterpartsAddressesHandlers = [
     const address = counterpartsAddressesFixture.find((address) =>
       address.data.find((addr) => addr.counterpart_id === counterpartId)
     );
-    console.log(`/addresses: ${counterpartId}, ${address}`);
 
     if (!address) {
       await delay();

--- a/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
+++ b/packages/sdk-react/src/mocks/counterparts/address/counterpartsAddressesHandlers.ts
@@ -40,7 +40,7 @@ export const counterpartsAddressesHandlers = [
       );
     }
 
-    // await delay();
+    await delay();
 
     return HttpResponse.json(address);
   }),

--- a/packages/sdk-react/src/mocks/entities/entitiesFixture.ts
+++ b/packages/sdk-react/src/mocks/entities/entitiesFixture.ts
@@ -11,12 +11,10 @@ function getEntitySettings(): MergedSettingsResponse {
     allow_purchase_order_autolinking: false,
     payment_priority: 'balanced',
     receivable_edit_flow: 'non_compliant',
-    currency: faker.datatype.boolean()
-      ? {
-          default: getRandomItemFromArray(['EUR', 'USD', 'GEL', 'KZT']),
-          exchange_rates: [],
-        }
-      : undefined,
+    currency: {
+      default: 'EUR',
+      exchange_rates: [],
+    },
   };
 }
 
@@ -35,7 +33,7 @@ function generateEntityVatIdResourceList(
 function generateEntityData(entityId: string): EntityResponse {
   const type = faker.datatype.boolean() ? 'individual' : 'organization';
   const address: components['schemas']['EntityAddressSchema'] = {
-    country: getRandomItemFromArray(['DE', 'US', 'KZ']),
+    country: 'DE',
     city: faker.location.city(),
     line1: faker.location.streetAddress(),
     postal_code: faker.location.zipCode(),
@@ -123,8 +121,6 @@ export const entityPaymentMethods: OnboardingPaymentMethodsResponse = {
   ],
 };
 
-type AllowedCountries = components['schemas']['AllowedCountries'];
-type CurrencyEnum = components['schemas']['CurrencyEnum'];
 type EntityIndividualResponse =
   components['schemas']['EntityIndividualResponse'];
 type EntityOrganizationResponse =
@@ -133,12 +129,5 @@ type EntityResponse = components['schemas']['EntityResponse'];
 type EntityVatIDResourceList = components['schemas']['EntityVatIDResourceList'];
 type EntityVatIDResponse = components['schemas']['EntityVatIDResponse'];
 type MergedSettingsResponse = components['schemas']['MergedSettingsResponse'];
-type MoniteAllPaymentMethods = components['schemas']['MoniteAllPaymentMethods'];
-type MoniteAllPaymentMethodsTypes =
-  components['schemas']['MoniteAllPaymentMethodsTypes'];
 type OnboardingPaymentMethodsResponse =
   components['schemas']['OnboardingPaymentMethodsResponse'];
-type PaymentMethodDirection = components['schemas']['PaymentMethodDirection'];
-type PaymentMethodStatus = components['schemas']['PaymentMethodStatus'];
-type StatusEnum = components['schemas']['StatusEnum'];
-type VatIDTypeEnum = components['schemas']['VatIDTypeEnum'];

--- a/packages/sdk-react/src/setupTests.tsx
+++ b/packages/sdk-react/src/setupTests.tsx
@@ -110,9 +110,16 @@ jest.mock('@/api/client', () => {
   };
 });
 
+const consoleError = console.error;
 beforeAll(() => {
   // Enable the mocking in tests.
   server.listen();
+
+  // suppress 'An update to ... inside a test was not wrapped in act(...)' errors in the console
+  console.error = (...args) => {
+    if (/act/.test(args[0])) return;
+    consoleError(...args);
+  };
 });
 
 afterEach(() => {
@@ -123,6 +130,9 @@ afterEach(() => {
 afterAll(() => {
   // Clean up once the tests are done.
   server.close();
+
+  // Restore console.error function
+  console.error = consoleError;
 });
 
 Object.defineProperty(window, 'matchMedia', {

--- a/packages/sdk-react/src/utils/test-utils.tsx
+++ b/packages/sdk-react/src/utils/test-utils.tsx
@@ -145,7 +145,7 @@ interface ICreateRenderWithClientProps {
  * @see {@link https://tkdodo.eu/blog/testing-react-query#always-await-the-query}
  */
 export function createRenderWithClient(props?: ICreateRenderWithClientProps) {
-  return ({ children }: { children: ReactElement }) => (
+  return ({ children }: { children: React.ReactNode }) => (
     <Provider
       client={queryClient}
       children={children}

--- a/packages/sdk-react/src/utils/test-utils.tsx
+++ b/packages/sdk-react/src/utils/test-utils.tsx
@@ -217,26 +217,27 @@ export async function waitUntilTableIsLoaded(
  *
  * @param predicate Predicate checking for condition
  * @param timeout Wait function timeout
+ * @param checkInterval Wait function check interval
  */
 export function waitForCondition(
   predicate: () => boolean,
-  timeout: number = 1_000
+  timeout: number = 1_000,
+  checkInterval: number = 50
 ) {
   return new Promise<void>((resolve, reject) => {
-    const interval = 50;
     let timeLeft = timeout;
     const intervalId = setInterval(() => {
       if (predicate()) {
         clearInterval(intervalId);
         resolve();
       } else {
-        timeLeft -= interval;
+        timeLeft -= checkInterval;
         if (timeLeft <= 0) {
           clearInterval(intervalId);
           reject(new Error('Timed out in waitForCondition.'));
         }
       }
-    }, interval);
+    }, checkInterval);
   });
 }
 

--- a/packages/sdk-react/src/utils/test-utils.tsx
+++ b/packages/sdk-react/src/utils/test-utils.tsx
@@ -213,29 +213,6 @@ export async function waitUntilTableIsLoaded(
 }
 
 /**
- * Waits when the spinner `progressbar`
- *  (which is used for all data-tables in our project)
- *  will be removed from the DOM.
- * That action will mean that the data is loaded in the table
- * Unlike `waitUntilTableIsLoaded`, this method will immediately return
- * if there are no spinners
- */
-export async function optionallyWaitUntilDataIsLoaded(
-  waitForOptions?: waitForOptions
-): Promise<void> {
-  const spinners = screen
-    .queryAllByRole('progressbar')
-    .filter((e) => !!e.parentElement);
-
-  if (spinners.length > 0) {
-    return await waitForElementToBeRemoved(spinners, {
-      timeout: waitForOptions?.timeout ?? 30_000,
-      interval: waitForOptions?.interval,
-    });
-  }
-}
-
-/**
  * Waits for condition to be true
  *
  * @param predicate Predicate checking for condition

--- a/packages/sdk-react/src/utils/test-utils.tsx
+++ b/packages/sdk-react/src/utils/test-utils.tsx
@@ -299,7 +299,7 @@ export function triggerClickOnAutocompleteOption(
   });
   fireEvent.mouseDown(dropdown);
 
-  const option = screen.getByRole('option', { name: selectOption });
+  const option = screen.getByText(selectOption);
   fireEvent.click(option);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,7 +4899,7 @@ __metadata:
     "@team-monite/sdk-themes": "workspace:~"
     "@testing-library/dom": "npm:~9.3.1"
     "@testing-library/jest-dom": "npm:~5.16.5"
-    "@testing-library/react": "npm:~16.0.1"
+    "@testing-library/react": "npm:~14.1.0"
     "@testing-library/user-event": "npm:~14.4.3"
     "@types/deep-eql": "npm:~4.0.2"
     "@types/jest": "npm:~29.5.11"
@@ -8166,6 +8166,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@testing-library/dom@npm:^9.0.0":
+  version: 9.3.4
+  resolution: "@testing-library/dom@npm:9.3.4"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.1.3"
+    chalk: "npm:^4.1.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10/510da752ea76f4a10a0a4e3a77917b0302cf03effe576cd3534cab7e796533ee2b0e9fb6fb11b911a1ebd7c70a0bb6f235bf4f816c9b82b95b8fe0cddfd10975
+  languageName: node
+  linkType: hard
+
 "@testing-library/jest-dom@npm:~5.16.5":
   version: 5.16.5
   resolution: "@testing-library/jest-dom@npm:5.16.5"
@@ -8213,23 +8229,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:~16.0.1":
-  version: 16.0.1
-  resolution: "@testing-library/react@npm:16.0.1"
+"@testing-library/react@npm:~14.1.0":
+  version: 14.1.2
+  resolution: "@testing-library/react@npm:14.1.2"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
+    "@testing-library/dom": "npm:^9.0.0"
+    "@types/react-dom": "npm:^18.0.0"
   peerDependencies:
-    "@testing-library/dom": ^10.0.0
-    "@types/react": ^18.0.0
-    "@types/react-dom": ^18.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10/904b48881cf5bd208e25899e168f5c99c78ed6d77389544838d9d861a038d2c5c5385863ee9a367436770cbf7d21c5e05a991b9e24a33806e9ac985df2448185
+  checksum: 10/1664990ad9673403ee1d74c1c1b60ec30591d42a3fe1e2175c28cb935cd49bc9a4ba398707f702acc3278c3b0cb492ee57fe66f41ceb040c5da57de98cba5414
   languageName: node
   linkType: hard
 
@@ -22556,7 +22566,7 @@ __metadata:
     "@team-monite/sdk-demo": "workspace:~"
     "@team-monite/sdk-themes": "workspace:~"
     "@testing-library/jest-dom": "npm:~6.1.4"
-    "@testing-library/react": "npm:~16.0.1"
+    "@testing-library/react": "npm:~14.1.0"
     "@trivago/prettier-plugin-sort-imports": "npm:^4.1.1"
     "@types/node": "npm:20.3.1"
     "@types/react": "npm:18.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4899,7 +4899,7 @@ __metadata:
     "@team-monite/sdk-themes": "workspace:~"
     "@testing-library/dom": "npm:~9.3.1"
     "@testing-library/jest-dom": "npm:~5.16.5"
-    "@testing-library/react": "npm:~14.0.0"
+    "@testing-library/react": "npm:~16.0.1"
     "@testing-library/user-event": "npm:~14.4.3"
     "@types/deep-eql": "npm:~4.0.2"
     "@types/jest": "npm:~29.5.11"
@@ -8150,7 +8150,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@testing-library/dom@npm:>=7, @testing-library/dom@npm:^9.0.0, @testing-library/dom@npm:~9.3.1":
+"@testing-library/dom@npm:>=7, @testing-library/dom@npm:~9.3.1":
   version: 9.3.1
   resolution: "@testing-library/dom@npm:9.3.1"
   dependencies:
@@ -8213,31 +8213,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:~14.0.0":
-  version: 14.0.0
-  resolution: "@testing-library/react@npm:14.0.0"
+"@testing-library/react@npm:~16.0.1":
+  version: 16.0.1
+  resolution: "@testing-library/react@npm:16.0.1"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
-    "@testing-library/dom": "npm:^9.0.0"
-    "@types/react-dom": "npm:^18.0.0"
   peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0
+    "@types/react-dom": ^18.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 10/1f2a4f78d107e741b35671e9c7dd992d5c9f49b48ee24112ccfe636179be72f3c62a65b1405901b59eb6cde996176ebc2c99099e04d9f14575641e46688747f0
-  languageName: node
-  linkType: hard
-
-"@testing-library/react@npm:~14.1.0":
-  version: 14.1.2
-  resolution: "@testing-library/react@npm:14.1.2"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-    "@testing-library/dom": "npm:^9.0.0"
-    "@types/react-dom": "npm:^18.0.0"
-  peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  checksum: 10/1664990ad9673403ee1d74c1c1b60ec30591d42a3fe1e2175c28cb935cd49bc9a4ba398707f702acc3278c3b0cb492ee57fe66f41ceb040c5da57de98cba5414
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/904b48881cf5bd208e25899e168f5c99c78ed6d77389544838d9d861a038d2c5c5385863ee9a367436770cbf7d21c5e05a991b9e24a33806e9ac985df2448185
   languageName: node
   linkType: hard
 
@@ -22564,7 +22556,7 @@ __metadata:
     "@team-monite/sdk-demo": "workspace:~"
     "@team-monite/sdk-themes": "workspace:~"
     "@testing-library/jest-dom": "npm:~6.1.4"
-    "@testing-library/react": "npm:~14.1.0"
+    "@testing-library/react": "npm:~16.0.1"
     "@trivago/prettier-plugin-sort-imports": "npm:^4.1.1"
     "@types/node": "npm:20.3.1"
     "@types/react": "npm:18.3.1"


### PR DESCRIPTION
This PR opens invoice for editing immediately after its creation. Previously the user were directed back to the invoices list.

The PR contains a long test that fills required fields when creating a new Receivable. I didn't mock nested components because we had a broken test that tested Receivable creation. Therefore my longer test both restores the disabled test from 2022 and tests the new receivable creation flow.