### PR TITLE
chore(proposal): more strict typing system for monite.ts

### DIFF
--- a/.changeset/pretty-parrots-fold.md
+++ b/.changeset/pretty-parrots-fold.md
@@ -1,0 +1,6 @@
+---
+'@team-monite/sdk-themes': patch
+'@monite/sdk-react': patch
+---
+
+chore(proposal): better typings system for monite.ts themesation file

--- a/packages/sdk-react/mui-styles.d.ts
+++ b/packages/sdk-react/mui-styles.d.ts
@@ -1,7 +1,7 @@
-import { type MoniteApprovalRequestStatusChipProps } from '@/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip';
-import { type MoniteCounterpartStatusChipProps } from '@/components/counterparts/CounterpartStatusChip';
-import { type MonitePayableDetailsInfoProps } from '@/components/payables/PayableDetails/PayableDetailsForm';
-import { MonitePayableTableProps } from '@/components/payables/PayablesTable/types';
+import type { MoniteApprovalRequestStatusChipProps } from '@/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestStatusChip/ApprovalRequestStatusChip';
+import type { MoniteCounterpartStatusChipProps } from '@/components/counterparts/CounterpartStatusChip';
+import type { MonitePayableDetailsInfoProps } from '@/components/payables/PayableDetails/PayableDetailsForm';
+import type { MonitePayableTableProps } from '@/components/payables/PayablesTable/types';
 import { type MonitePayableStatusChipProps } from '@/components/payables/PayableStatusChip/PayableStatusChip';
 import { type MoniteInvoiceRecurrenceIterationStatusChipProps } from '@/components/receivables/InvoiceRecurrenceIterationStatusChip/InvoiceRecurrenceIterationStatusChip';
 import { type MoniteInvoiceRecurrenceStatusChipProps } from '@/components/receivables/InvoiceRecurrenceStatusChip/InvoiceRecurrenceStatusChip';
@@ -20,7 +20,7 @@ type Theme = Omit<MuiTheme, 'components'>;
  * Extends theme `components` with Monite components,
  * allowing to configure default props, style overrides, and variants.
  */
-interface ComponentType<T> {
+interface ComponentType<T extends keyof ComponentsPropsList> {
   defaultProps?: ComponentsPropsList[T];
   styleOverrides?: ComponentsOverrides<Theme>[T];
   variants?: ComponentsVariants[T];

--- a/packages/sdk-themes/tsconfig.json
+++ b/packages/sdk-themes/tsconfig.json
@@ -11,7 +11,11 @@
     "esModuleInterop": true,
     "declaration": true,
     "declarationMap": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
After this patch it highlights unexisted properties

<img width="912" alt="Screenshot 2024-10-07 at 14 30 22" src="https://github.com/user-attachments/assets/82c5e8b4-5253-4933-ac4c-cdd9926c49e4">
