### PR TITLE
Fix/on pay contine to handlepay

### DIFF
--- a/packages/sdk-react/src/components/payables/PayableDetails/usePayableDetails.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/usePayableDetails.tsx
@@ -864,11 +864,7 @@ export function usePayableDetails({
       if (onPayUS && payable.currency === 'USD') {
         onPayUS(payable.id);
       } else {
-        if (onPay) {
-          onPay?.(payable.id);
-        } else {
-          handlePay();
-        }
+        onPay ? onPay?.(payable.id) : handlePay();
       }
     }
   }, [payable, handlePay, onPay, onPayUS]);

--- a/packages/sdk-react/src/components/payables/PayablesTable/components/PayablesTableAction.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/components/PayablesTableAction.tsx
@@ -47,8 +47,7 @@ export const PayablesTableAction = ({
               if (onPayUS && payable.currency === 'USD') {
                 onPayUS?.(payable.id);
               } else {
-                onPay?.(payable.id);
-                handlePay();
+                onPay ? onPay?.(payable.id) : handlePay();
               }
             }}
           >


### PR DESCRIPTION
Current behavior:

Clicking the Pay button on the PayablesTable and PayablesDetails will trigger the `handlepay()` regradless if an override prop was passed to `<Payables >` or not. 

Change:

Changed the logic that will ignore the `handlepay()` method if the prop `onPay` is passed to the <Payables> component

