### PR TITLE
feat(DEV-14246): onboarding + send invoice email events

### DIFF
--- a/.changeset/nervous-llamas-battle.md
+++ b/.changeset/nervous-llamas-battle.md
@@ -1,0 +1,6 @@
+---
+'@monite/sdk-drop-in': patch
+'@monite/sdk-react': patch
+---
+
+Added onboarding and sent invoice email events to the SDK and Drop-in component

--- a/packages/sdk-drop-in/src/lib/MoniteEvents.ts
+++ b/packages/sdk-drop-in/src/lib/MoniteEvents.ts
@@ -34,17 +34,14 @@ export type InvoiceEventPayload = BaseEventPayload & {
 
 export type PaymentsOnboardingEventPayload = BaseEventPayload & {
   entityId: string;
-  timestamp: string;
 };
 
 export type WorkingCapitalOnboardingEventPayload = BaseEventPayload & {
   entityId: string;
-  timestamp: string;
 };
 
 export type FirstInvoiceSentEventPayload = BaseEventPayload & {
   invoice: ReceivableResponseType;
-  timestamp: string;
 };
 
 export type EventPayload =

--- a/packages/sdk-drop-in/src/lib/MoniteEvents.ts
+++ b/packages/sdk-drop-in/src/lib/MoniteEvents.ts
@@ -28,27 +28,15 @@ export interface BaseEventPayload {
   id: string;
 }
 
-export type InvoiceEventPayload = BaseEventPayload & {
+export interface InvoiceEventPayload extends BaseEventPayload {
   invoice?: ReceivableResponseType;
-};
+}
 
-export type PaymentsOnboardingEventPayload = BaseEventPayload & {
-  entityId: string;
-};
+export interface ReceivableEventPayload extends BaseEventPayload {
+  response?: APISchema.components['schemas']['EntityBankAccountResponse'];
+}
 
-export type WorkingCapitalOnboardingEventPayload = BaseEventPayload & {
-  entityId: string;
-};
-
-export type FirstInvoiceSentEventPayload = BaseEventPayload & {
-  invoice: ReceivableResponseType;
-};
-
-export type EventPayload =
-  | InvoiceEventPayload
-  | PaymentsOnboardingEventPayload
-  | WorkingCapitalOnboardingEventPayload
-  | FirstInvoiceSentEventPayload;
+export type EventPayload = InvoiceEventPayload | ReceivableEventPayload;
 
 export interface MoniteEvent<T extends EventPayload = EventPayload> {
   id: string;
@@ -162,20 +150,20 @@ export function enhanceOnboardingSettings(
   settings: ComponentSettings['onboarding'] = {}
 ): ComponentSettings['onboarding'] {
   const {
-    onPaymentOnboardingCompleted,
-    onWorkingCapitalOnboardingCompleted,
+    onPaymentOnboardingComplete,
+    onWorkingCapitalOnboardingComplete,
     ...rest
   } = settings;
 
   return {
     ...rest,
-    onPaymentOnboardingCompleted: createEventHandler(
-      onPaymentOnboardingCompleted,
+    onPaymentOnboardingComplete: createEventHandler(
+      onPaymentOnboardingComplete,
       MoniteEventTypes.PAYMENTS_ONBOARDING_COMPLETED,
-      (id) => ({ id })
+      (id, response) => ({ id, response })
     ),
-    onWorkingCapitalOnboardingCompleted: createEventHandler(
-      onWorkingCapitalOnboardingCompleted,
+    onWorkingCapitalOnboardingComplete: createEventHandler(
+      onWorkingCapitalOnboardingComplete,
       MoniteEventTypes.WORKING_CAPITAL_ONBOARDING_COMPLETED,
       (id) => ({ id })
     ),

--- a/packages/sdk-react/src/components/onboarding/Onboarding.tsx
+++ b/packages/sdk-react/src/components/onboarding/Onboarding.tsx
@@ -6,21 +6,22 @@ import { LinearProgress } from '@mui/material';
 
 import { OnboardingContextProvider } from './context';
 import { OnboardingContent } from './OnboardingContent';
+import type { OnboardingProps } from './types';
 
 /**
  * Onboarding component
  * @alpha
  * @description Onboarding component has not yet been released.
  */
-export function Onboarding() {
+export const Onboarding = function (props: OnboardingProps) {
   return (
     <MoniteScopedProviders>
-      <OnboardingComponent />
+      <OnboardingComponent {...props} />
     </MoniteScopedProviders>
   );
-}
+};
 
-function OnboardingComponent() {
+function OnboardingComponent(props: OnboardingProps) {
   const { isLoading, error } = useOnboardingRequirementsData();
   const { i18n } = useLingui();
 
@@ -34,7 +35,7 @@ function OnboardingComponent() {
 
   return (
     <OnboardingContextProvider>
-      <OnboardingContent />
+      <OnboardingContent {...props} />
     </OnboardingContextProvider>
   );
 }

--- a/packages/sdk-react/src/components/onboarding/Onboarding.tsx
+++ b/packages/sdk-react/src/components/onboarding/Onboarding.tsx
@@ -1,4 +1,3 @@
-import { components } from '@/api';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useOnboardingRequirementsData } from '@/core/queries/useOnboarding';
 import { getAPIErrorMessage } from '@/core/utils/getAPIErrorMessage';
@@ -7,32 +6,7 @@ import { LinearProgress } from '@mui/material';
 
 import { OnboardingContextProvider } from './context';
 import { OnboardingContent } from './OnboardingContent';
-
-export interface OnboardingProps {
-  /**
-   * Called when bank account setup is completed.
-   *
-   * @param {components['schemas']['EntityBankAccountResponse']} response - The bank account response data
-   * @returns {void}
-   */
-  onBankAccountComplete?: (
-    response: components['schemas']['EntityBankAccountResponse']
-  ) => void;
-  /**
-   * Called when working capital onboarding is completed.
-   * This happens when the business status transitions to 'ONBOARDED'.
-   *
-   * @returns {void}
-   */
-  onWorkingCapitalOnboardingComplete?: () => void;
-
-  /**
-   * Called when the onboarding process is completed.
-   *
-   * @returns {void}
-   */
-  onComplete?: () => void;
-}
+import { OnboardingProps } from './types';
 
 /**
  * Onboarding component

--- a/packages/sdk-react/src/components/onboarding/Onboarding.tsx
+++ b/packages/sdk-react/src/components/onboarding/Onboarding.tsx
@@ -1,5 +1,4 @@
-import type { FC } from 'react';
-
+import { components } from '@/api';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useOnboardingRequirementsData } from '@/core/queries/useOnboarding';
 import { getAPIErrorMessage } from '@/core/utils/getAPIErrorMessage';
@@ -8,14 +7,39 @@ import { LinearProgress } from '@mui/material';
 
 import { OnboardingContextProvider } from './context';
 import { OnboardingContent } from './OnboardingContent';
-import type { OnboardingProps } from './types';
+
+export interface OnboardingProps {
+  /**
+   * Called when bank account setup is completed.
+   *
+   * @param {components['schemas']['EntityBankAccountResponse']} response - The bank account response data
+   * @returns {void}
+   */
+  onBankAccountComplete?: (
+    response: components['schemas']['EntityBankAccountResponse']
+  ) => void;
+  /**
+   * Called when working capital onboarding is completed.
+   * This happens when the business status transitions to 'ONBOARDED'.
+   *
+   * @returns {void}
+   */
+  onWorkingCapitalOnboardingComplete?: () => void;
+
+  /**
+   * Called when the onboarding process is completed.
+   *
+   * @returns {void}
+   */
+  onComplete?: () => void;
+}
 
 /**
  * Onboarding component
  * @alpha
  * @description Onboarding component has not yet been released.
  */
-export const Onboarding: FC<OnboardingProps> = (props) => {
+export const Onboarding = (props: OnboardingProps) => {
   return (
     <MoniteScopedProviders>
       <OnboardingComponent {...props} />
@@ -23,7 +47,7 @@ export const Onboarding: FC<OnboardingProps> = (props) => {
   );
 };
 
-const OnboardingComponent: FC<OnboardingProps> = (props) => {
+const OnboardingComponent = (props: OnboardingProps) => {
   const { isLoading, error } = useOnboardingRequirementsData();
   const { i18n } = useLingui();
 

--- a/packages/sdk-react/src/components/onboarding/Onboarding.tsx
+++ b/packages/sdk-react/src/components/onboarding/Onboarding.tsx
@@ -1,3 +1,5 @@
+import type { FC } from 'react';
+
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useOnboardingRequirementsData } from '@/core/queries/useOnboarding';
 import { getAPIErrorMessage } from '@/core/utils/getAPIErrorMessage';
@@ -13,7 +15,7 @@ import type { OnboardingProps } from './types';
  * @alpha
  * @description Onboarding component has not yet been released.
  */
-export const Onboarding = function (props: OnboardingProps) {
+export const Onboarding: FC<OnboardingProps> = (props) => {
   return (
     <MoniteScopedProviders>
       <OnboardingComponent {...props} />
@@ -21,7 +23,7 @@ export const Onboarding = function (props: OnboardingProps) {
   );
 };
 
-function OnboardingComponent(props: OnboardingProps) {
+const OnboardingComponent: FC<OnboardingProps> = (props) => {
   const { isLoading, error } = useOnboardingRequirementsData();
   const { i18n } = useLingui();
 
@@ -38,4 +40,4 @@ function OnboardingComponent(props: OnboardingProps) {
       <OnboardingContent {...props} />
     </OnboardingContextProvider>
   );
-}
+};

--- a/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
@@ -9,6 +9,7 @@ import {
   RHFAutocomplete,
 } from '@/components/RHF/RHFAutocomplete';
 import { RHFTextField } from '@/components/RHF/RHFTextField';
+import { useMoniteContext } from '@/core/context/MoniteContext';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import { MenuItem } from '@mui/material';
@@ -20,15 +21,19 @@ type EntityBankAccountResponse =
   components['schemas']['EntityBankAccountResponse'];
 
 export interface OnboardingBankAccountProps {
-  onOnboardingBankAccountSubmit?: (response: EntityBankAccountResponse) => void;
-  onWorkingCapitalOnboardingComplete?: () => void;
+  onPaymentOnboardingComplete?: (
+    entityId: string,
+    response?: EntityBankAccountResponse
+  ) => void;
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void;
 }
 
 export const OnboardingBankAccount = ({
-  onOnboardingBankAccountSubmit,
+  onPaymentOnboardingComplete,
   onWorkingCapitalOnboardingComplete,
 }: OnboardingBankAccountProps = {}) => {
   const { i18n } = useLingui();
+  const { entityId } = useMoniteContext();
 
   useWorkingCapitalOnboarding(onWorkingCapitalOnboardingComplete);
 
@@ -62,7 +67,7 @@ export const OnboardingBankAccount = ({
   const handleFormSubmit = handleSubmit(async (data) => {
     const result = await primaryAction(data);
 
-    onOnboardingBankAccountSubmit?.(result);
+    onPaymentOnboardingComplete?.(entityId, result);
 
     return result;
   });

--- a/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 
+import { components } from '@/api';
 import { useOnboardingBankAccount } from '@/components/onboarding/hooks/useOnboardingBankAccount';
 import { getRegionName } from '@/components/onboarding/utils';
+import { useWorkingCapitalOnboarding } from '@/components/receivables/Financing/hooks/useWorkingCapitalOnboarding';
 import {
   CountryOption,
   RHFAutocomplete,
@@ -14,8 +16,21 @@ import { MenuItem } from '@mui/material';
 import { OnboardingFormActions } from '../OnboardingFormActions';
 import { OnboardingForm, OnboardingStepContent } from '../OnboardingLayout';
 
-export const OnboardingBankAccount = () => {
+type EntityBankAccountResponse =
+  components['schemas']['EntityBankAccountResponse'];
+
+export interface OnboardingBankAccountProps {
+  onOnboardingBankAccountSubmit?: (response: EntityBankAccountResponse) => void;
+  onWorkingCapitalOnboardingComplete?: () => void;
+}
+
+export const OnboardingBankAccount = ({
+  onOnboardingBankAccountSubmit,
+  onWorkingCapitalOnboardingComplete,
+}: OnboardingBankAccountProps = {}) => {
   const { i18n } = useLingui();
+
+  useWorkingCapitalOnboarding(onWorkingCapitalOnboardingComplete);
 
   const {
     isLoading,
@@ -44,11 +59,19 @@ export const OnboardingBankAccount = () => {
     }
   }, [countries, resetField, getValues]);
 
+  const handleFormSubmit = handleSubmit(async (data) => {
+    const result = await primaryAction(data);
+
+    onOnboardingBankAccountSubmit?.(result);
+
+    return result;
+  });
+
   if (isLoading) return null;
 
   return (
     <OnboardingForm
-      onSubmit={handleSubmit(primaryAction)}
+      onSubmit={handleFormSubmit}
       actions={<OnboardingFormActions isLoading={isPending} />}
     >
       <OnboardingStepContent>

--- a/packages/sdk-react/src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx
@@ -1,11 +1,20 @@
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import { useEffect } from 'react';
 
 import { OnboardingLayout, OnboardingTitle } from '../OnboardingLayout';
 
-export const OnboardingCompleted = () => {
+interface OnboardingCompletedProps {
+  onComplete?: () => void;
+}
+
+export const OnboardingCompleted = ({ onComplete }: OnboardingCompletedProps = {}) => {
   const { i18n } = useLingui();
+
+  useEffect(() => {
+    onComplete?.();
+  }, [onComplete]);
 
   return (
     <OnboardingLayout

--- a/packages/sdk-react/src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx
@@ -1,7 +1,8 @@
+import { useEffect } from 'react';
+
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
-import { useEffect } from 'react';
 
 import { OnboardingLayout, OnboardingTitle } from '../OnboardingLayout';
 
@@ -9,7 +10,9 @@ interface OnboardingCompletedProps {
   onComplete?: () => void;
 }
 
-export const OnboardingCompleted = ({ onComplete }: OnboardingCompletedProps = {}) => {
+export const OnboardingCompleted = ({
+  onComplete,
+}: OnboardingCompletedProps = {}) => {
   const { i18n } = useLingui();
 
   useEffect(() => {

--- a/packages/sdk-react/src/components/onboarding/OnboardingContent/OnboardingContent.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingContent/OnboardingContent.tsx
@@ -41,7 +41,7 @@ import type { OnboardingPersonId, OnboardingProps } from '../types';
 type OnboardingRequirement = components['schemas']['OnboardingRequirement'];
 
 export function OnboardingContent({
-  onBankAccountComplete,
+  onPaymentOnboardingComplete,
   onWorkingCapitalOnboardingComplete,
   onComplete,
 }: OnboardingProps = {}) {
@@ -60,7 +60,7 @@ export function OnboardingContent({
 
   const Step = getComponent(currentRequirement, personId);
   const props = getProps(currentRequirement, {
-    onBankAccountComplete,
+    onPaymentOnboardingComplete,
     onWorkingCapitalOnboardingComplete,
   });
 
@@ -236,7 +236,7 @@ const getProps = (
 ) => {
   if (isBankAccount(requirement)) {
     return {
-      onOnboardingBankAccountSubmit: callbacks.onBankAccountComplete,
+      onPaymentOnboardingComplete: callbacks.onPaymentOnboardingComplete,
       onWorkingCapitalOnboardingComplete:
         callbacks.onWorkingCapitalOnboardingComplete,
     };

--- a/packages/sdk-react/src/components/onboarding/OnboardingContent/OnboardingContent.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingContent/OnboardingContent.tsx
@@ -105,27 +105,18 @@ const getTitle = (
   }
 
   if (isEditingPerson(personId)) return t(i18n)`Edit individual`;
-
-  const titleMap = new Map<boolean, string>([
-    [isEntity(requirement), t(i18n)`Company details`],
-    [
-      isRepresentative(requirement),
-      t(i18n)`Verify you represent this business`,
-    ],
-    [isOwners(requirement), t(i18n)`Business owners`],
-    [isDirectors(requirement), t(i18n)`Business directors`],
-    [isExecutives(requirement), t(i18n)`Business executives`],
-    [isBankAccount(requirement), t(i18n)`Bank account`],
-    [isBusinessProfile(requirement), t(i18n)`Business details`],
-    [isPersons(requirement), t(i18n)`Persons review`],
-    [isTosAcceptance(requirement), t(i18n)`Terms and conditions`],
-    [isOwnershipDeclaration(requirement), t(i18n)`Terms and conditions`],
-    [isEntityDocuments(requirement), t(i18n)`Entity documents`],
-  ]);
-
-  for (const [condition, title] of titleMap) {
-    if (condition) return title;
-  }
+  if (isEntity(requirement)) return t(i18n)`Company details`;
+  if (isRepresentative(requirement))
+    return t(i18n)`Verify you represent this business`;
+  if (isOwners(requirement)) return t(i18n)`Business owners`;
+  if (isDirectors(requirement)) return t(i18n)`Business directors`;
+  if (isExecutives(requirement)) return t(i18n)`Business executives`;
+  if (isBankAccount(requirement)) return t(i18n)`Bank account`;
+  if (isBusinessProfile(requirement)) return t(i18n)`Business details`;
+  if (isPersons(requirement)) return t(i18n)`Persons review`;
+  if (isTosAcceptance(requirement)) return t(i18n)`Terms and conditions`;
+  if (isOwnershipDeclaration(requirement)) return t(i18n)`Terms and conditions`;
+  if (isEntityDocuments(requirement)) return t(i18n)`Entity documents`;
 
   throw new Error(`Unknown step title ${JSON.stringify(requirement)}`);
 };

--- a/packages/sdk-react/src/components/onboarding/helpers.ts
+++ b/packages/sdk-react/src/components/onboarding/helpers.ts
@@ -2,7 +2,7 @@ import { components } from '@/api';
 
 import type {
   EntityOrganizationRelationshipCode,
-  OnboardingPersonIndex,
+  OnboardingPersonId,
   OnboardingRequirementMask,
 } from './types';
 
@@ -233,12 +233,12 @@ export const PERSON_CREATION = '';
 /**
  * Checks if person mode is enabled, i.e., the personId is not null or undefined.
  *
- * @param {OnboardingPersonIndex} personId - The personId of the person.
+ * @param {OnboardingPersonId} personId - The personId of the person.
  *
  * @returns {boolean} - Returns true if person mode is enabled, false otherwise.
  */
 export const isPersonEditingEnabled = (
-  personId?: OnboardingPersonIndex
+  personId?: OnboardingPersonId
 ): personId is string => {
   return personId !== null && personId !== undefined;
 };
@@ -246,12 +246,12 @@ export const isPersonEditingEnabled = (
 /**
  * Checks if person is being created.
  *
- * @param {OnboardingPersonIndex} personId - The id of the person.
+ * @param {OnboardingPersonId} personId - The id of the person.
  *
  * @returns {boolean} - Returns true if person mode is enabled and the index equals PERSON_CREATION, false otherwise.
  */
 export const isCreatingPerson = (
-  personId?: OnboardingPersonIndex
+  personId?: OnboardingPersonId
 ): personId is string => {
   return isPersonEditingEnabled(personId) && personId === PERSON_CREATION;
 };
@@ -259,12 +259,12 @@ export const isCreatingPerson = (
 /**
  * Checks if person is being edited.
  *
- * @param {OnboardingPersonIndex} personId - The id of the person.
+ * @param {OnboardingPersonId} personId - The id of the person.
  *
  * @returns {boolean} - Returns true if person mode is enabled and the index is greater than PERSON_CREATION, false otherwise.
  */
 export const isEditingPerson = (
-  personId?: OnboardingPersonIndex
+  personId?: OnboardingPersonId
 ): personId is string => {
   return isPersonEditingEnabled(personId) && personId !== PERSON_CREATION;
 };

--- a/packages/sdk-react/src/components/onboarding/hooks/useOnboardingBankAccount.ts
+++ b/packages/sdk-react/src/components/onboarding/hooks/useOnboardingBankAccount.ts
@@ -45,7 +45,13 @@ export type OnboardingBankAccountReturnType = {
   >;
 };
 
-export function useOnboardingBankAccount(): OnboardingBankAccountReturnType {
+export type OnboardingBankAccountProps = {
+  onBankAccountComplete?: () => void;
+};
+
+export function useOnboardingBankAccount({
+  onBankAccountComplete,
+}: OnboardingBankAccountProps = {}): OnboardingBankAccountReturnType {
   const { data: onboarding, isLoading: isOnboardingDataLoading } =
     useOnboardingRequirementsData();
 
@@ -171,6 +177,8 @@ export function useOnboardingBankAccount(): OnboardingBankAccountReturnType {
         },
       });
 
+      onBankAccountComplete?.();
+
       return response;
     },
     [
@@ -179,6 +187,7 @@ export function useOnboardingBankAccount(): OnboardingBankAccountReturnType {
       currentBankAccount,
       patchOnboardingRequirements,
       fields,
+      onBankAccountComplete,
     ]
   );
 

--- a/packages/sdk-react/src/components/onboarding/hooks/useOnboardingBankAccount.ts
+++ b/packages/sdk-react/src/components/onboarding/hooks/useOnboardingBankAccount.ts
@@ -45,13 +45,7 @@ export type OnboardingBankAccountReturnType = {
   >;
 };
 
-export type OnboardingBankAccountProps = {
-  onBankAccountComplete?: () => void;
-};
-
-export function useOnboardingBankAccount({
-  onBankAccountComplete,
-}: OnboardingBankAccountProps = {}): OnboardingBankAccountReturnType {
+export function useOnboardingBankAccount(): OnboardingBankAccountReturnType {
   const { data: onboarding, isLoading: isOnboardingDataLoading } =
     useOnboardingRequirementsData();
 
@@ -177,8 +171,6 @@ export function useOnboardingBankAccount({
         },
       });
 
-      onBankAccountComplete?.();
-
       return response;
     },
     [
@@ -187,7 +179,6 @@ export function useOnboardingBankAccount({
       currentBankAccount,
       patchOnboardingRequirements,
       fields,
-      onBankAccountComplete,
     ]
   );
 

--- a/packages/sdk-react/src/components/onboarding/index.ts
+++ b/packages/sdk-react/src/components/onboarding/index.ts
@@ -1,1 +1,2 @@
 export * from './Onboarding';
+export * from './types';

--- a/packages/sdk-react/src/components/onboarding/types.ts
+++ b/packages/sdk-react/src/components/onboarding/types.ts
@@ -105,3 +105,32 @@ export type OnboardingRequirementMask = Extract<
   components['schemas']['OnboardingRequirement'],
   'representative' | 'directors' | 'executives' | 'owners'
 >;
+
+export interface OnboardingProps {
+  /**
+   * Called when bank account setup is completed.
+   *
+   * @param entityId The entity id
+   * @param {components['schemas']['EntityBankAccountResponse']} response - The bank account response data
+   * @returns {void}
+   */
+  onPaymentOnboardingComplete?: (
+    entityId: string,
+    response?: components['schemas']['EntityBankAccountResponse']
+  ) => void;
+  /**
+   * Called when working capital onboarding is completed.
+   * This happens when the business status transitions to 'ONBOARDED'.
+   *
+   * @param entityId The entity id
+   * @returns {void}
+   */
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void;
+
+  /**
+   * Called when the onboarding process is completed.
+   *
+   * @returns {void}
+   */
+  onComplete?: () => void;
+}

--- a/packages/sdk-react/src/components/onboarding/types.ts
+++ b/packages/sdk-react/src/components/onboarding/types.ts
@@ -105,3 +105,29 @@ export type OnboardingRequirementMask = Extract<
   components['schemas']['OnboardingRequirement'],
   'representative' | 'directors' | 'executives' | 'owners'
 >;
+
+export interface OnboardingProps {
+  /**
+   * Called when bank account setup is completed.
+   *
+   * @param {components['schemas']['EntityBankAccountResponse']} response - The bank account response data
+   * @returns {void}
+   */
+  onBankAccountComplete?: (
+    response: components['schemas']['EntityBankAccountResponse']
+  ) => void;
+  /**
+   * Called when working capital onboarding is completed.
+   * This happens when the business status transitions to 'ONBOARDED'.
+   *
+   * @returns {void}
+   */
+  onWorkingCapitalOnboardingComplete?: () => void;
+
+  /**
+   * Called when the onboarding process is completed.
+   *
+   * @returns {void}
+   */
+  onComplete?: () => void;
+}

--- a/packages/sdk-react/src/components/onboarding/types.ts
+++ b/packages/sdk-react/src/components/onboarding/types.ts
@@ -105,29 +105,3 @@ export type OnboardingRequirementMask = Extract<
   components['schemas']['OnboardingRequirement'],
   'representative' | 'directors' | 'executives' | 'owners'
 >;
-
-export interface OnboardingProps {
-  /**
-   * Called when bank account setup is completed.
-   *
-   * @param {components['schemas']['EntityBankAccountResponse']} response - The bank account response data
-   * @returns {void}
-   */
-  onBankAccountComplete?: (
-    response: components['schemas']['EntityBankAccountResponse']
-  ) => void;
-  /**
-   * Called when working capital onboarding is completed.
-   * This happens when the business status transitions to 'ONBOARDED'.
-   *
-   * @returns {void}
-   */
-  onWorkingCapitalOnboardingComplete?: () => void;
-
-  /**
-   * Called when the onboarding process is completed.
-   *
-   * @returns {void}
-   */
-  onComplete?: () => void;
-}

--- a/packages/sdk-react/src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx
+++ b/packages/sdk-react/src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx
@@ -4,6 +4,7 @@ import { components } from '@/api';
 import { FinanceOverviewCard } from '@/components/receivables/Financing/FinanceInvoice/FinanceOverviewCard';
 import { useWorkingCapitalOnboarding } from '@/components/receivables/Financing/hooks/useWorkingCapitalOnboarding';
 import { FinanceCardStack } from '@/components/receivables/Financing/infographics/FinanceCardStack';
+import { useMoniteContext } from '@/core/context/MoniteContext';
 import {
   useFinanceAnInvoice,
   useFinancing,
@@ -25,7 +26,7 @@ const SIX_DAYS_IN_MILLISECONDS = 6 * 24 * 60 * 60 * 1000;
 
 interface FinanceInvoiceProps {
   invoice: components['schemas']['InvoiceResponsePayload'];
-  onWorkingCapitalOnboardingComplete?: () => void;
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void;
 }
 
 export const FinanceInvoice = ({
@@ -33,6 +34,7 @@ export const FinanceInvoice = ({
   onWorkingCapitalOnboardingComplete,
 }: FinanceInvoiceProps) => {
   const { i18n } = useLingui();
+  const { entityId } = useMoniteContext();
   const [isFinancingAnInvoice, setIsFinancingAnInvoice] = useState(false);
 
   const { isLoading: isLoadingFinancedInvoices, data: financedInvoices } =
@@ -51,8 +53,8 @@ export const FinanceInvoice = ({
   const { isLoading: isLoadingFinanceOffers, data: financeOffersData } =
     useGetFinanceOffers();
 
-  const { isOnboarded } = useWorkingCapitalOnboarding(
-    onWorkingCapitalOnboardingComplete
+  const { isOnboarded } = useWorkingCapitalOnboarding(() =>
+    onWorkingCapitalOnboardingComplete?.(entityId)
   );
 
   const isLoading =

--- a/packages/sdk-react/src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx
+++ b/packages/sdk-react/src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx
@@ -1,8 +1,8 @@
-// import { toast } from 'react-hot-toast';
 import { useState } from 'react';
 
 import { components } from '@/api';
 import { FinanceOverviewCard } from '@/components/receivables/Financing/FinanceInvoice/FinanceOverviewCard';
+import { useWorkingCapitalOnboarding } from '@/components/receivables/Financing/hooks/useWorkingCapitalOnboarding';
 import { FinanceCardStack } from '@/components/receivables/Financing/infographics/FinanceCardStack';
 import {
   useFinanceAnInvoice,
@@ -10,7 +10,6 @@ import {
   useGetFinancedInvoices,
   useGetFinanceOffers,
 } from '@/core/queries/useFinancing';
-// import { getAPIErrorMessage } from '@/core/utils/getAPIErrorMessage';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import {
@@ -24,11 +23,15 @@ import {
 
 const SIX_DAYS_IN_MILLISECONDS = 6 * 24 * 60 * 60 * 1000;
 
+interface FinanceInvoiceProps {
+  invoice: components['schemas']['InvoiceResponsePayload'];
+  onWorkingCapitalOnboardingComplete?: () => void;
+}
+
 export const FinanceInvoice = ({
   invoice,
-}: {
-  invoice: components['schemas']['InvoiceResponsePayload'];
-}) => {
+  onWorkingCapitalOnboardingComplete,
+}: FinanceInvoiceProps) => {
   const { i18n } = useLingui();
   const [isFinancingAnInvoice, setIsFinancingAnInvoice] = useState(false);
 
@@ -44,11 +47,17 @@ export const FinanceInvoice = ({
     isInitializing,
     startFinanceSession,
   } = useFinancing();
+
   const { isLoading: isLoadingFinanceOffers, data: financeOffersData } =
     useGetFinanceOffers();
 
+  const { isOnboarded } = useWorkingCapitalOnboarding(
+    onWorkingCapitalOnboardingComplete
+  );
+
   const isLoading =
-    isLoadingFinanceOffers || isLoadingFinanceSdk || isLoadingFinancedInvoices;
+    isLoadingFinanceSdk || isLoadingFinancedInvoices || isLoadingFinanceOffers;
+
   const financeInvoiceMutation = useFinanceAnInvoice();
 
   const invoiceStatusIsValid = ['issued', 'partially_paid'].includes(
@@ -78,7 +87,6 @@ export const FinanceInvoice = ({
         {
           onError: () => {
             setIsFinancingAnInvoice(false);
-            // toast.error(getAPIErrorMessage(i18n, error));
           },
           onSuccess: ({ session_token }) => {
             startFinanceSession({
@@ -93,8 +101,6 @@ export const FinanceInvoice = ({
       setIsFinancingAnInvoice(false);
     }
   };
-
-  const isOnboarded = financeOffersData?.business_status === 'ONBOARDED';
 
   if (isLoading) {
     return <CircularProgress color="inherit" size={20} />;

--- a/packages/sdk-react/src/components/receivables/Financing/hooks/useWorkingCapitalOnboarding.ts
+++ b/packages/sdk-react/src/components/receivables/Financing/hooks/useWorkingCapitalOnboarding.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { usePrevious } from 'react-use';
 
+import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useGetFinanceOffers } from '@/core/queries/useFinancing';
 
 /**
@@ -8,8 +9,9 @@ import { useGetFinanceOffers } from '@/core/queries/useFinancing';
  * Triggers a callback when the business status transitions to 'ONBOARDED'.
  */
 export const useWorkingCapitalOnboarding = (
-  onWorkingCapitalOnboardingComplete?: () => void
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void
 ) => {
+  const { entityId } = useMoniteContext();
   const { data: financeOffersData } = useGetFinanceOffers();
   const prevBusinessStatus = usePrevious(financeOffersData?.business_status);
 
@@ -18,12 +20,13 @@ export const useWorkingCapitalOnboarding = (
       financeOffersData?.business_status === 'ONBOARDED' &&
       prevBusinessStatus !== 'ONBOARDED'
     ) {
-      onWorkingCapitalOnboardingComplete?.();
+      onWorkingCapitalOnboardingComplete?.(entityId);
     }
   }, [
     financeOffersData?.business_status,
     prevBusinessStatus,
     onWorkingCapitalOnboardingComplete,
+    entityId,
   ]);
 
   return {

--- a/packages/sdk-react/src/components/receivables/Financing/hooks/useWorkingCapitalOnboarding.ts
+++ b/packages/sdk-react/src/components/receivables/Financing/hooks/useWorkingCapitalOnboarding.ts
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { usePrevious } from 'react-use';
+
+import { useGetFinanceOffers } from '@/core/queries/useFinancing';
+
+/**
+ * Hook to monitor working capital onboarding status.
+ * Triggers a callback when the business status transitions to 'ONBOARDED'.
+ */
+export const useWorkingCapitalOnboarding = (
+  onWorkingCapitalOnboardingComplete?: () => void
+) => {
+  const { data: financeOffersData } = useGetFinanceOffers();
+  const prevBusinessStatus = usePrevious(financeOffersData?.business_status);
+
+  useEffect(() => {
+    if (
+      financeOffersData?.business_status === 'ONBOARDED' &&
+      prevBusinessStatus !== 'ONBOARDED'
+    ) {
+      onWorkingCapitalOnboardingComplete?.();
+    }
+  }, [
+    financeOffersData?.business_status,
+    prevBusinessStatus,
+    onWorkingCapitalOnboardingComplete,
+  ]);
+
+  return {
+    businessStatus: financeOffersData?.business_status,
+    isOnboarded: financeOffersData?.business_status === 'ONBOARDED',
+  };
+};

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx
@@ -182,15 +182,18 @@ const ExistingInvoiceDetailsBase = (props: ExistingReceivableDetailsProps) => {
     );
   }
 
+  const isFirstInvoice = !receivable.document_id;
   const documentId = receivable.document_id ?? INVOICE_DOCUMENT_AUTO_ID;
 
   if (presentation === InvoiceDetailsPresentation.Email) {
     return (
       <EmailInvoiceDetails
         invoiceId={props.id}
+        isFirstInvoice={isFirstInvoice}
         onClose={() => {
           setPresentation(InvoiceDetailsPresentation.Overview);
         }}
+        onSendEmail={props.onSendEmail}
       />
     );
   }

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx
@@ -139,7 +139,7 @@ const ExistingInvoiceDetailsBase = (props: ExistingReceivableDetailsProps) => {
 
   const { loading, buttons, callbacks, view } = useExistingInvoiceDetails({
     receivableId: props.id,
-    receivable: receivable,
+    receivable,
     deliveryMethod,
   });
 
@@ -416,7 +416,12 @@ const ExistingInvoiceDetailsBase = (props: ExistingReceivableDetailsProps) => {
                   />
                 )
               )}
-              <Overview {...receivable} />
+              <Overview
+                invoice={receivable}
+                onWorkingCapitalOnboardingComplete={
+                  props.onWorkingCapitalOnboardingComplete
+                }
+              />
             </Stack>
           </Grid>
         </Grid>

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.test.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.test.tsx
@@ -33,6 +33,7 @@ const renderEmailInvoiceDetails = (props = {}) => {
           <EmailInvoiceDetails
             invoiceId={mockInvoiceId}
             onClose={jest.fn()}
+            isFirstInvoice={false}
             {...props}
           />
         </Dialog>

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx
@@ -48,7 +48,7 @@ import { getDefaultContact } from './helpers/contacts';
 
 interface EmailInvoiceDetailsProps {
   invoiceId: string;
-  isFirstInvoice: boolean;
+  isFirstInvoice?: boolean;
   onClose: () => void;
   onSendEmail?: (invoiceId: string, isFirstInvoice: boolean) => void;
 }
@@ -205,7 +205,7 @@ export const EmailInvoiceDetailsBase = ({
           await createPaymentLink({
             recipient: { id: entityId, type: 'entity' },
             payment_methods: availablePaymentMethods.map(
-              (method) => method.type as PaymentMethod
+              (method) => method.type
             ),
             object: { id: invoiceId, type: 'receivable' },
           });
@@ -224,7 +224,7 @@ export const EmailInvoiceDetailsBase = ({
          */
         sendEmail(emailParams, {
           onSuccess: () => {
-            onSendEmail?.(invoiceId, isFirstInvoice);
+            onSendEmail?.(invoiceId, Boolean(isFirstInvoice));
             onClose();
           },
         });

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx
@@ -14,9 +14,15 @@ import { PreviewItemsSection } from './sections/PreviewItemsSection';
 import { PreviewPaymentDetailsSection } from './sections/PreviewPaymentDetailsSection';
 import { PaymentTabPanel } from './TabPanels/PaymentTabPanel/PaymentTabPanel';
 
-export const Overview = (
-  invoice: components['schemas']['InvoiceResponsePayload']
-) => {
+interface OverviewProps {
+  invoice: components['schemas']['InvoiceResponsePayload'];
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void;
+}
+
+export const Overview = ({
+  invoice,
+  onWorkingCapitalOnboardingComplete,
+}: OverviewProps) => {
   const { i18n } = useLingui();
   const [view, setView] = useState<
     'overview' | 'details' | 'recurrence' | 'payments'
@@ -69,6 +75,9 @@ export const Overview = (
           id={`${tabsBaseId}-overview-tabpanel`}
           aria-labelledby={`${tabsBaseId}-overview-tab`}
           onSetView={setView}
+          onWorkingCapitalOnboardingComplete={
+            onWorkingCapitalOnboardingComplete
+          }
         />
       )}
 

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx
@@ -42,8 +42,9 @@ import { FinanceInvoice } from '../../../Financing/FinanceInvoice/FinanceInvoice
 
 interface OverviewTabPanelProps
   extends Pick<BoxProps, 'id' | 'role' | 'aria-labelledby'> {
-  onSetView: (view: 'recurrence') => void;
   invoice: components['schemas']['InvoiceResponsePayload'];
+  onSetView: (view: 'recurrence') => void;
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void;
 }
 
 interface TransformCreditNotes {
@@ -55,6 +56,7 @@ interface TransformCreditNotes {
 export const OverviewTabPanel = ({
   invoice,
   onSetView,
+  onWorkingCapitalOnboardingComplete,
   ...restProps
 }: OverviewTabPanelProps) => {
   const { i18n } = useLingui();
@@ -125,7 +127,10 @@ export const OverviewTabPanel = ({
 
   return (
     <>
-      <FinanceInvoice invoice={invoice} />
+      <FinanceInvoice
+        invoice={invoice}
+        onWorkingCapitalOnboardingComplete={onWorkingCapitalOnboardingComplete}
+      />
       <Box
         sx={{
           '& > * + *': {

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/InvoiceDetails.types.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/InvoiceDetails.types.ts
@@ -74,6 +74,16 @@ export interface ExistingReceivableDetailsProps {
    * @returns {void}
    */
   onMarkAsUncollectible?: (invoiceId: string) => void;
+
+  /**
+   * Indicates that an invoice email has been sent to the counterpart.
+   *
+   * @param {string} invoiceId - Invoice ID
+   * @param {boolean} isFirstInvoice - Whether this is the first invoice sent by the entity
+   *
+   * @returns {void}
+   */
+  onSendEmail?: (invoiceId: string, isFirstInvoice: boolean) => void;
 }
 
 export interface InvoiceDetailsCreateProps {

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/InvoiceDetails.types.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/InvoiceDetails.types.ts
@@ -84,6 +84,7 @@ export interface ExistingReceivableDetailsProps {
    * @returns {void}
    */
   onSendEmail?: (invoiceId: string, isFirstInvoice: boolean) => void;
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void;
 }
 
 export interface InvoiceDetailsCreateProps {

--- a/packages/sdk-react/src/components/receivables/Receivables.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.tsx
@@ -38,6 +38,7 @@ const ReceivablesBase = () => {
       onUpdate: componentSettings?.receivables?.onUpdate,
       onDelete: componentSettings?.receivables?.onDelete,
       onCreate: componentSettings?.receivables?.onCreate,
+      onFirstInvoiceSent: componentSettings?.receivables?.onFirstInvoiceSent,
     }),
     [componentSettings?.receivables]
   );
@@ -82,6 +83,15 @@ const ReceivablesBase = () => {
       receivableCallbacks.onCreate?.(receivableId);
     },
     [receivableCallbacks, openInvoiceModal, setActiveTab]
+  );
+
+  const handleSendEmail = useCallback(
+    (_invoiceId: string, isFirstInvoice: boolean) => {
+      if (isFirstInvoice) {
+        receivableCallbacks.onFirstInvoiceSent?.();
+      }
+    },
+    [receivableCallbacks]
   );
 
   const { root } = useRootElements();
@@ -149,6 +159,7 @@ const ReceivablesBase = () => {
           id={invoiceId}
           onUpdate={handleUpdate}
           onDelete={handleDelete}
+          onSendEmail={handleSendEmail}
         />
       </Dialog>
       <Dialog

--- a/packages/sdk-react/src/components/receivables/Receivables.tsx
+++ b/packages/sdk-react/src/components/receivables/Receivables.tsx
@@ -86,9 +86,9 @@ const ReceivablesBase = () => {
   );
 
   const handleSendEmail = useCallback(
-    (_invoiceId: string, isFirstInvoice: boolean) => {
+    (invoiceId: string, isFirstInvoice: boolean) => {
       if (isFirstInvoice) {
-        receivableCallbacks.onFirstInvoiceSent?.();
+        receivableCallbacks.onFirstInvoiceSent?.(invoiceId);
       }
     },
     [receivableCallbacks]

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -18,14 +18,29 @@ interface ReceivableSettings extends MoniteReceivablesTableProps {
   /** Callback to be called when an invoice is deleted */
   onDelete?: (receivableId: string) => void;
   /** Callback to be called when a first invoice is sent */
-  onFirstInvoiceSent?: () => void;
+  onFirstInvoiceSent?: (invoiceId: string) => void;
 }
 
-interface OnboardingSettings {
-  /** Callback to be called when payment onboarding is completed */
-  onPaymentOnboardingCompleted?: () => void;
-  /** Callback to be called when a working capital onboarding is completed */
-  onWorkingCapitalOnboardingCompleted?: () => void;
+export interface OnboardingSettings {
+  /**
+   * Called when bank account setup is completed.
+   *
+   * @param {string} entityId - The ID of the entity
+   * @param {components['schemas']['EntityBankAccountResponse']} response - The bank account response data
+   * @returns {void}
+   */
+  onPaymentOnboardingComplete?: (
+    entityId: string,
+    response?: components['schemas']['EntityBankAccountResponse']
+  ) => void;
+  /**
+   * Called when working capital onboarding is completed.
+   * This happens when the business status transitions to 'ONBOARDED'.
+   *
+   * @param {string} entityId - The ID of the entity
+   * @returns {void}
+   */
+  onWorkingCapitalOnboardingComplete?: (entityId: string) => void;
 }
 
 interface PayableSettings

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -166,4 +166,5 @@ export const getDefaultComponentSettings = (
     pageSizeOptions:
       componentSettings?.userRoles?.pageSizeOptions || defaultPageSizeOptions,
   },
+  onboarding: componentSettings?.onboarding ?? {},
 });

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -17,6 +17,15 @@ interface ReceivableSettings extends MoniteReceivablesTableProps {
   ) => void;
   /** Callback to be called when an invoice is deleted */
   onDelete?: (receivableId: string) => void;
+  /** Callback to be called when a first invoice is sent */
+  onFirstInvoiceSent?: () => void;
+}
+
+interface OnboardingSettings {
+  /** Callback to be called when payment onboarding is completed */
+  onPaymentOnboardingCompleted?: () => void;
+  /** Callback to be called when a working capital onboarding is completed */
+  onWorkingCapitalOnboardingCompleted?: () => void;
 }
 
 interface PayableSettings
@@ -49,6 +58,7 @@ export interface ComponentSettings {
   userRoles: {
     pageSizeOptions: number[];
   };
+  onboarding: Partial<OnboardingSettings>;
 }
 
 const defaultPageSizeOptions = [15, 30, 100];

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -255,7 +255,7 @@ msgstr "Active"
 msgid "Add"
 msgstr "Add"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:192
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:183
 msgid "Add a bank to receive transfers of funds to your business."
 msgstr "Add a bank to receive transfers of funds to your business."
 
@@ -925,7 +925,7 @@ msgstr "Bangladesh"
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:114
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:544
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:279
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:118
@@ -1169,15 +1169,15 @@ msgstr "Bus Lines"
 msgid "Business address"
 msgstr "Business address"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:119
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
 msgid "Business details"
 msgstr "Business details"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:112
 msgid "Business directors"
 msgstr "Business directors"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
 msgid "Business executives"
 msgstr "Business executives"
 
@@ -1189,7 +1189,7 @@ msgstr "Business Identification Number (Liechtenstein)"
 msgid "Business Number (Canada)"
 msgstr "Business Number (Canada)"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:111
 msgid "Business owners"
 msgstr "Business owners"
 
@@ -1612,7 +1612,7 @@ msgstr "Comoros"
 msgid "Companies"
 msgstr "Companies"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:110
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:108
 msgid "Company details"
 msgstr "Company details"
 
@@ -2637,11 +2637,11 @@ msgstr "Due Date"
 msgid "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 msgstr "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:182
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:173
 msgid "Due to regulations, we’re required to collect information about a company’s directors."
 msgstr "Due to regulations, we’re required to collect information about a company’s directors."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:177
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:168
 msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 
@@ -2906,7 +2906,7 @@ msgstr "Entity"
 msgid "Entity bank account"
 msgstr "Entity bank account"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:123
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:119
 msgid "Entity documents"
 msgstr "Entity documents"
 
@@ -3989,11 +3989,11 @@ msgstr "It looks like the phone number is too short."
 msgid "It will remain in all the documents where it is added. You can’t undo this action."
 msgstr "It will remain in all the documents where it is added. You can’t undo this action."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:140
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:131
 msgid "It’s required to add any individual who is on the governing board of the company."
 msgstr "It’s required to add any individual who is on the governing board of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:146
 msgid "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 msgstr "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 
@@ -5381,7 +5381,7 @@ msgstr "Permissions"
 msgid "Person"
 msgstr "Person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:120
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
 msgid "Persons review"
 msgstr "Persons review"
 
@@ -5467,11 +5467,11 @@ msgstr "Please accept Service Agreement to proceed."
 msgid "Please add any individual who owns 25% or more of the company."
 msgstr "Please add any individual who owns 25% or more of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:146
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:137
 msgid "Please add any individual who owns 25% or more of your business."
 msgstr "Please add any individual who owns 25% or more of your business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:198
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:189
 msgid "Please correct the errors in persons information."
 msgstr "Please correct the errors in persons information."
 
@@ -5515,11 +5515,11 @@ msgstr "Please list all individuals who are members of the governing board of th
 msgid "Please provide a valid date."
 msgstr "Please provide a valid date."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:151
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:142
 msgid "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 msgstr "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:195
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:186
 msgid "Please provide information about your business."
 msgstr "Please provide information about your business."
 
@@ -5527,8 +5527,8 @@ msgstr "Please provide information about your business."
 msgid "Please provide the following documents for the person"
 msgstr "Please provide the following documents for the person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:201
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:206
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:192
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:197
 msgid "Please review the terms and conditions and accept them to continue."
 msgstr "Please review the terms and conditions and accept them to continue."
 
@@ -5541,9 +5541,9 @@ msgstr "Please try again later."
 msgid "Please try to reload."
 msgstr "Please try to reload."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:162
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:164
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:211
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:153
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:202
 msgid "Please upload the required documents to continue."
 msgstr "Please upload the required documents to continue."
 
@@ -6840,7 +6840,7 @@ msgstr "Telecommunication Services"
 msgid "Telegraph Services"
 msgstr "Telegraph Services"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:169
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:160
 msgid "Tell us more about your business"
 msgstr "Tell us more about your business"
 
@@ -6852,8 +6852,8 @@ msgstr "Tent and Awning Shops"
 msgid "Terms"
 msgstr "Terms"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:121
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:122
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
 msgid "Terms and conditions"
 msgstr "Terms and conditions"
 
@@ -6992,7 +6992,7 @@ msgstr "There was an issue reading the file."
 msgid "This action can't be undone."
 msgstr "This action can't be undone."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:172
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:163
 msgid "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 msgstr "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 
@@ -7717,7 +7717,7 @@ msgstr "Venezuela"
 msgid "Verify identity"
 msgstr "Verify identity"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:110
 msgid "Verify you represent this business"
 msgstr "Verify you represent this business"
 
@@ -7774,7 +7774,7 @@ msgstr "Wallis And Futuna"
 msgid "Watch/Jewelry Repair"
 msgstr "Watch/Jewelry Repair"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:187
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:178
 msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -38,7 +38,7 @@ msgstr "{0, select, credit_note {Credit Note has been deleted} invoice {Invoice 
 msgid "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has been sent} quote {Quote has been sent} other {Receivable has been sent}}"
 msgstr "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has been sent} quote {Quote has been sent} other {Receivable has been sent}}"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:81
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:104
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:20
 #: src/components/receivables/Financing/FinanceFaq/FinanceFaqDetails.tsx:58
 #: src/components/receivables/Financing/FinanceFaq/FinanceFaqDetails.tsx:62
@@ -205,7 +205,7 @@ msgstr "Access Restricted"
 msgid "Account holder name"
 msgstr "Account holder name"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:106
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:129
 msgid "Account Holder Name"
 msgstr "Account Holder Name"
 
@@ -220,7 +220,7 @@ msgstr "Account name"
 msgid "Account number"
 msgstr "Account number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:115
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:138
 msgid "Account Number"
 msgstr "Account Number"
 
@@ -255,7 +255,7 @@ msgstr "Active"
 msgid "Add"
 msgstr "Add"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:170
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:192
 msgid "Add a bank to receive transfers of funds to your business."
 msgstr "Add a bank to receive transfers of funds to your business."
 
@@ -267,16 +267,20 @@ msgstr "Add a business executive"
 msgid "Add a business owner"
 msgstr "Add a business owner"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:84
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:96
 #: src/components/onboarding/OnboardingPersonList/OnboardingPersonList.tsx:176
 msgid "Add a director"
 msgstr "Add a director"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:86
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:99
+msgid "Add a person"
+msgstr "Add a person"
+
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:98
 msgid "Add an executive"
 msgstr "Add an executive"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:85
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:97
 msgid "Add an owner"
 msgstr "Add an owner"
 
@@ -921,7 +925,7 @@ msgstr "Bangladesh"
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:101
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:544
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:279
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:118
@@ -1165,15 +1169,15 @@ msgstr "Bus Lines"
 msgid "Business address"
 msgstr "Business address"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:102
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:119
 msgid "Business details"
 msgstr "Business details"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:99
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
 msgid "Business directors"
 msgstr "Business directors"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:100
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
 msgid "Business executives"
 msgstr "Business executives"
 
@@ -1185,7 +1189,7 @@ msgstr "Business Identification Number (Liechtenstein)"
 msgid "Business Number (Canada)"
 msgstr "Business Number (Canada)"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:98
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
 msgid "Business owners"
 msgstr "Business owners"
 
@@ -1322,7 +1326,7 @@ msgstr "Cancel bill?"
 msgid "Cancel invoice"
 msgstr "Cancel invoice"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:320
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:323
 msgid "Cancel Invoice"
 msgstr "Cancel Invoice"
 
@@ -1335,7 +1339,7 @@ msgid "Cancel receivable?"
 msgstr "Cancel receivable?"
 
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceRecurrenceCancelModal.tsx:150
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:379
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:382
 msgid "Cancel recurrence"
 msgstr "Cancel recurrence"
 
@@ -1608,7 +1612,7 @@ msgstr "Comoros"
 msgid "Companies"
 msgstr "Companies"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:95
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:110
 msgid "Company details"
 msgstr "Company details"
 
@@ -1875,7 +1879,7 @@ msgstr "Counterparts"
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:110
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:75
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:44
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:76
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:99
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:26
 #: src/components/onboarding/validators/validationSchemas.ts:115
 #: src/components/onboarding/validators/validationSchemas.ts:151
@@ -1992,7 +1996,7 @@ msgstr "Create invoice"
 #: src/components/receivables/Receivables.test.tsx:34
 #: src/components/receivables/Receivables.test.tsx:75
 #: src/components/receivables/Receivables.test.tsx:112
-#: src/components/receivables/Receivables.tsx:128
+#: src/components/receivables/Receivables.tsx:138
 msgid "Create Invoice"
 msgstr "Create Invoice"
 
@@ -2087,7 +2091,7 @@ msgstr "Created by user"
 msgid "Created on"
 msgstr "Created on"
 
-#: src/core/componentSettings/index.ts:125
+#: src/core/componentSettings/index.ts:135
 msgid "Credit notes"
 msgstr "Credit notes"
 
@@ -2123,7 +2127,7 @@ msgstr "Cuba"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:20
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:114
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:58
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:81
 #: src/components/onboarding/validators/validationSchemas.ts:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:146
 #: src/components/products/ProductDetails/validation.ts:48
@@ -2281,7 +2285,7 @@ msgstr "Defaulted"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:78
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/ReminderFormLayout.tsx:38
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceDeleteModal.tsx:82
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:279
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:282
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingReceivableDetails.tsx:279
 #: src/components/TableActions/TableActions.tsx:59
 #: src/components/tags/ConfirmDeleteModal/ConfirmDeleteModal.test.tsx:51
@@ -2542,7 +2546,7 @@ msgstr "Dominican Peso"
 msgid "Dominican Republic"
 msgstr "Dominican Republic"
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:160
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:166
 msgid "Don't wait for the payment"
 msgstr "Don't wait for the payment"
 
@@ -2560,7 +2564,7 @@ msgstr "Done, continue"
 msgid "Door-To-Door Sales"
 msgstr "Door-To-Door Sales"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:337
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:340
 msgid "Download PDF"
 msgstr "Download PDF"
 
@@ -2633,11 +2637,11 @@ msgstr "Due Date"
 msgid "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 msgstr "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:160
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:182
 msgid "Due to regulations, we’re required to collect information about a company’s directors."
 msgstr "Due to regulations, we’re required to collect information about a company’s directors."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:177
 msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 
@@ -2744,15 +2748,15 @@ msgstr "Edit Customer Close"
 msgid "Edit customer's profile"
 msgstr "Edit customer's profile"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:90
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:103
 msgid "Edit documents for person"
 msgstr "Edit documents for person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:94
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:107
 msgid "Edit individual"
 msgstr "Edit individual"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:290
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:293
 msgid "Edit invoice"
 msgstr "Edit invoice"
 
@@ -2902,7 +2906,7 @@ msgstr "Entity"
 msgid "Entity bank account"
 msgstr "Entity bank account"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:106
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:123
 msgid "Entity documents"
 msgstr "Entity documents"
 
@@ -3378,7 +3382,7 @@ msgstr "Germany"
 msgid "Get a small business loan plan to manage finances more efficiently."
 msgstr "Get a small business loan plan to manage finances more efficiently."
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:191
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:197
 msgid "Get paid now"
 msgstr "Get paid now"
 
@@ -3645,7 +3649,7 @@ msgstr "I own 25% or more of the company."
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:130
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:8
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:90
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:97
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:120
 #: src/components/onboarding/validators/validationSchemas.ts:120
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:31
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:45
@@ -3814,7 +3818,7 @@ msgstr "Invoice {0}"
 msgid "Invoice {0} from {entityName}"
 msgstr "Invoice {0} from {entityName}"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:258
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:261
 msgid "Invoice {documentId}"
 msgstr "Invoice {documentId}"
 
@@ -3879,7 +3883,7 @@ msgstr "Invoice total"
 
 #: src/components/receivables/Financing/FinanceTab/FinancedInvoicesTable/FinancedInvoicesTable.tsx:271
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:419
-#: src/core/componentSettings/index.ts:117
+#: src/core/componentSettings/index.ts:127
 msgid "Invoices"
 msgstr "Invoices"
 
@@ -3907,7 +3911,7 @@ msgstr "Israel"
 msgid "Israeli New Shekel"
 msgstr "Israeli New Shekel"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:367
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:370
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingReceivableDetails.tsx:284
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingReceivableDetails.tsx:289
 msgid "Issue"
@@ -3985,11 +3989,11 @@ msgstr "It looks like the phone number is too short."
 msgid "It will remain in all the documents where it is added. You can’t undo this action."
 msgstr "It will remain in all the documents where it is added. You can’t undo this action."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:140
 msgid "It’s required to add any individual who is on the governing board of the company."
 msgstr "It’s required to add any individual who is on the governing board of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:133
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
 msgid "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 msgstr "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 
@@ -4294,7 +4298,7 @@ msgid "Loading payment page..."
 msgstr "Loading payment page..."
 
 #: src/components/counterparts/CounterpartDetails/CounterpartView/useCounterpartView.tsx:115
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:190
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:196
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -4601,7 +4605,7 @@ msgstr "Monthly recurrence"
 msgid "Montserrat"
 msgstr "Montserrat"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:301
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:304
 msgid "More"
 msgstr "More"
 
@@ -5041,7 +5045,7 @@ msgstr "Omani Rial"
 msgid "Onboarding"
 msgstr "Onboarding"
 
-#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:19
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:31
 msgid "Onboarding Completed"
 msgstr "Onboarding Completed"
 
@@ -5377,7 +5381,7 @@ msgstr "Permissions"
 msgid "Person"
 msgstr "Person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:103
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:120
 msgid "Persons review"
 msgstr "Persons review"
 
@@ -5463,11 +5467,11 @@ msgstr "Please accept Service Agreement to proceed."
 msgid "Please add any individual who owns 25% or more of the company."
 msgstr "Please add any individual who owns 25% or more of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:124
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:146
 msgid "Please add any individual who owns 25% or more of your business."
 msgstr "Please add any individual who owns 25% or more of your business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:176
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:198
 msgid "Please correct the errors in persons information."
 msgstr "Please correct the errors in persons information."
 
@@ -5511,11 +5515,11 @@ msgstr "Please list all individuals who are members of the governing board of th
 msgid "Please provide a valid date."
 msgstr "Please provide a valid date."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:129
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:151
 msgid "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 msgstr "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:173
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:195
 msgid "Please provide information about your business."
 msgstr "Please provide information about your business."
 
@@ -5523,8 +5527,8 @@ msgstr "Please provide information about your business."
 msgid "Please provide the following documents for the person"
 msgstr "Please provide the following documents for the person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:179
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:184
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:201
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:206
 msgid "Please review the terms and conditions and accept them to continue."
 msgstr "Please review the terms and conditions and accept them to continue."
 
@@ -5537,9 +5541,9 @@ msgstr "Please try again later."
 msgid "Please try to reload."
 msgstr "Please try to reload."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:140
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:142
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:189
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:162
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:164
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:211
 msgid "Please upload the required documents to continue."
 msgstr "Please upload the required documents to continue."
 
@@ -5738,7 +5742,7 @@ msgstr "Project"
 msgid "Provide documents"
 msgstr "Provide documents"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:91
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:104
 msgid "Provide documents for persons"
 msgstr "Provide documents for persons"
 
@@ -5801,7 +5805,7 @@ msgid "Quick Copy, Repro, and Blueprint"
 msgstr "Quick Copy, Repro, and Blueprint"
 
 #: src/components/receivables/QuotesTable/QuotesTable.tsx:301
-#: src/core/componentSettings/index.ts:121
+#: src/core/componentSettings/index.ts:131
 msgid "Quotes"
 msgstr "Quotes"
 
@@ -5860,7 +5864,7 @@ msgid "Reconciliation"
 msgstr "Reconciliation"
 
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/TabPanels/PaymentTabPanel/PaymentRecordForm.tsx:69
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:346
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:349
 msgid "Record payment"
 msgstr "Record payment"
 
@@ -5910,7 +5914,7 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "Recurring"
 msgstr "Recurring"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:246
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:249
 msgid "Recurring invoice"
 msgstr "Recurring invoice"
 
@@ -6116,7 +6120,7 @@ msgstr "Roofing/Siding, Sheet Metal"
 msgid "Routing number"
 msgstr "Routing number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:124
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:147
 msgid "Routing Number"
 msgstr "Routing Number"
 
@@ -6160,7 +6164,7 @@ msgstr "Saint Pierre And Miquelon"
 msgid "Saint Vincent And Grenadines"
 msgstr "Saint Vincent And Grenadines"
 
-#: src/components/receivables/Receivables.tsx:113
+#: src/components/receivables/Receivables.tsx:123
 msgid "Sales"
 msgstr "Sales"
 
@@ -6302,7 +6306,7 @@ msgstr "Send"
 msgid "Send failed"
 msgstr "Send failed"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:309
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:312
 msgid "Send invoice"
 msgstr "Send invoice"
 
@@ -6501,7 +6505,7 @@ msgstr "Something went wrong. Please try again"
 msgid "Sort code"
 msgstr "Sort code"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:133
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:156
 msgid "Sort Code"
 msgstr "Sort Code"
 
@@ -6836,7 +6840,7 @@ msgstr "Telecommunication Services"
 msgid "Telegraph Services"
 msgstr "Telegraph Services"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:147
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:169
 msgid "Tell us more about your business"
 msgstr "Tell us more about your business"
 
@@ -6848,8 +6852,8 @@ msgstr "Tent and Awning Shops"
 msgid "Terms"
 msgstr "Terms"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:104
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:105
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:121
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:122
 msgid "Terms and conditions"
 msgstr "Terms and conditions"
 
@@ -6869,7 +6873,7 @@ msgstr "Thai Baht"
 msgid "Thailand"
 msgstr "Thailand"
 
-#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:20
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:32
 msgid "Thank you for completing onboarding for payments services. We will now review the information submitted."
 msgstr "Thank you for completing onboarding for payments services. We will now review the information submitted."
 
@@ -6893,7 +6897,7 @@ msgstr "The following fields are required:"
 msgid "The IBAN should correspond to the chosen country - {country}."
 msgstr "The IBAN should correspond to the chosen country - {country}."
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:167
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:173
 msgid "The issue date should be less than 7 days ago. You can't fund overdue invoices. The loan sum must be within your remaining limit."
 msgstr "The issue date should be less than 7 days ago. You can't fund overdue invoices. The loan sum must be within your remaining limit."
 
@@ -6988,11 +6992,11 @@ msgstr "There was an issue reading the file."
 msgid "This action can't be undone."
 msgstr "This action can't be undone."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:150
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:172
 msgid "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 msgstr "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:164
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:170
 msgid "This invoice can be financed"
 msgstr "This invoice can be financed"
 
@@ -7713,7 +7717,7 @@ msgstr "Venezuela"
 msgid "Verify identity"
 msgstr "Verify identity"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:97
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
 msgid "Verify you represent this business"
 msgstr "Verify you represent this business"
 
@@ -7770,7 +7774,7 @@ msgstr "Wallis And Futuna"
 msgid "Watch/Jewelry Repair"
 msgstr "Watch/Jewelry Repair"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:165
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:187
 msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 
@@ -7802,7 +7806,7 @@ msgstr "Who needs to approve the document and how:"
 msgid "Wholesale Clubs"
 msgstr "Wholesale Clubs"
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:175
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:181
 msgid "Why?"
 msgstr "Why?"
 
@@ -7945,7 +7949,7 @@ msgstr "You don’t have any roles yet."
 msgid "You don’t have any tags yet."
 msgstr "You don’t have any tags yet."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:403
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:406
 msgid "You don't have permission to issue this document. Please, contact your system administrator for details."
 msgstr "You don't have permission to issue this document. Please, contact your system administrator for details."
 

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -38,7 +38,7 @@ msgstr "{0, select, credit_note {Credit Note has been deleted} invoice {Invoice 
 msgid "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has been sent} quote {Quote has been sent} other {Receivable has been sent}}"
 msgstr "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has been sent} quote {Quote has been sent} other {Receivable has been sent}}"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:104
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:109
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:20
 #: src/components/receivables/Financing/FinanceFaq/FinanceFaqDetails.tsx:58
 #: src/components/receivables/Financing/FinanceFaq/FinanceFaqDetails.tsx:62
@@ -205,7 +205,7 @@ msgstr "Access Restricted"
 msgid "Account holder name"
 msgstr "Account holder name"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:129
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:134
 msgid "Account Holder Name"
 msgstr "Account Holder Name"
 
@@ -220,7 +220,7 @@ msgstr "Account name"
 msgid "Account number"
 msgstr "Account number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:138
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:143
 msgid "Account Number"
 msgstr "Account Number"
 
@@ -856,7 +856,7 @@ msgstr "Azerbaijani Manat"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartIndividualForm/CounterpartIndividualForm.tsx:435
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:432
 #: src/components/products/ProductCancelEditModal/ProductCancelEditModal.tsx:48
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:259
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:272
 msgid "Back"
 msgstr "Back"
 
@@ -885,7 +885,7 @@ msgstr "Back of your identify document"
 msgid "Back of your identity document"
 msgstr "Back of your identity document"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:272
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:285
 msgid "Back to edit"
 msgstr "Back to edit"
 
@@ -1219,7 +1219,7 @@ msgstr "Business/Secretarial Schools"
 msgid "Buying/Shopping Services"
 msgstr "Buying/Shopping Services"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:381
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:386
 msgid "by"
 msgstr "by"
 
@@ -1632,8 +1632,8 @@ msgid "Completed"
 msgstr "Completed"
 
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx:143
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:260
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:359
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:273
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:362
 msgid "Compose email"
 msgstr "Compose email"
 
@@ -1879,7 +1879,7 @@ msgstr "Counterparts"
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:110
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:75
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:44
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:99
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:104
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:26
 #: src/components/onboarding/validators/validationSchemas.ts:115
 #: src/components/onboarding/validators/validationSchemas.ts:151
@@ -2091,7 +2091,7 @@ msgstr "Created by user"
 msgid "Created on"
 msgstr "Created on"
 
-#: src/core/componentSettings/index.ts:135
+#: src/core/componentSettings/index.ts:150
 msgid "Credit notes"
 msgstr "Credit notes"
 
@@ -2127,7 +2127,7 @@ msgstr "Cuba"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:20
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:114
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:81
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:86
 #: src/components/onboarding/validators/validationSchemas.ts:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:146
 #: src/components/products/ProductDetails/validation.ts:48
@@ -2141,7 +2141,7 @@ msgstr "Currency"
 msgid "Current offer"
 msgstr "Current offer"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:153
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:158
 msgid "Current status"
 msgstr "Current status"
 
@@ -2156,7 +2156,7 @@ msgstr "Current status"
 #: src/components/receivables/Financing/FinanceTab/FinancedInvoicesTable/FinancedInvoicesTable.tsx:143
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/CounterpartSelector.tsx:199
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:176
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:140
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:145
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewCustomerSection.tsx:56
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:262
 #: src/components/receivables/QuotesTable/QuotesTable.tsx:189
@@ -2422,7 +2422,7 @@ msgstr "Description is required"
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:449
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:211
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:310
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:43
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:49
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:19
 msgid "Details"
 msgstr "Details"
@@ -2546,7 +2546,7 @@ msgstr "Dominican Peso"
 msgid "Dominican Republic"
 msgstr "Dominican Republic"
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:166
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:168
 msgid "Don't wait for the payment"
 msgstr "Don't wait for the payment"
 
@@ -3060,7 +3060,7 @@ msgstr "Failed to delete Unit."
 msgid "Failed to delete VAT."
 msgstr "Failed to delete VAT."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:400
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:414
 msgid "Failed to generate email preview"
 msgstr "Failed to generate email preview"
 
@@ -3382,7 +3382,7 @@ msgstr "Germany"
 msgid "Get a small business loan plan to manage finances more efficiently."
 msgstr "Get a small business loan plan to manage finances more efficiently."
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:197
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:199
 msgid "Get paid now"
 msgstr "Get paid now"
 
@@ -3557,7 +3557,7 @@ msgstr "Heating, Plumbing, A/C"
 msgid "here."
 msgstr "here."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:87
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:82
 msgid ""
 "Hi {0},\n"
 "Please find the invoice attached as discussed.\n"
@@ -3649,7 +3649,7 @@ msgstr "I own 25% or more of the company."
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:130
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:8
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:90
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:120
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:125
 #: src/components/onboarding/validators/validationSchemas.ts:120
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:31
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:45
@@ -3668,7 +3668,7 @@ msgstr "Icelandic Króna"
 msgid "If amount is"
 msgstr "If amount is"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:407
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:421
 msgid "If the error recurs, contact support, please."
 msgstr "If the error recurs, contact support, please."
 
@@ -3814,7 +3814,7 @@ msgstr "Invoice"
 msgid "Invoice {0}"
 msgstr "Invoice {0}"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:101
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:96
 msgid "Invoice {0} from {entityName}"
 msgstr "Invoice {0} from {entityName}"
 
@@ -3843,7 +3843,7 @@ msgstr "Invoice delete confirmation"
 msgid "Invoice financing"
 msgstr "Invoice financing"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:102
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:97
 msgid "Invoice from {entityName}"
 msgstr "Invoice from {entityName}"
 
@@ -3877,13 +3877,13 @@ msgstr "Invoice Reminder type is not provided"
 msgid "Invoice to “{0}” was created"
 msgstr "Invoice to “{0}” was created"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:165
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:170
 msgid "Invoice total"
 msgstr "Invoice total"
 
 #: src/components/receivables/Financing/FinanceTab/FinancedInvoicesTable/FinancedInvoicesTable.tsx:271
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:419
-#: src/core/componentSettings/index.ts:127
+#: src/core/componentSettings/index.ts:142
 msgid "Invoices"
 msgstr "Invoices"
 
@@ -3922,7 +3922,7 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "Issue"
 msgstr "Issue"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:308
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:321
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/SubmitInvoice.tsx:119
 msgid "Issue and send"
 msgstr "Issue and send"
@@ -3962,12 +3962,12 @@ msgstr "Issue only"
 msgid "Issued"
 msgstr "Issued"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:51
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:57
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceDetails.tsx:65
 msgid "Issued documents"
 msgstr "Issued documents"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:381
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:386
 msgid "Issued on"
 msgstr "Issued on"
 
@@ -4285,7 +4285,7 @@ msgstr "Line 1"
 msgid "Line 2"
 msgstr "Line 2"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:184
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:189
 msgid "Linked documents"
 msgstr "Linked documents"
 
@@ -4298,7 +4298,7 @@ msgid "Loading payment page..."
 msgstr "Loading payment page..."
 
 #: src/components/counterparts/CounterpartDetails/CounterpartView/useCounterpartView.tsx:115
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:196
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:198
 msgid "Loading..."
 msgstr "Loading..."
 
@@ -4824,7 +4824,7 @@ msgstr "No {entityName}"
 msgid "No {entityName} Found"
 msgstr "No {entityName} Found"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:184
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:188
 msgid "No active payment methods available. The email will be sent without a payment link"
 msgstr "No active payment methods available. The email will be sent without a payment link"
 
@@ -5111,7 +5111,7 @@ msgstr "Overdue reminder error"
 msgid "Overdue reminders"
 msgstr "Overdue reminders"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:37
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:43
 msgid "Overview"
 msgstr "Overview"
 
@@ -5350,7 +5350,7 @@ msgstr "Payment term updated"
 msgid "Payment terms"
 msgstr "Payment terms"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:58
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:64
 msgid "Payments"
 msgstr "Payments"
 
@@ -5492,7 +5492,7 @@ msgstr "Please enter a valid phone number."
 msgid "Please enter your IBAN number."
 msgstr "Please enter your IBAN number."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:93
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:88
 msgid ""
 "Please find the invoice attached as discussed.\n"
 "Kind Regards,\n"
@@ -5536,7 +5536,7 @@ msgstr "Please review the terms and conditions and accept them to continue."
 msgid "Please try again later."
 msgstr "Please try again later."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:404
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:418
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoicePDFViewer.tsx:70
 msgid "Please try to reload."
 msgstr "Please try to reload."
@@ -5633,7 +5633,7 @@ msgstr "Preset name"
 msgid "Preset Name"
 msgstr "Preset Name"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:299
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:312
 msgid "Preview email"
 msgstr "Preview email"
 
@@ -5805,7 +5805,7 @@ msgid "Quick Copy, Repro, and Blueprint"
 msgstr "Quick Copy, Repro, and Blueprint"
 
 #: src/components/receivables/QuotesTable/QuotesTable.tsx:301
-#: src/core/componentSettings/index.ts:131
+#: src/core/componentSettings/index.ts:146
 msgid "Quotes"
 msgstr "Quotes"
 
@@ -5955,7 +5955,7 @@ msgstr "Religious Goods Stores"
 msgid "Religious Organizations"
 msgstr "Religious Organizations"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:416
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:430
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoicePDFViewer.tsx:88
 #: src/ui/DataGridEmptyState/GetNoRowsOverlay.tsx:101
 msgid "Reload"
@@ -5978,7 +5978,7 @@ msgstr "Remind"
 msgid "Reminder {0}"
 msgstr "Reminder {0}"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:234
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:239
 msgid "Reminder emails"
 msgstr "Reminder emails"
 
@@ -5987,7 +5987,7 @@ msgstr "Reminder emails"
 msgid "Reminder has been created"
 msgstr "Reminder has been created"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:303
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:308
 msgid "Reminder has been deleted"
 msgstr "Reminder has been deleted"
 
@@ -6120,7 +6120,7 @@ msgstr "Roofing/Siding, Sheet Metal"
 msgid "Routing number"
 msgstr "Routing number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:147
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:152
 msgid "Routing Number"
 msgstr "Routing Number"
 
@@ -6505,7 +6505,7 @@ msgstr "Something went wrong. Please try again"
 msgid "Sort code"
 msgstr "Sort code"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:156
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:161
 msgid "Sort Code"
 msgstr "Sort Code"
 
@@ -6617,7 +6617,7 @@ msgstr "Status"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/OverdueReminderForm.tsx:238
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/validation.ts:17
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/validation.ts:64
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:159
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:155
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.ts:14
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceForm.tsx:402
 msgid "Subject"
@@ -6897,7 +6897,7 @@ msgstr "The following fields are required:"
 msgid "The IBAN should correspond to the chosen country - {country}."
 msgstr "The IBAN should correspond to the chosen country - {country}."
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:173
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:175
 msgid "The issue date should be less than 7 days ago. You can't fund overdue invoices. The loan sum must be within your remaining limit."
 msgstr "The issue date should be less than 7 days ago. You can't fund overdue invoices. The loan sum must be within your remaining limit."
 
@@ -6996,7 +6996,7 @@ msgstr "This action can't be undone."
 msgid "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 msgstr "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:170
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:172
 msgid "This invoice can be financed"
 msgstr "This invoice can be financed"
 
@@ -7038,7 +7038,7 @@ msgstr "Tire Retreading and Repair"
 msgid "Title"
 msgstr "Title"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:141
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:137
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.ts:10
 #: src/components/receivables/InvoiceDetails/InvoiceTo/InvoiceTo.tsx:29
 msgid "To"
@@ -7356,7 +7356,7 @@ msgstr "Units"
 msgid "Unknown"
 msgstr "Unknown"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:370
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:375
 msgid "Unknown date"
 msgstr "Unknown date"
 
@@ -7750,7 +7750,7 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "View"
 msgstr "View"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:207
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:212
 msgid "View all"
 msgstr "View all"
 
@@ -7806,7 +7806,7 @@ msgstr "Who needs to approve the document and how:"
 msgid "Wholesale Clubs"
 msgstr "Wholesale Clubs"
 
-#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:181
+#: src/components/receivables/Financing/FinanceInvoice/FinanceInvoice.tsx:183
 msgid "Why?"
 msgstr "Why?"
 


### PR DESCRIPTION
Added the following event flows:

1. First Invoice Sent:
Triggered when an email is sent for the first invoice
onSendEmail in InvoiceDetails provides isFirstInvoice flag
If isFirstInvoice is true, onFirstInvoiceSent callback is called

2. Bank Account Complete:
Triggered when bank account setup is completed
onPaymentOnboardingCompleted callback is called from the onboarding flow

3. Working Capital Onboarding Complete:
Triggered when working capital onboarding status changes to 'ONBOARDED'
onWorkingCapitalOnboardingCompleted callback is called

TODO:
[ ✔️ ] Clean up the types, lint errors and translations (remove unused timestamps etc)
[ ✔️ ] Rebase on Main