### PR TITLE
fix(DEV-14109): issue and send fixed on the preview page

### DIFF
--- a/.changeset/rotten-lizards-sleep.md
+++ b/.changeset/rotten-lizards-sleep.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Issue and send fixed on the preview page

--- a/packages/sdk-react/src/components/Dialog/index.ts
+++ b/packages/sdk-react/src/components/Dialog/index.ts
@@ -1,1 +1,2 @@
 export * from './Dialog';
+export * from './DialogProps.types';

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx
@@ -1,4 +1,10 @@
-import React, { FC, PropsWithChildren} from 'react';
+import type {
+  FC,
+  PropsWithChildren,
+  CSSProperties,
+  ReactNode,
+  FormEvent,
+} from 'react';
 import { Control, Controller } from 'react-hook-form';
 
 import { DefaultEmail } from '@/components/counterparts/CounterpartDetails/CounterpartView/CounterpartOrganizationView';
@@ -28,9 +34,9 @@ import { getDefaultContact, getContactList } from './helpers/contacts';
 
 export interface FormProps {
   formName: string;
-  style?: React.CSSProperties;
-  children: React.ReactNode;
-  handleIssueAndSend: (e: React.FormEvent) => void;
+  style?: CSSProperties;
+  children: ReactNode;
+  handleIssueAndSend: (e: FormEvent) => void;
 }
 
 export const Form: FC<PropsWithChildren<FormProps>> = ({
@@ -88,6 +94,7 @@ const RecipientSelector: FC<RecipientSelectorProps> = ({
           <Select
             MenuProps={{ container: root }}
             className="Monite-NakedField Monite-RecipientSelector"
+            data-testid={`${field.name}-select`}
             {...field}
           >
             {getContactList(contacts, defaultContact).map((contact) => (
@@ -156,6 +163,7 @@ export const FormContent: FC<FormContentProps> = ({
               render={({ field, fieldState: { error } }) => (
                 <TextField
                   id={field.name}
+                  data-testid={`${field.name}-input`}
                   variant="standard"
                   className="Monite-NakedField"
                   fullWidth
@@ -176,6 +184,7 @@ export const FormContent: FC<FormContentProps> = ({
             render={({ field, fieldState: { error } }) => (
               <TextField
                 id={field.name}
+                data-testid={`${field.name}-input`}
                 variant="standard"
                 className="Monite-NakedField"
                 fullWidth

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx
@@ -1,5 +1,4 @@
 import type {
-  FC,
   PropsWithChildren,
   CSSProperties,
   ReactNode,
@@ -39,12 +38,12 @@ export interface FormProps {
   handleIssueAndSend: (e: FormEvent) => void;
 }
 
-export const Form: FC<PropsWithChildren<FormProps>> = ({
+export const Form = ({
   formName,
   style,
   children,
   handleIssueAndSend,
-}) => {
+}: PropsWithChildren<FormProps>) => {
   return (
     <form id={formName} noValidate onSubmit={handleIssueAndSend} style={style}>
       {children}
@@ -63,10 +62,7 @@ interface RecipientSelectorProps {
   control: Control<ControlProps>;
 }
 
-const RecipientSelector: FC<RecipientSelectorProps> = ({
-  invoiceId,
-  control,
-}) => {
+const RecipientSelector = ({ invoiceId, control }: RecipientSelectorProps) => {
   const { data: contacts, isLoading } = useReceivableContacts(invoiceId);
   const { data: receivable } = useReceivableById(invoiceId);
   const { data: counterpart } = useCounterpartById(receivable?.counterpart_id);
@@ -119,11 +115,11 @@ interface FormContentProps {
   isDisabled: boolean;
 }
 
-export const FormContent: FC<FormContentProps> = ({
+export const FormContent = ({
   invoiceId,
   control,
   isDisabled,
-}) => {
+}: FormContentProps) => {
   const { i18n } = useLingui();
 
   return (

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx
@@ -1,0 +1,196 @@
+import React, { FC, PropsWithChildren} from 'react';
+import { Control, Controller } from 'react-hook-form';
+
+import { DefaultEmail } from '@/components/counterparts/CounterpartDetails/CounterpartView/CounterpartOrganizationView';
+import type { CounterpartOrganizationRootResponse } from '@/components/receivables/InvoiceDetails/InvoiceDetails.types';
+import { useRootElements } from '@/core/context/RootElementsProvider';
+import {
+  useReceivableById,
+  useReceivableContacts,
+  useCounterpartById,
+} from '@/core/queries';
+import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+import {
+  Card,
+  CardContent,
+  CircularProgress,
+  FormControl,
+  FormHelperText,
+  MenuItem,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+import { getDefaultContact, getContactList } from './helpers/contacts';
+
+export interface FormProps {
+  formName: string;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+  handleIssueAndSend: (e: React.FormEvent) => void;
+}
+
+export const Form: FC<PropsWithChildren<FormProps>> = ({
+  formName,
+  style,
+  children,
+  handleIssueAndSend,
+}) => {
+  return (
+    <form id={formName} noValidate onSubmit={handleIssueAndSend} style={style}>
+      {children}
+    </form>
+  );
+};
+
+export interface ControlProps {
+  subject: string;
+  body: string;
+  to: string;
+}
+
+interface RecipientSelectorProps {
+  invoiceId: string;
+  control: Control<ControlProps>;
+}
+
+const RecipientSelector: FC<RecipientSelectorProps> = ({
+  invoiceId,
+  control,
+}) => {
+  const { data: contacts, isLoading } = useReceivableContacts(invoiceId);
+  const { data: receivable } = useReceivableById(invoiceId);
+  const { data: counterpart } = useCounterpartById(receivable?.counterpart_id);
+
+  const { root } = useRootElements();
+
+  if (isLoading) return <CircularProgress />;
+
+  const defaultContact = getDefaultContact(
+    contacts,
+    counterpart as CounterpartOrganizationRootResponse
+  );
+
+  return (
+    <Controller
+      name="to"
+      control={control}
+      render={({ field, fieldState: { error } }) => (
+        <FormControl
+          variant="standard"
+          required
+          fullWidth
+          error={Boolean(error)}
+        >
+          <Select
+            MenuProps={{ container: root }}
+            className="Monite-NakedField Monite-RecipientSelector"
+            {...field}
+          >
+            {getContactList(contacts, defaultContact).map((contact) => (
+              <MenuItem key={contact.id} value={contact.email}>
+                <DefaultEmail
+                  email={contact.email ?? ''}
+                  isDefault={contact.is_default}
+                />
+              </MenuItem>
+            ))}
+          </Select>
+          {error && <FormHelperText>{error.message}</FormHelperText>}
+        </FormControl>
+      )}
+    />
+  );
+};
+
+interface FormContentProps {
+  invoiceId: string;
+  control: Control<ControlProps>;
+  isDisabled: boolean;
+}
+
+export const FormContent: FC<FormContentProps> = ({
+  invoiceId,
+  control,
+  isDisabled,
+}) => {
+  const { i18n } = useLingui();
+
+  return (
+    <>
+      <Card sx={{ mb: 3 }}>
+        <CardContent
+          sx={{
+            px: 3,
+            pt: 1,
+            pb: 1,
+            '&:last-child': { pb: 1 }, // last-child is necessary to override default style of the MUI theme
+          }}
+        >
+          <Stack spacing={2} direction="row" alignItems="center">
+            <Typography variant="body2" sx={{ minWidth: '52px' }}>{t(
+              i18n
+            )`To`}</Typography>
+            <RecipientSelector invoiceId={invoiceId} control={control} />
+          </Stack>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent
+          sx={{
+            px: 3,
+            py: 1,
+            borderBottomWidth: '1px',
+            borderBottomStyle: 'solid',
+            borderBottomColor: 'divider',
+          }}
+        >
+          <Stack spacing={2} direction="row" alignItems="center">
+            <Typography variant="body2">{t(i18n)`Subject`}</Typography>
+            <Controller
+              name="subject"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <TextField
+                  id={field.name}
+                  variant="standard"
+                  className="Monite-NakedField"
+                  fullWidth
+                  error={Boolean(error)}
+                  helperText={error?.message}
+                  required
+                  {...field}
+                  disabled={isDisabled}
+                />
+              )}
+            />
+          </Stack>
+        </CardContent>
+        <CardContent sx={{ pl: 3, pr: 3, pb: 3, pt: 1 }}>
+          <Controller
+            name="body"
+            control={control}
+            render={({ field, fieldState: { error } }) => (
+              <TextField
+                id={field.name}
+                variant="standard"
+                className="Monite-NakedField"
+                fullWidth
+                error={Boolean(error)}
+                helperText={error?.message}
+                required
+                multiline
+                rows={8}
+                {...field}
+                disabled={isDisabled}
+              />
+            )}
+          />
+        </CardContent>
+      </Card>
+    </>
+  );
+};

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.test.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.test.tsx
@@ -1,0 +1,106 @@
+import { VirtuosoMockContext } from 'react-virtuoso';
+
+import { Dialog } from '@/components/Dialog';
+import { RootElementsProvider } from '@/core/context/RootElementsProvider';
+import { receivableListFixture } from '@/mocks';
+import { entityIds } from '@/mocks/entities';
+import { renderWithClient } from '@/utils/test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { EmailInvoiceDetails } from './EmailInvoiceDetails';
+
+const mockInvoice = receivableListFixture.invoice[1];
+const mockInvoiceId = mockInvoice.id;
+
+const moniteSettings = {
+  entityId: entityIds[0],
+  fetchToken: () =>
+    Promise.resolve({
+      access_token: 'token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    }),
+};
+
+const renderEmailInvoiceDetails = (props = {}) => {
+  return renderWithClient(
+    <VirtuosoMockContext.Provider
+      value={{ viewportHeight: 300, itemHeight: 50 }}
+    >
+      <RootElementsProvider>
+        <Dialog open={true}>
+          <EmailInvoiceDetails
+            invoiceId={mockInvoiceId}
+            onClose={jest.fn()}
+            {...props}
+          />
+        </Dialog>
+      </RootElementsProvider>
+    </VirtuosoMockContext.Provider>,
+    moniteSettings
+  );
+};
+
+describe('EmailInvoiceDetails', () => {
+  test('should pre-populate email details with values', async () => {
+    renderEmailInvoiceDetails();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('subject-input')).not.toHaveValue('');
+      expect(screen.getByTestId('body-input')).not.toHaveValue('');
+      expect(screen.getByTestId('to-select')).toHaveTextContent(/.+/);
+    });
+  });
+
+  test('should show issue and send button in compose view', async () => {
+    renderEmailInvoiceDetails();
+
+    const button = await screen.findByTestId('issue-and-send-button');
+
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+      expect(button).toHaveTextContent(/./);
+    });
+  });
+
+  test('should handle issue and send flow in compose view', async () => {
+    const onClose = jest.fn();
+    renderEmailInvoiceDetails({ onClose });
+
+    const button = await screen.findByTestId('issue-and-send-button');
+
+    await waitFor(() => {
+      expect(button).toBeEnabled();
+    });
+
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  test('should handle preview and issue-send flow', async () => {
+    const onClose = jest.fn();
+    renderEmailInvoiceDetails({ onClose });
+
+    const previewButton = await screen.findByTestId('preview-button');
+    await waitFor(() => {
+      expect(previewButton).toBeEnabled();
+    });
+    await userEvent.click(previewButton);
+
+    const issueAndSendButton = await screen.findByTestId(
+      'issue-and-send-button'
+    );
+    await waitFor(() => {
+      expect(issueAndSendButton).toBeEnabled();
+    });
+    await userEvent.click(issueAndSendButton);
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx
@@ -1,15 +1,12 @@
-import React, { FC } from 'react';
 import {
+  type FC,
   useCallback,
   useEffect,
   useId,
   useMemo,
   useState,
 } from 'react';
-import {
-  useForm,
-  UseFormGetValues,
-} from 'react-hook-form';
+import { useForm, type UseFormGetValues } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 
 import type { CounterpartOrganizationRootResponse } from '@/components/receivables/InvoiceDetails/InvoiceDetails.types';
@@ -48,9 +45,7 @@ import {
   Box,
 } from '@mui/material';
 
-import { 
-  getEmailInvoiceDetailsSchema,
-} from './EmailInvoiceDetails.form';
+import { getEmailInvoiceDetailsSchema } from './EmailInvoiceDetails.form';
 import {
   type ControlProps,
   Form,
@@ -260,6 +255,7 @@ const EmailInvoiceDetailsBase: FC<EmailInvoiceFormProps> = ({
                       onClick={onClose}
                       startIcon={<ArrowBackIcon />}
                       disabled={isDisabled}
+                      data-testid="back-button"
                     >{t(i18n)`Back`}</Button>
                     <Typography variant="h3">{t(
                       i18n
@@ -273,7 +269,8 @@ const EmailInvoiceDetailsBase: FC<EmailInvoiceFormProps> = ({
                     onClick={() => {
                       setPresentation(FormPresentation.Edit);
                     }}
-                    aria-label="close"
+                    aria-label={t(i18n)`Back to edit`}
+                    data-testid="close-preview-button"
                   >
                     <CloseIcon />
                   </IconWrapper>
@@ -298,6 +295,7 @@ const EmailInvoiceDetailsBase: FC<EmailInvoiceFormProps> = ({
                       const isValid = await trigger();
                       if (isValid) setPresentation(FormPresentation.Preview);
                     }}
+                    data-testid="preview-button"
                   >{t(i18n)`Preview email`}</Button>
                 )}
                 <Button
@@ -306,6 +304,7 @@ const EmailInvoiceDetailsBase: FC<EmailInvoiceFormProps> = ({
                   type="submit"
                   form={formName}
                   disabled={isDisabled || isLoading}
+                  data-testid="issue-and-send-button"
                 >{t(i18n)`Issue and send`}</Button>
               </Stack>
             </Grid>
@@ -326,7 +325,7 @@ const EmailInvoiceDetailsBase: FC<EmailInvoiceFormProps> = ({
         <Form
           formName={formName}
           handleIssueAndSend={handleIssueAndSend}
-          style={{ 
+          style={{
             display: 'flex',
             flexDirection: 'column',
             flex: 1,
@@ -353,16 +352,12 @@ const EmailInvoiceDetailsBase: FC<EmailInvoiceFormProps> = ({
     </>
   );
 };
-
 interface PreviewProps {
   invoiceId: string;
   getValues: UseFormGetValues<ControlProps>;
 }
 
-const Preview: FC<PreviewProps> = ({
-  invoiceId,
-  getValues,
-}) => {
+const Preview: FC<PreviewProps> = ({ invoiceId, getValues }) => {
   const { i18n } = useLingui();
   const { subject, body } = getValues();
   const { isLoading, preview, error, refresh } = useReceivableEmailPreview(
@@ -372,13 +367,15 @@ const Preview: FC<PreviewProps> = ({
   );
 
   return (
-    <Box sx={{ 
-      flex: 1,
-      display: 'flex',
-      flexDirection: 'column',
-      minHeight: 0,
-      overflow: 'hidden'
-    }}>
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0,
+        overflow: 'hidden',
+      }}
+    >
       {isLoading && (
         <CenteredContentBox className="Monite-LoadingPage">
           <CircularProgress />
@@ -415,6 +412,7 @@ const Preview: FC<PreviewProps> = ({
                 variant="text"
                 onClick={refresh}
                 startIcon={<RefreshIcon />}
+                data-testid="reload-preview-button"
               >{t(i18n)`Reload`}</Button>
             </Stack>
           </Stack>

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -852,7 +852,7 @@ msgstr "Azerbaijani Manat"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartIndividualForm/CounterpartIndividualForm.tsx:435
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:432
 #: src/components/products/ProductCancelEditModal/ProductCancelEditModal.tsx:48
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:288
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:263
 msgid "Back"
 msgstr "Back"
 
@@ -1624,7 +1624,7 @@ msgid "Completed"
 msgstr "Completed"
 
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx:143
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:289
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:264
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:359
 msgid "Compose email"
 msgstr "Compose email"
@@ -3052,7 +3052,7 @@ msgstr "Failed to delete Unit."
 msgid "Failed to delete VAT."
 msgstr "Failed to delete VAT."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:555
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:403
 msgid "Failed to generate email preview"
 msgstr "Failed to generate email preview"
 
@@ -3549,7 +3549,7 @@ msgstr "Heating, Plumbing, A/C"
 msgid "here."
 msgstr "here."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:94
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:92
 msgid ""
 "Hi {0},\n"
 "Please find the invoice attached as discussed.\n"
@@ -3660,7 +3660,7 @@ msgstr "Icelandic Króna"
 msgid "If amount is"
 msgstr "If amount is"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:562
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:410
 msgid "If the error recurs, contact support, please."
 msgstr "If the error recurs, contact support, please."
 
@@ -3806,7 +3806,7 @@ msgstr "Invoice"
 msgid "Invoice {0}"
 msgstr "Invoice {0}"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:108
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:106
 msgid "Invoice {0} from {entityName}"
 msgstr "Invoice {0} from {entityName}"
 
@@ -3835,7 +3835,7 @@ msgstr "Invoice delete confirmation"
 msgid "Invoice financing"
 msgstr "Invoice financing"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:109
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:107
 msgid "Invoice from {entityName}"
 msgstr "Invoice from {entityName}"
 
@@ -3914,7 +3914,7 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "Issue"
 msgstr "Issue"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:334
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:309
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/SubmitInvoice.tsx:119
 msgid "Issue and send"
 msgstr "Issue and send"
@@ -4816,7 +4816,7 @@ msgstr "No {entityName}"
 msgid "No {entityName} Found"
 msgstr "No {entityName} Found"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:199
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:189
 msgid "No active payment methods available. The email will be sent without a payment link"
 msgstr "No active payment methods available. The email will be sent without a payment link"
 
@@ -5484,7 +5484,7 @@ msgstr "Please enter a valid phone number."
 msgid "Please enter your IBAN number."
 msgstr "Please enter your IBAN number."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:100
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:98
 msgid ""
 "Please find the invoice attached as discussed.\n"
 "Kind Regards,\n"
@@ -5528,7 +5528,7 @@ msgstr "Please review the terms and conditions and accept them to continue."
 msgid "Please try again later."
 msgstr "Please try again later."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:559
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:407
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoicePDFViewer.tsx:70
 msgid "Please try to reload."
 msgstr "Please try to reload."
@@ -5625,7 +5625,7 @@ msgstr "Preset name"
 msgid "Preset Name"
 msgstr "Preset Name"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:326
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:301
 msgid "Preview email"
 msgstr "Preview email"
 
@@ -5947,7 +5947,7 @@ msgstr "Religious Goods Stores"
 msgid "Religious Organizations"
 msgstr "Religious Organizations"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:570
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:418
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoicePDFViewer.tsx:88
 #: src/ui/DataGridEmptyState/GetNoRowsOverlay.tsx:101
 msgid "Reload"
@@ -6609,8 +6609,8 @@ msgstr "Status"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/OverdueReminderForm.tsx:238
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/validation.ts:17
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/validation.ts:64
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:152
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.ts:14
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:471
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceForm.tsx:402
 msgid "Subject"
 msgstr "Subject"
@@ -7030,8 +7030,8 @@ msgstr "Tire Retreading and Repair"
 msgid "Title"
 msgstr "Title"
 
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:134
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.ts:10
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:453
 #: src/components/receivables/InvoiceDetails/InvoiceTo/InvoiceTo.tsx:29
 msgid "To"
 msgstr "To"

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -852,7 +852,7 @@ msgstr "Azerbaijani Manat"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartIndividualForm/CounterpartIndividualForm.tsx:435
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:432
 #: src/components/products/ProductCancelEditModal/ProductCancelEditModal.tsx:48
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:263
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:259
 msgid "Back"
 msgstr "Back"
 
@@ -880,6 +880,10 @@ msgstr "Back of your identify document"
 #: src/components/onboarding/OnboardingPersonDocuments/OnboardingPersonDocuments.tsx:128
 msgid "Back of your identity document"
 msgstr "Back of your identity document"
+
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:272
+msgid "Back to edit"
+msgstr "Back to edit"
 
 #: src/core/utils/countries.ts:35
 msgid "Bahamas"
@@ -1624,7 +1628,7 @@ msgid "Completed"
 msgstr "Completed"
 
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx:143
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:264
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:260
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:359
 msgid "Compose email"
 msgstr "Compose email"
@@ -3052,7 +3056,7 @@ msgstr "Failed to delete Unit."
 msgid "Failed to delete VAT."
 msgstr "Failed to delete VAT."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:403
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:400
 msgid "Failed to generate email preview"
 msgstr "Failed to generate email preview"
 
@@ -3549,7 +3553,7 @@ msgstr "Heating, Plumbing, A/C"
 msgid "here."
 msgstr "here."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:92
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:87
 msgid ""
 "Hi {0},\n"
 "Please find the invoice attached as discussed.\n"
@@ -3660,7 +3664,7 @@ msgstr "Icelandic Króna"
 msgid "If amount is"
 msgstr "If amount is"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:410
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:407
 msgid "If the error recurs, contact support, please."
 msgstr "If the error recurs, contact support, please."
 
@@ -3806,7 +3810,7 @@ msgstr "Invoice"
 msgid "Invoice {0}"
 msgstr "Invoice {0}"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:106
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:101
 msgid "Invoice {0} from {entityName}"
 msgstr "Invoice {0} from {entityName}"
 
@@ -3835,7 +3839,7 @@ msgstr "Invoice delete confirmation"
 msgid "Invoice financing"
 msgstr "Invoice financing"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:107
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:102
 msgid "Invoice from {entityName}"
 msgstr "Invoice from {entityName}"
 
@@ -3914,7 +3918,7 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "Issue"
 msgstr "Issue"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:309
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:308
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/SubmitInvoice.tsx:119
 msgid "Issue and send"
 msgstr "Issue and send"
@@ -4816,7 +4820,7 @@ msgstr "No {entityName}"
 msgid "No {entityName} Found"
 msgstr "No {entityName} Found"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:189
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:184
 msgid "No active payment methods available. The email will be sent without a payment link"
 msgstr "No active payment methods available. The email will be sent without a payment link"
 
@@ -5484,7 +5488,7 @@ msgstr "Please enter a valid phone number."
 msgid "Please enter your IBAN number."
 msgstr "Please enter your IBAN number."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:98
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:93
 msgid ""
 "Please find the invoice attached as discussed.\n"
 "Kind Regards,\n"
@@ -5528,7 +5532,7 @@ msgstr "Please review the terms and conditions and accept them to continue."
 msgid "Please try again later."
 msgstr "Please try again later."
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:407
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:404
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoicePDFViewer.tsx:70
 msgid "Please try to reload."
 msgstr "Please try to reload."
@@ -5625,7 +5629,7 @@ msgstr "Preset name"
 msgid "Preset Name"
 msgstr "Preset Name"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:301
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:299
 msgid "Preview email"
 msgstr "Preview email"
 
@@ -5947,7 +5951,7 @@ msgstr "Religious Goods Stores"
 msgid "Religious Organizations"
 msgstr "Religious Organizations"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:418
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.tsx:416
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoicePDFViewer.tsx:88
 #: src/ui/DataGridEmptyState/GetNoRowsOverlay.tsx:101
 msgid "Reload"
@@ -6609,7 +6613,7 @@ msgstr "Status"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/OverdueReminderForm.tsx:238
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/validation.ts:17
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/validation.ts:64
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:152
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:159
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.ts:14
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceForm.tsx:402
 msgid "Subject"
@@ -7030,7 +7034,7 @@ msgstr "Tire Retreading and Repair"
 msgid "Title"
 msgstr "Title"
 
-#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:134
+#: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.components.tsx:141
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EmailInvoiceDetails.form.ts:10
 #: src/components/receivables/InvoiceDetails/InvoiceTo/InvoiceTo.tsx:29
 msgid "To"

--- a/packages/sdk-react/src/mocks/counterparts/contact/counterpartContactHandlers.ts
+++ b/packages/sdk-react/src/mocks/counterparts/contact/counterpartContactHandlers.ts
@@ -11,8 +11,10 @@ type UpdateCounterpartContactParams = CreateCounterpartContactParams & {
   contactAccountId: string;
 };
 
-const contactAccountPath = `*/counterparts/:counterpartId/contacts`;
-const contactAccountIdPath = `${contactAccountPath}/:contactAccountId`;
+const COUNTERPARTS_ENDPOINT = 'counterparts';
+
+const contactAccountPath = `*/${COUNTERPARTS_ENDPOINT}/:counterpartId/contacts`;
+const contactAccountIdPath = `${contactAccountPath}/:contactId`;
 
 export const counterpartContactHandlers = [
   // read list

--- a/packages/sdk-react/src/mocks/receivables/receivablesFixture.ts
+++ b/packages/sdk-react/src/mocks/receivables/receivablesFixture.ts
@@ -347,3 +347,49 @@ export const receivableListFixture: ReceivablesListFixture = {
   invoice: Array.from(Array(30).keys()).map(createRandomInvoice),
   credit_note: Array.from(Array(30).keys()).map(createRandomCreditNote),
 };
+
+
+function createRandomContact(): components['schemas']['CounterpartContactResponse'] {
+  return {
+    id: faker.string.uuid(),
+    first_name: faker.person.firstName(),
+    last_name: faker.person.lastName(),
+    email: faker.internet.email(),
+    phone: faker.phone.number(),
+    is_default: faker.datatype.boolean(),
+    counterpart_id: faker.string.uuid(),
+    address: {
+      country: getRandomItemFromArray(AllowedCountries),
+      city: faker.location.city(),
+      postal_code: faker.location.zipCode(),
+      state: faker.location.state(),
+      line1: faker.location.streetAddress(),
+      line2: faker.location.secondaryAddress(),
+    }
+  };
+}
+
+function createRandomPreview(): components['schemas']['ReceivablePreviewResponse'] {
+  return {
+    body_preview: `<html>
+      <body>
+        <h1>${faker.company.name()}</h1>
+        <p>${faker.lorem.paragraphs(2)}</p>
+        <p>Best regards,<br/>${faker.person.fullName()}</p>
+      </body>
+    </html>`,
+    subject_preview: `Invoice ${faker.string.alphanumeric(8)} from ${faker.company.name()}`,
+  };
+}
+
+export const receivableContactsFixture: Record<string, Array<components['schemas']['CounterpartContactResponse']>> = 
+  receivableListFixture.invoice.reduce((acc, invoice) => ({
+    ...acc,
+    [invoice.id]: Array.from({ length: faker.number.int({ min: 1, max: 3 }) }, () => createRandomContact())
+  }), {});
+
+export const receivablePreviewFixture: Record<string, components['schemas']['ReceivablePreviewResponse']> = 
+  receivableListFixture.invoice.reduce((acc, invoice) => ({
+    ...acc,
+    [invoice.id]: createRandomPreview()
+  }), {});


### PR DESCRIPTION
### Main changes
- EmailInvoiceDetails has been reorganized so that buttons have access to the parent form's context
- Form components (`Form`, `RecipientSelector`, `FormContent`) have been extracted into a separate file `EmailInvoiceDetails.form.components.tsx`

### Tests
- Added tests for EmailInvoiceDetails covering:
  - Pre-population of email details
  - Issue and send button visibility
  - Issue and send flow in compose view
  - Preview and issue-send flow functionality
