### PR TITLE
fix(proposal): edit AR invoice update button unresponsive

### DIFF
--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
@@ -148,8 +148,6 @@ const EditInvoiceDetailsContent = ({
 
   const formName = `Monite-Form-receivablesDetailsForm-${useId()}`;
 
-  console.log(formName);
-
   const {
     createReminderDialog,
     editReminderDialog,

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
@@ -195,7 +195,6 @@ const EditInvoiceDetailsContent = ({
             id={formName}
             noValidate
             onSubmit={handleSubmit((values) => {
-              console.log("hanlding submit");
               const lineItems: components['schemas']['UpdateLineItems'] = {
                 data: values.line_items.map((lineItem) => ({
                   quantity: lineItem.quantity,

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
@@ -99,9 +99,11 @@ const EditInvoiceDetailsContent = ({
       line_items: invoice.line_items.map((lineItem) => ({
         quantity: lineItem.quantity,
         product_id: lineItem.product.id,
-        ...(lineItem.vat_rate_id !== undefined
-          ? { vat_rate_id: lineItem.vat_rate_id }
-          : { tax_rate_value: lineItem.tax_rate_value * 100 }),
+        ...(lineItem.product.vat_rate.id !== null
+          ? { vat_rate_id: lineItem.product.vat_rate.id,
+              vat_rate_value: lineItem.product.vat_rate.value,
+           }
+          : { tax_rate_value: lineItem.product.vat_rate.value / 100 }),
         name: lineItem.product.name,
         price: lineItem.product.price,
         measure_unit_id: lineItem.product.measure_unit?.id ?? '',
@@ -117,6 +119,7 @@ const EditInvoiceDetailsContent = ({
       overdue_reminder_id: invoice.overdue_reminder_id ?? '',
     },
   });
+
   const [actualCurrency, setActualCurrency] = useState(invoice.currency);
   const {
     handleSubmit,
@@ -198,7 +201,8 @@ const EditInvoiceDetailsContent = ({
                   quantity: lineItem.quantity,
                   product_id: lineItem.product_id,
                   ...(lineItem.vat_rate_id !== undefined
-                    ? { vat_rate_id: lineItem.vat_rate_id }
+                    ? { vat_rate_id: lineItem.vat_rate_id,
+                    }
                     : { tax_rate_value: lineItem.tax_rate_value * 100 }),
                 })),
               };

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx
@@ -99,8 +99,9 @@ const EditInvoiceDetailsContent = ({
       line_items: invoice.line_items.map((lineItem) => ({
         quantity: lineItem.quantity,
         product_id: lineItem.product.id,
-        vat_rate_id: lineItem.product.vat_rate.id,
-        vat_rate_value: lineItem.product.vat_rate.value,
+        ...(lineItem.vat_rate_id !== undefined
+          ? { vat_rate_id: lineItem.vat_rate_id }
+          : { tax_rate_value: lineItem.tax_rate_value * 100 }),
         name: lineItem.product.name,
         price: lineItem.product.price,
         measure_unit_id: lineItem.product.measure_unit?.id ?? '',
@@ -116,9 +117,7 @@ const EditInvoiceDetailsContent = ({
       overdue_reminder_id: invoice.overdue_reminder_id ?? '',
     },
   });
-
   const [actualCurrency, setActualCurrency] = useState(invoice.currency);
-
   const {
     handleSubmit,
     formState: { isDirty },
@@ -148,6 +147,8 @@ const EditInvoiceDetailsContent = ({
     isEntityLoading;
 
   const formName = `Monite-Form-receivablesDetailsForm-${useId()}`;
+
+  console.log(formName);
 
   const {
     createReminderDialog,
@@ -193,11 +194,14 @@ const EditInvoiceDetailsContent = ({
             id={formName}
             noValidate
             onSubmit={handleSubmit((values) => {
+              console.log("hanlding submit");
               const lineItems: components['schemas']['UpdateLineItems'] = {
                 data: values.line_items.map((lineItem) => ({
                   quantity: lineItem.quantity,
                   product_id: lineItem.product_id,
-                  vat_rate_id: lineItem.vat_rate_id,
+                  ...(lineItem.vat_rate_id !== undefined
+                    ? { vat_rate_id: lineItem.vat_rate_id }
+                    : { tax_rate_value: lineItem.tax_rate_value * 100 }),
                 })),
               };
 


### PR DESCRIPTION
Issue was presented by a customer where the update button in the invoice editing screen was not responsive when the entity is not VAT obligated

Issue:
* tax rate value was not included, hence when VAT value was passed it didn't inculde any values

* note for QA and testing - there's a quirk, when launching the SDK for the first time, the VAT rate IDs will not apply, however, when closing and opening the editing component will reflect the VAT rates and the issue doesn't appear for any other invoice