### PR TITLE
fix(DEV-13389): default bank account automatically chosen

### DIFF
--- a/.changeset/flat-walls-reflect.md
+++ b/.changeset/flat-walls-reflect.md
@@ -2,4 +2,4 @@
 '@monite/sdk-react': minor
 ---
 
-"@monite/sdk-react": minor -> Default bank account is selected during counterpart and currency selection
+feat(DEV-13389): Default bank account is selected during counterpart and currency selection

--- a/.changeset/flat-walls-reflect.md
+++ b/.changeset/flat-walls-reflect.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': minor
+---
+
+"@monite/sdk-react": minor -> Default bank account is selected during counterpart and currency selection

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -23,7 +23,6 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import type { I18n } from '@lingui/core';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import { EntityBankAccountResponse } from '@monite/sdk-api';
 import {
   Autocomplete,
   Box,
@@ -354,12 +353,13 @@ const PayableDetailsFormBase = forwardRef<
       ) {
         resetField('counterpartBankAccount', {
           defaultValue: findDefaultBankAccount(
-            counterpartBankAccountQuery.data.data as EntityBankAccountResponse[]
+            counterpartBankAccountQuery.data.data,
+            currentCurrency
           ),
           keepTouched: true,
         });
       }
-    }, [counterpartBankAccountQuery.data]);
+    }, [counterpartBankAccountQuery.data, currentCurrency]);
 
     return (
       <>

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -359,7 +359,7 @@ const PayableDetailsFormBase = forwardRef<
           keepTouched: true,
         });
       }
-    }, [counterpartBankAccountQuery.data, currentCurrency]);
+    }, [counterpartBankAccountQuery, currentCurrency, resetField]);
 
     return (
       <>

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -23,6 +23,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import type { I18n } from '@lingui/core';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
+import { EntityBankAccountResponse } from '@monite/sdk-api';
 import {
   Autocomplete,
   Box,
@@ -50,6 +51,7 @@ import { PayableLineItemsForm } from '../PayableLineItemsForm';
 import {
   calculateTotalsForPayable,
   counterpartsToSelect,
+  findDefaultBankAccount,
   isFieldRequired,
   LineItem,
   MonitePayableDetailsInfoProps,
@@ -345,6 +347,20 @@ const PayableDetailsFormBase = forwardRef<
       trigger();
     }, [trigger]);
 
+    useEffect(() => {
+      if (
+        counterpartBankAccountQuery.isSuccess &&
+        counterpartBankAccountQuery.data?.data
+      ) {
+        resetField('counterpartBankAccount', {
+          defaultValue: findDefaultBankAccount(
+            counterpartBankAccountQuery.data.data as EntityBankAccountResponse[]
+          ),
+          keepTouched: true,
+        });
+      }
+    }, [counterpartBankAccountQuery.data]);
+
     return (
       <>
         <Box
@@ -450,11 +466,7 @@ const PayableDetailsFormBase = forwardRef<
                               label={t(i18n)`Counterpart`}
                               MenuProps={{ container: root }}
                               onChange={(event) => {
-                                resetField('counterpartBankAccount', {
-                                  keepTouched: true,
-                                });
-
-                                return field.onChange(event);
+                                field.onChange(event);
                               }}
                             >
                               {counterpartsToSelect(

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/helpers.ts
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/helpers.ts
@@ -12,10 +12,6 @@ import {
   OptionalFields,
 } from '@/components/payables/types';
 import { CounterpartResponse } from '@/core/queries';
-import {
-  CounterpartBankAccountResponse,
-  EntityBankAccountResponse,
-} from '@monite/sdk-api';
 import { useThemeProps } from '@mui/material';
 
 import { format } from 'date-fns';
@@ -315,8 +311,11 @@ export const usePayableDetailsThemeProps = (
   });
 
 export const findDefaultBankAccount = (
-  accounts: EntityBankAccountResponse[]
+  accounts: components['schemas']['CounterpartBankAccountResponse'][],
+  currentCurrency: components['schemas']['CurrencyEnum']
 ): string => {
-  const defaultAccount = accounts.find((acc) => acc.is_default_for_currency);
+  const defaultAccount = accounts.find(
+    (acc) => acc.currency === currentCurrency && acc.is_default_for_currency
+  );
   return defaultAccount?.id || '';
 };

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/helpers.ts
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/helpers.ts
@@ -12,6 +12,10 @@ import {
   OptionalFields,
 } from '@/components/payables/types';
 import { CounterpartResponse } from '@/core/queries';
+import {
+  CounterpartBankAccountResponse,
+  EntityBankAccountResponse,
+} from '@monite/sdk-api';
 import { useThemeProps } from '@mui/material';
 
 import { format } from 'date-fns';
@@ -309,3 +313,10 @@ export const usePayableDetailsThemeProps = (
     props: inProps,
     name: 'MonitePayableDetailsInfo',
   });
+
+export const findDefaultBankAccount = (
+  accounts: EntityBankAccountResponse[]
+): string => {
+  const defaultAccount = accounts.find((acc) => acc.is_default_for_currency);
+  return defaultAccount?.id || '';
+};


### PR DESCRIPTION
Ready for review. Please let me know if I should include tests.

Current result:
https://github.com/user-attachments/assets/0f7f40a7-6db7-4e03-b676-e0ae0c5010ee

-> Default bank is selected when vendor is selected
-> Default bank changes accordingly when currency changes
-> Bank selection is cleared when different vendor is selected
