### PR TITLE
feat(DEV-14646): Payables table prevent row click while processing OCR status

### DIFF
--- a/.changeset/eighty-grapes-collect.md
+++ b/.changeset/eighty-grapes-collect.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Payables table: prevent row click (and disable hover effect) for rows of payables with OCR status in processing

--- a/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 
-import { components } from '@/api';
 import { useOnboardingBankAccount } from '@/components/onboarding/hooks/useOnboardingBankAccount';
 import { getRegionName } from '@/components/onboarding/utils';
 import {

--- a/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
@@ -14,9 +14,7 @@ import { MenuItem } from '@mui/material';
 import { OnboardingFormActions } from '../OnboardingFormActions';
 import { OnboardingForm, OnboardingStepContent } from '../OnboardingLayout';
 
-export interface OnboardingBankAccountProps {}
-
-export const OnboardingBankAccount = ({}: OnboardingBankAccountProps = {}) => {
+export const OnboardingBankAccount = () => {
   const { i18n } = useLingui();
 
   const {

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
@@ -515,8 +515,11 @@ const PayablesTableBase = ({
         loading={isLoading}
         onSortModelChange={onChangeSort}
         onRowClick={(params) => {
-          if (!hasSelectedText()) {
-            onRowClick?.(params.row.id);
+          const payable =
+            params.row as components['schemas']['PayableResponseSchema'];
+
+          if (!hasSelectedText() && payable.ocr_status !== 'processing') {
+            onRowClick?.(payable.id);
           }
         }}
         sx={{
@@ -526,7 +529,14 @@ const PayablesTableBase = ({
           '&.MuiDataGrid-withBorderColor': {
             borderColor: 'divider',
           },
+          '& .MuiDataGrid-row.ocr-processing': {
+            pointerEvents: 'none',
+            backgroundColor: 'inherit',
+          },
         }}
+        getRowClassName={(params) =>
+          isPayableInOCRProcessing(params.row) ? 'ocr-processing' : ''
+        }
         slots={{
           pagination: () => (
             <TablePagination


### PR DESCRIPTION
# Scope

Payables table: prevent row click (and disable hover effect) for rows of payables with OCR status in processing.

https://monite.atlassian.net/browse/DEV-14646

# Implementation

- changed the onRowClick prop of the DataGrid to trigger if status is not processing.
- added 'ocr-processing' className to rows that have OCR status in procesing and disable hover effects for that className.

# Steps to test

1. Open Payables table.
2. Click "add new bill" and submit a PDF file.
3. Check the first row, that shows "Processing file....", the row should not be clickable and have no hoverable effects.