### PR TITLE
feat(DEV-14165): product creation default values

### DIFF
--- a/.changeset/lazy-rabbits-obey.md
+++ b/.changeset/lazy-rabbits-obey.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Product creation default values

--- a/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useEffect } from 'react';
+import { useEffect } from 'react';
 import { Controller, FormProvider, useForm } from 'react-hook-form';
 
 import { RHFRadioGroup } from '@/components/RHF/RHFRadioGroup';
@@ -62,18 +62,20 @@ export const ProductForm = ({
   const { i18n } = useLingui();
   const { root } = useRootElements();
   const { api } = useMoniteContext();
-  const { data: measureUnits, isLoading } =
+
+  const { data: measureUnits, isLoading: isLoadingUnits } =
     api.measureUnits.getMeasureUnits.useQuery();
 
   const methods = useForm<IProductFormSubmitValues>({
     resolver: yupResolver(getValidationSchema(i18n)),
-    defaultValues: useMemo(() => defaultValues, [defaultValues]),
+    defaultValues,
   });
 
   const {
     control,
     handleSubmit,
     formState: { isDirty },
+    reset,
   } = methods;
 
   useEffect(() => onChanged?.(isDirty), [isDirty, onChanged]);
@@ -83,6 +85,10 @@ export const ProductForm = ({
   function isManageMeasureUnits(option: string): boolean {
     return option === MANAGE_MEASURE_UNITS_ID;
   }
+
+  useEffect(() => {
+    reset(defaultValues);
+  }, [reset, defaultValues]);
 
   return (
     <FormProvider {...methods}>
@@ -146,7 +152,7 @@ export const ProductForm = ({
                       fullWidth
                       error={Boolean(error)}
                       required
-                      disabled={isLoading}
+                      disabled={isLoadingUnits}
                     >
                       <InputLabel id={field.name}>{t(i18n)`Unit`}</InputLabel>
                       <Select


### PR DESCRIPTION
The Create component acts as an aggregator of default values, combining:
- Base defaults
- API-provided defaults
- Parent-provided defaults (highest priority)

defaultValues logic:
- Wait for data to load before setting defaults (units and entity settings)
- Use first measure unit as default (measureUnits?.data?.[0]?.id)
- Use entity's default currency (entitySettings?.currency?.default)  

ProductForm.tsx
- Removed redundant useMemo for defaultValues since they're already memoized in parent
- Added form reset functionality using useEffect to handle default value changes