### PR TITLE
fix(DEV-14402): remove special fileds like id from updatePerson payloads

### DIFF
--- a/.changeset/five-brooms-sparkle.md
+++ b/.changeset/five-brooms-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Filter forbidden fields in update person payloads

--- a/packages/sdk-react/src/components/onboarding/hooks/useOnboardingPerson.ts
+++ b/packages/sdk-react/src/components/onboarding/hooks/useOnboardingPerson.ts
@@ -9,7 +9,7 @@ import {
 
 import { useOnboardingRequirementsContext } from '../context';
 import { isRepresentative } from '../helpers';
-import { enrichFieldsByValues } from '../transformers';
+import { enrichFieldsByValues, filterRequestBody } from '../transformers';
 import { showErrorToast } from '../utils';
 import { useOnboardingActions } from './useOnboardingActions';
 import { useOnboardingEntity } from './useOnboardingEntity';
@@ -155,7 +155,7 @@ export function useOnboardingPerson(): OnboardingPersonReturnType {
     async (personId: string, payload: OptionalPersonRequest) => {
       const response = await updatePersonMutation({
         path: { person_id: personId },
-        body: payload,
+        body: filterRequestBody(payload),
       });
 
       patchOnboardingRequirements({
@@ -184,7 +184,7 @@ export function useOnboardingPerson(): OnboardingPersonReturnType {
     async (personId: string, payload: OptionalPersonRequest) => {
       const response = await updatePersonMutation({
         path: { person_id: personId },
-        body: payload,
+        body: filterRequestBody(payload),
       });
 
       patchOnboardingRequirements({

--- a/packages/sdk-react/src/components/onboarding/transformers/commonDataTransformers.ts
+++ b/packages/sdk-react/src/components/onboarding/transformers/commonDataTransformers.ts
@@ -196,6 +196,46 @@ export const prepareValuesToSubmit = <
   }, {} as TOutput);
 };
 
+export const EXCLUDED_REQUEST_FIELDS = ['id'] as const;
+
+/**
+ * Filters out fields that should not be included in API request bodies
+ * This is useful for preparing data for update requests where the response data
+ * includes fields that should not be sent back to the API
+ *
+ * @param payload The request payload to filter
+ * @returns A new object with excluded fields removed
+ */
+export const filterRequestBody = <T extends OnboardingOutputValuesType>(
+  payload: T
+): Omit<T, (typeof EXCLUDED_REQUEST_FIELDS)[number]> => {
+  if (!payload) {
+    return {} as Omit<T, (typeof EXCLUDED_REQUEST_FIELDS)[number]>;
+  }
+
+  return Object.entries(payload).reduce((filteredPayload, [key, value]) => {
+    if (
+      EXCLUDED_REQUEST_FIELDS.includes(
+        key as (typeof EXCLUDED_REQUEST_FIELDS)[number]
+      )
+    ) {
+      return filteredPayload;
+    }
+
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      return {
+        ...filteredPayload,
+        [key]: filterRequestBody(value as OnboardingOutputValuesType),
+      };
+    }
+
+    return {
+      ...filteredPayload,
+      [key]: value,
+    };
+  }, {} as Omit<T, (typeof EXCLUDED_REQUEST_FIELDS)[number]>);
+};
+
 type GenerateFieldsByValuesParams = OnboardingOptionalParams & {
   values: OnboardingOutputValuesType;
 };


### PR DESCRIPTION
## The reasons behind the bug
Schema Mismatch: The API's PersonResponse schema includes an id field, which is returned when fetching a person. However, the OptionalPersonRequest schema used for updates explicitly disallows this field with "additionalProperties": false.

Data Flow Issue: When updating a person, the application was using the complete person object (including the id field) from the previous API response as the basis for the update request. The enrichFieldsByValues function was preserving all fields from the original object, including those that shouldn't be sent back to the API.

## Changes Made
1. Added type-safe filtering of request body fields to prevent "Extra inputs are not permitted" error
   - Created `EXCLUDED_REQUEST_FIELDS` constant with `id` field that should not be sent in update requests
   - Implemented `filterRequestBody` utility function that removes excluded fields from request payloads
   - The function is generic and type-safe, preserving TypeScript types while removing specified fields

2. Applied filtering in person update operations
   - Updated `updatePerson` and `updateRepresentativePerson` functions to use `filterRequestBody`
   - This ensures the `id` field is properly removed before sending update requests to the API
   