### PR TITLE
fix(DEV-14690): payment terms update validation fixed, dialog close focus hook

### DIFF
--- a/.changeset/spotty-ladybugs-obey.md
+++ b/.changeset/spotty-ladybugs-obey.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Payment terms update validation fixed, dialog close focus hook

--- a/packages/sdk-react/src/components/Dialog/Dialog.tsx
+++ b/packages/sdk-react/src/components/Dialog/Dialog.tsx
@@ -51,70 +51,75 @@ export const useDialog = (): DialogContextType | undefined => {
   return useContext(DialogContext);
 };
 
-export const Dialog = (props: MoniteDialogProps) => (
-  <MoniteScopedProviders>
-    <DialogBase {...props} />
-  </MoniteScopedProviders>
+export const Dialog = forwardRef<HTMLDivElement, MoniteDialogProps>(
+  (props, ref) => (
+    <MoniteScopedProviders>
+      <DialogBase {...props} ref={ref} />
+    </MoniteScopedProviders>
+  )
 );
 
-export const DialogBase = (props: MoniteDialogProps) => {
-  const { alignDialog, onClosed, ...otherProps } = props;
-  const { root } = useRootElements();
+export const DialogBase = forwardRef<HTMLDivElement, MoniteDialogProps>(
+  (props, ref) => {
+    const { alignDialog, onClosed, ...otherProps } = props;
+    const { root } = useRootElements();
 
-  return (
-    <DialogContext.Provider
-      value={{ isDialogContent: true, onClose: props.onClose }}
-    >
-      <MuiDialog
-        {...otherProps}
-        open={props.open}
-        container={root}
-        TransitionComponent={Transition}
-        TransitionProps={{
-          alignDialog: alignDialog,
-          onExited: onClosed,
-        }}
-        onClose={props.onClose}
-        classes={{
-          container: [
-            ScopedCssBaselineContainerClassName,
-            alignDialog && `MuiDialog-container__align-${alignDialog}`,
-          ]
-            .filter(Boolean)
-            .join(' '),
-          paper: alignDialog && `MuiDialog-paper__align-${alignDialog}`,
-        }}
-        slotProps={
-          props.fullScreen
-            ? {
-                backdrop: {
-                  style: {
-                    background: 'none',
-                  },
-                },
-              }
-            : {}
-        }
-        css={css`
-          .MuiDialog-container__align-right {
-            justify-content: right;
-          }
-          .MuiDialog-container__align-left {
-            justify-content: left;
-          }
-
-          .MuiDialog-paper__align-left,
-          .MuiDialog-paper__align-right {
-            width: 50%;
-            height: 100%;
-            max-height: none;
-            margin: 0;
-            border-radius: 0;
-          }
-        `}
+    return (
+      <DialogContext.Provider
+        value={{ isDialogContent: true, onClose: props.onClose }}
       >
-        {props.children}
-      </MuiDialog>
-    </DialogContext.Provider>
-  );
-};
+        <MuiDialog
+          ref={ref}
+          {...otherProps}
+          open={props.open}
+          container={root}
+          TransitionComponent={Transition}
+          TransitionProps={{
+            alignDialog: alignDialog,
+            onExited: onClosed,
+          }}
+          onClose={props.onClose}
+          classes={{
+            container: [
+              ScopedCssBaselineContainerClassName,
+              alignDialog && `MuiDialog-container__align-${alignDialog}`,
+            ]
+              .filter(Boolean)
+              .join(' '),
+            paper: alignDialog && `MuiDialog-paper__align-${alignDialog}`,
+          }}
+          slotProps={
+            props.fullScreen
+              ? {
+                  backdrop: {
+                    style: {
+                      background: 'none',
+                    },
+                  },
+                }
+              : {}
+          }
+          css={css`
+            .MuiDialog-container__align-right {
+              justify-content: right;
+            }
+            .MuiDialog-container__align-left {
+              justify-content: left;
+            }
+
+            .MuiDialog-paper__align-left,
+            .MuiDialog-paper__align-right {
+              width: 50%;
+              height: 100%;
+              max-height: none;
+              margin: 0;
+              border-radius: 0;
+            }
+          `}
+        >
+          {props.children}
+        </MuiDialog>
+      </DialogContext.Provider>
+    );
+  }
+);

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx
@@ -2,10 +2,10 @@ import { useId, useState } from 'react';
 
 import { components } from '@/api';
 import { Dialog } from '@/components';
+import { useHandleDialogCloseFocus } from '@/core/hooks/useHandleDialogCloseFocus';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import {
-  Typography,
   DialogTitle,
   DialogContent,
   Divider,
@@ -34,6 +34,9 @@ export const PaymentTermsDialog = ({
   const formName = `Monite-Form-paymentTerms-${useId()}`;
   const { i18n } = useLingui();
 
+  const { dialogRef, handleClose } =
+    useHandleDialogCloseFocus<HTMLDivElement>(closeDialog);
+
   const submitButtonText = selectedTerm ? t(i18n)`Save` : t(i18n)`Create`;
   const titleText = selectedTerm
     ? t(i18n)`Edit payment term`
@@ -48,16 +51,19 @@ export const PaymentTermsDialog = ({
 
   return (
     <>
-      <Dialog open={show} alignDialog="right" onClose={() => closeDialog()}>
-        <DialogTitle>
-          <Typography variant="h4">{titleText}</Typography>
-        </DialogTitle>
+      <Dialog
+        ref={dialogRef}
+        open={show}
+        alignDialog="right"
+        onClose={handleClose}
+      >
+        <DialogTitle>{titleText}</DialogTitle>
         <Divider />
         <DialogContent>
           <PaymentTermsForm
             formName={formName}
             selectedTerm={selectedTerm}
-            onTermsChange={closeDialog}
+            onTermsChange={handleClose}
           />
         </DialogContent>
         <Divider />
@@ -78,7 +84,7 @@ export const PaymentTermsDialog = ({
               >{t(i18n)`Delete`}</Button>
             )}
             <Stack direction="row" gap={1} useFlexGap>
-              <Button variant="text" onClick={() => closeDialog()}>{t(
+              <Button variant="text" onClick={handleClose}>{t(
                 i18n
               )`Cancel`}</Button>
               <Button type="submit" variant="contained" form={formName}>

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts
@@ -37,6 +37,7 @@ export const getValidation = (i18n: I18n, getFormState: () => any) =>
     description: yup.string().max(250).optional(),
     term_1: yup
       .object()
+      .nullable()
       .shape({
         number_of_days: yup
           .number()
@@ -61,6 +62,7 @@ export const getValidation = (i18n: I18n, getFormState: () => any) =>
       .optional(),
     term_2: yup
       .object()
+      .nullable()
       .shape({
         number_of_days: yup
           .number()

--- a/packages/sdk-react/src/core/hooks/useHandleDialogCloseFocus.ts
+++ b/packages/sdk-react/src/core/hooks/useHandleDialogCloseFocus.ts
@@ -1,0 +1,45 @@
+import { useRef, useCallback, RefObject } from 'react';
+
+/**
+ * Hook to manage blurring focus within a dialog before closing.
+ *
+ * Ensures that if the currently focused element is inside the dialog
+ * when the close handler is called, it gets blurred to prevent focus
+ * trapping in a hidden element (accessibility fix for aria-hidden warnings).
+ *
+ * @template T - The type of the HTML element the ref will be attached to (e.g., HTMLDivElement).
+ * @template Args - Tuple type representing the arguments expected by the onClose function. Defaults to `[]`.
+ * @param onClose The original function to call when the dialog should close.
+ * @param onClose Optional callback function to be called after potential focus blurring.
+ * @returns An object containing the `dialogRef` to attach to the dialog element and the memoized `handleClose` function.
+ */
+export function useHandleDialogCloseFocus<
+  T extends HTMLElement,
+  Args extends any[] = []
+>(
+  onClose?: (...args: Args) => void
+): {
+  dialogRef: RefObject<T>;
+  handleClose: (...args: Args) => void;
+} {
+  const dialogRef = useRef<T>(null);
+
+  const handleClose = useCallback(
+    (...args: Args) => {
+      const elementToBlur = document.activeElement;
+
+      if (
+        dialogRef.current &&
+        elementToBlur instanceof HTMLElement &&
+        dialogRef.current.contains(elementToBlur)
+      ) {
+        elementToBlur.blur();
+      }
+
+      onClose?.(...args);
+    },
+    [onClose]
+  );
+
+  return { dialogRef, handleClose };
+}

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -59,7 +59,7 @@ msgstr "{0} - {1}"
 msgid "{0} ({code})"
 msgstr "{0} ({code})"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:307
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:288
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:46
 msgid "{0} days"
 msgstr "{0} days"
@@ -88,7 +88,7 @@ msgstr "{0}% advance rate"
 msgid "{0}% advance rate, Pay in {1} days, {2}% fee"
 msgstr "{0}% advance rate, Pay in {1} days, {2}% fee"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:282
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:263
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:31
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:39
 msgid "{0}% discount"
@@ -98,7 +98,7 @@ msgstr "{0}% discount"
 msgid "{0}% fee"
 msgstr "{0}% fee"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:297
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:278
 msgid "{0}%discount"
 msgstr "{0}%discount"
 
@@ -1312,8 +1312,8 @@ msgstr "Canadian Dollar"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:495
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:682
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:445
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:38
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:81
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:40
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:87
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:459
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/OverdueReminderForm.tsx:295
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx:178
@@ -1949,7 +1949,7 @@ msgstr "Court Costs, Including Alimony and Child Support - Courts of Law"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartIndividualForm/CounterpartIndividualForm.tsx:449
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:446
 #: src/components/products/ProductDetails/ProductCreate/CreateProduct.tsx:191
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:37
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:40
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:469
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/OverdueReminderForm.tsx:308
 #: src/components/tags/TagFormModal/TagFormModal.test.tsx:21
@@ -2016,7 +2016,7 @@ msgstr "Create customer"
 msgid "Create from email"
 msgstr "Create from email"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:736
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:723
 msgid "Create invoice"
 msgstr "Create invoice"
 
@@ -2075,7 +2075,7 @@ msgstr "Create new product or service"
 msgid "Create new tag"
 msgstr "Create new tag"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:40
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:43
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/PaymentSection.tsx:87
 msgid "Create payment term"
 msgstr "Create payment term"
@@ -2189,7 +2189,7 @@ msgstr "Current status"
 #: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:160
 #: src/components/receivables/Financing/FinanceTab/FinancedInvoicesTable/FinancedInvoicesTable.tsx:143
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/CounterpartSelector.tsx:199
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:202
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:183
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:145
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewCustomerSection.tsx:56
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:249
@@ -2313,9 +2313,9 @@ msgstr "Defaulted"
 #: src/components/products/Products.test.tsx:203
 #: src/components/products/Products.test.tsx:235
 #: src/components/products/ProductsTable/ProductsTable.test.tsx:270
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:46
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:48
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DiscountForm.tsx:74
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:78
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:84
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/ReminderFormLayout.tsx:38
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceDeleteModal.tsx:82
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/ExistingInvoiceDetails.tsx:282
@@ -2385,7 +2385,7 @@ msgstr "Delete Counterpart \"{0}\"?"
 msgid "Delete invoice"
 msgstr "Delete invoice"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:31
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:33
 msgid "Delete payment term?"
 msgstr "Delete payment term?"
 
@@ -2455,7 +2455,7 @@ msgstr "Description is required"
 
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:453
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:221
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:764
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:751
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:49
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:19
 msgid "Details"
@@ -2646,7 +2646,7 @@ msgstr "Dry Cleaners"
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:642
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:321
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:110
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:247
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:228
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:235
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:420
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/reminderCardTermsHelpers.tsx:45
@@ -2794,7 +2794,7 @@ msgstr "Edit individual"
 msgid "Edit invoice"
 msgstr "Edit invoice"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:39
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:42
 msgid "Edit payment term"
 msgstr "Edit payment term"
 
@@ -3355,7 +3355,7 @@ msgstr "Fuel Dealers (Non Automotive)"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:545
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:564
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:153
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:257
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:238
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:133
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:187
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:30
@@ -3843,7 +3843,7 @@ msgstr "Invalid website URL. Please ensure it starts with 'http://' or 'https://
 #: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:215
 #: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:283
 #: src/components/receivables/Financing/FinanceTab/FinancedInvoicesTable/FinancedInvoicesTable.tsx:272
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:187
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:168
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx:314
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:337
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:339
@@ -3994,7 +3994,7 @@ msgstr "Issue at"
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:302
 #: src/components/receivables/CreditNotesTable/CreditNotesTable.tsx:154
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:85
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:244
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:225
 #: src/components/receivables/InvoicesTable/InvoicesTable.tsx:271
 msgid "Issue date"
 msgstr "Issue date"
@@ -4063,7 +4063,7 @@ msgid "item"
 msgstr "item"
 
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:160
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:480
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:481
 msgid "Item name"
 msgstr "Item name"
 
@@ -4098,7 +4098,7 @@ msgstr "items"
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:718
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:441
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx:120
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:464
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:465
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:90
 #: src/components/receivables/InvoiceDetails/InvoiceItems/InvoiceItems.tsx:23
 msgid "Items"
@@ -4920,7 +4920,7 @@ msgstr "No file provided"
 msgid "No financed invoices yet"
 msgstr "No financed invoices yet"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:366
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:347
 msgid "No items"
 msgstr "No items"
 
@@ -4928,7 +4928,7 @@ msgstr "No items"
 msgid "No items yet"
 msgstr "No items yet"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:195
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:176
 msgid "No logo"
 msgstr "No logo"
 
@@ -5047,9 +5047,9 @@ msgid "NOT allowed"
 msgstr "NOT allowed"
 
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:405
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:206
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:187
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:232
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:251
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:270
 #: src/components/tags/TagFormModal/TagFormModal.tsx:204
 msgid "Not set"
 msgstr "Not set"
@@ -5280,8 +5280,8 @@ msgstr "Pay in"
 msgid "Pay in {0} days"
 msgstr "Pay in {0} days"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:276
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:291
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:257
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:272
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:30
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:38
 msgid "Pay in the first {0} days"
@@ -5352,12 +5352,12 @@ msgstr "Payment date"
 msgid "Payment details"
 msgstr "Payment details"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:445
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:426
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:23
 msgid "Payment Details"
 msgstr "Payment Details"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:306
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:287
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsForm.tsx:153
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:45
 msgid "Payment due"
@@ -5405,7 +5405,7 @@ msgstr "Payment term successfully deleted"
 msgid "Payment term updated"
 msgstr "Payment term updated"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:265
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:246
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/PaymentSection.tsx:73
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:151
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:204
@@ -5620,7 +5620,7 @@ msgstr "Please try to reload."
 msgid "Please upload the required documents to continue."
 msgstr "Please upload the required documents to continue."
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:707
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:708
 msgid "Please use some of the rows before adding new ones."
 msgstr "Please use some of the rows before adding new ones."
 
@@ -5722,8 +5722,8 @@ msgstr "Previous page"
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:449
 #: src/components/payables/PayableDetails/PayableLineItemsForm/PayableLineItemsForm.tsx:107
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:127
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:329
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:486
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:310
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:487
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:89
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:92
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:100
@@ -5758,7 +5758,7 @@ msgstr "Processing..."
 #: src/components/products/ProductDetails/components/ProductType/ProductType.tsx:17
 #: src/components/products/ProductsTable/ProductsTable.tsx:315
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTableFilters.tsx:72
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:325
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:306
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:73
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:104
 #: src/components/userRoles/consts.ts:43
@@ -5862,13 +5862,13 @@ msgstr "Qatar"
 msgid "Qatari Rial"
 msgstr "Qatari Rial"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:326
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:307
 msgid "Qty"
 msgstr "Qty"
 
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:448
 #: src/components/payables/PayableDetails/PayableLineItemsForm/PayableLineItemsForm.tsx:62
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:483
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:484
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:33
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:99
 msgid "Quantity"
@@ -6203,7 +6203,7 @@ msgstr "Routing number"
 msgid "Routing Number"
 msgstr "Routing Number"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:704
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:705
 msgid "Row"
 msgstr "Row"
 
@@ -6298,7 +6298,7 @@ msgstr "Saudi Riyal"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:501
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:688
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:451
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:37
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:40
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceForm.tsx:352
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/TabPanels/PaymentTabPanel/PaymentRecordForm.tsx:150
 #: src/components/tags/TagFormModal/TagFormModal.test.tsx:155
@@ -6471,7 +6471,7 @@ msgstr "Set reminders"
 msgid "Set this counterpart as:"
 msgstr "Set this counterpart as:"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:449
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:430
 msgid ""
 "Set up bank account to add payment info\n"
 "and set a QR code"
@@ -6734,8 +6734,8 @@ msgstr "Submit invoice"
 
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:728
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:497
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:377
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:747
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:358
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:748
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:158
 #: src/components/receivables/InvoiceDetails/InvoiceTotal/InvoiceTotal.tsx:31
 msgid "Subtotal"
@@ -6845,8 +6845,8 @@ msgstr "Tanzania"
 msgid "Tanzanian Shilling"
 msgstr "Tanzanian Shilling"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:331
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:490
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:312
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:491
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:53
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:61
 msgid "Tax"
@@ -6863,8 +6863,8 @@ msgstr "Tax ID"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:217
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:381
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:398
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:230
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:429
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:211
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:410
 msgid "TAX ID"
 msgstr "TAX ID"
 
@@ -6909,7 +6909,7 @@ msgstr "Tax Preparation Services"
 msgid "Tax Registration Number (UAE)"
 msgstr "Tax Registration Number (UAE)"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:754
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:755
 msgid "Taxes total"
 msgstr "Taxes total"
 
@@ -7005,12 +7005,12 @@ msgstr "The IBAN should correspond to the chosen country - {country}."
 msgid "The issue date should be less than 7 days ago. You can't fund overdue invoices. The loan sum must be within your remaining limit."
 msgstr "The issue date should be less than 7 days ago. You can't fund overdue invoices. The loan sum must be within your remaining limit."
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:79
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:81
 msgid "The number of days in Discount 2 must be more than the number of Discount 1 days"
 msgstr "The number of days in Discount 2 must be more than the number of Discount 1 days"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:49
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:72
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:50
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:74
 msgid "The number of days in Discount must be less than of Due days"
 msgstr "The number of days in Discount must be less than of Due days"
 
@@ -7153,10 +7153,10 @@ msgstr "To"
 msgid "To (including)"
 msgstr "To (including)"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:45
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:57
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:68
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:87
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:46
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:58
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:70
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/paymentTermsValidation.ts:89
 msgid "To add a discount you need to fill out all the fields"
 msgstr "To add a discount you need to fill out all the fields"
 
@@ -7199,8 +7199,8 @@ msgstr "Tongan Paʻanga"
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:825
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:336
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:535
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:396
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:761
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:377
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:762
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:173
 #: src/components/receivables/InvoiceDetails/InvoiceItems/InvoiceItems.tsx:38
 #: src/components/receivables/InvoiceDetails/InvoiceTotal/InvoiceTotal.tsx:25
@@ -7222,7 +7222,7 @@ msgstr "Total Amount"
 msgid "Total amount for <0>{totalPendingInvoices}</0> canceled {invoicesPluralForm}: <1>{pendingInvoicesTotalAmountWithCreditNotes}</1>"
 msgstr "Total amount for <0>{totalPendingInvoices}</0> canceled {invoicesPluralForm}: <1>{pendingInvoicesTotalAmountWithCreditNotes}</1>"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:385
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:366
 msgid "Total Tax"
 msgstr "Total Tax"
 
@@ -7450,7 +7450,7 @@ msgstr "United States Outlying Islands"
 
 #: src/components/products/ProductDetails/validation.ts:31
 #: src/components/products/ProductsTable/components/Filters/Filters.tsx:88
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:327
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:308
 msgid "Units"
 msgstr "Units"
 
@@ -7708,7 +7708,7 @@ msgid "Variety Stores"
 msgstr "Variety Stores"
 
 #: src/components/payables/PayableDetails/PayableLineItemsForm/PayableLineItemsForm.tsx:129
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:490
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:491
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:49
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:50
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:66
@@ -7729,7 +7729,7 @@ msgstr "Vat “{0}” has been updated."
 msgid "VAT {0}%"
 msgstr "VAT {0}%"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:722
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:723
 msgid "VAT Exempt Rationale"
 msgstr "VAT Exempt Rationale"
 
@@ -7749,8 +7749,8 @@ msgstr "Vat ID"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:222
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:342
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:348
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:235
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:434
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:216
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:415
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/VatAndTaxValidator.tsx:49
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:125
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:128
@@ -8090,7 +8090,7 @@ msgstr "You don’t have permissions to view this page.<0/>Contact your system a
 msgid "You have unsaved changes"
 msgstr "You have unsaved changes"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:33
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:35
 msgid "You won't be able to use it to create new invoices, but it won't affect the existing invoices with this term and their future copies."
 msgstr "You won't be able to use it to create new invoices, but it won't affect the existing invoices with this term and their future copies."
 


### PR DESCRIPTION
1.  **Validation Fix:**
    *   Updated the Yup validation schema in `paymentTermsValidation.ts` by adding `.nullable()` to the `term_1` and `term_2` object schemas. This explicitly allows `null` as a valid value, resolving the primary modification bug

2.  **Accessibility (Focus Management):**
    *   Created a new reusable hook `useHandleDialogCloseFocus` (in `src/core/hooks/`) to manage focus when a dialog closes

3.  **Ref Forwarding:**
    *   Modified the custom `Dialog` component (`src/components/Dialog/Dialog.tsx`) and its internal `DialogBase` component to correctly use `React.forwardRef`. This allows the `ref` from `useHandleDialogCloseFocus` to be passed down to the underlying MUI `Dialog`

4.  **Semantic HTML:**
    *   Fixed the DOM nesting warning in `PaymentTermsDialog` by removing the nested `Typography` component within `DialogTitle` and passing the title text directly as a child