### PR TITLE
fix(DEV-12328) Handle file upload error max size

### DIFF
--- a/packages/sdk-react/src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx
+++ b/packages/sdk-react/src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx
@@ -1,4 +1,4 @@
-import React, { DragEvent, useState } from 'react';
+import { DragEvent, useState } from 'react';
 import { toast } from 'react-hot-toast';
 
 import { useFileInput, useMenuButton } from '@/core/hooks';
@@ -23,7 +23,7 @@ export const CreatePayableMenu = ({
 }: CreatePayableMenuProps) => {
   const { i18n } = useLingui();
   const { buttonProps, menuProps, open, closeMenu } = useMenuButton();
-  const { FileInput, openFileInput } = useFileInput();
+  const { FileInput, openFileInput, checkFileError } = useFileInput();
   const [dragIsOver, setDragIsOver] = useState(false);
 
   const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
@@ -41,16 +41,11 @@ export const CreatePayableMenu = ({
     setDragIsOver(false);
 
     const droppedFiles = Array.from(event.dataTransfer.files);
-    const allowedTypes = [
-      'application/pdf',
-      'image/png',
-      'image/jpeg',
-      'image/tiff',
-    ];
 
     droppedFiles.forEach((file) => {
-      if (!allowedTypes.includes(file.type)) {
-        toast.error(t(i18n)`Unsupported file format for ${file.name}`);
+      const error = checkFileError(file);
+      if (error) {
+        toast.error(error);
         return;
       }
 
@@ -148,13 +143,10 @@ export const CreatePayableMenu = ({
         </Stack>
       </Menu>
       <FileInput
-        accept="application/pdf, image/png, image/jpeg, image/tiff"
         aria-label={t(i18n)`Upload payable files`}
         multiple
         onChange={(event) => {
           const files = event.target.files;
-          console.debug('Files selected:', files);
-
           if (files) handleFileUpload(files);
           closeMenu();
         }}

--- a/packages/sdk-react/src/components/payables/Payables.tsx
+++ b/packages/sdk-react/src/components/payables/Payables.tsx
@@ -76,7 +76,7 @@ const PayablesBase = ({
   const [isCreateInvoiceDialogOpen, setIsCreateInvoiceDialogOpen] =
     useState(false);
 
-  const { FileInput, openFileInput } = useFileInput();
+  const { FileInput, openFileInput, checkFileError } = useFileInput();
   const payableUploadFromFileMutation =
     api.payables.postPayablesUploadFromFile.useMutation(
       {},
@@ -87,18 +87,12 @@ const PayablesBase = ({
     );
 
   const handleFileUpload = (files: File | FileList) => {
-    const allowedTypes = [
-      'application/pdf',
-      'image/png',
-      'image/jpeg',
-      'image/tiff',
-    ];
-
     const fileArray = files instanceof File ? [files] : Array.from(files);
 
     fileArray.forEach((file) => {
-      if (!allowedTypes.includes(file.type)) {
-        toast.error(t(i18n)`Unsupported file format for ${file.name}`);
+      const error = checkFileError(file);
+      if (error) {
+        toast.error(error);
         return;
       }
 
@@ -166,7 +160,6 @@ const PayablesBase = ({
         />
       )}
       <FileInput
-        accept="application/pdf, image/png, image/jpeg, image/tiff"
         aria-label={t(i18n)`Upload payable files`}
         multiple
         onChange={(event) => {

--- a/packages/sdk-react/src/components/payables/Payables.tsx
+++ b/packages/sdk-react/src/components/payables/Payables.tsx
@@ -83,9 +83,6 @@ const PayablesBase = ({
       {
         onSuccess: () =>
           api.payables.getPayables.invalidateQueries(queryClient),
-        onError: (error) => {
-          toast.error(getAPIErrorMessage(i18n, error));
-        },
       }
     );
 

--- a/packages/sdk-react/src/core/hooks/useFileInput.tsx
+++ b/packages/sdk-react/src/core/hooks/useFileInput.tsx
@@ -1,6 +1,18 @@
 import { ComponentProps, forwardRef, useRef, useState } from 'react';
 
 import { css } from '@emotion/react';
+import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+
+const maxFileSizeInMB = 20;
+const maxFileSizeInKB = 1024 * 1024 * maxFileSizeInMB;
+
+const OCR_SUPPORTED_FORMATS = [
+  'application/pdf',
+  'image/jpg',
+  'image/png',
+  'image/gif',
+];
 
 /**
  * `useFileInput` is a React hook that creates an invisible `<input type="file" />` and `open()` method for interacting with it.
@@ -8,10 +20,11 @@ import { css } from '@emotion/react';
  * @returns {Object} An object containing two properties:
  *  - `FileInput`: A component that renders an invisible file input element. It takes all the standard HTML input attributes and forwardRefs the underlying input element.
  *  - `openFileInput`: A function that programmatically opens the file input dialog. It can be used to open the file input dialog when another element is clicked.
+ *  - `checkFileError`: A function that checks for file errors based on type and size. It returns an error message if there is an issue, or null if the file is valid.
  *
  * @example
  * ```jsx
- * const { FileInput, openFileInput } = useFileInput();
+ * const { FileInput, openFileInput, checkFileError } = useFileInput();
  *
  * return (
  *   <>
@@ -19,7 +32,13 @@ import { css } from '@emotion/react';
  *     <FileInput
  *       onChange={(event) => {
  *         const file = event.target.files?.item(0);
- *         // handle the selected file
+ *         const error = checkFileError(file);
+ *         if (error) {
+ *           // handle the error (e.g., show a message)
+ *           console.error(error);
+ *         } else {
+ *           // handle the selected file
+ *         }
  *       }}
  *     />
  *   </>
@@ -27,6 +46,8 @@ import { css } from '@emotion/react';
  * ```
  */
 export const useFileInput = () => {
+  const { i18n } = useLingui();
+
   const fileInputRef = useRef<{ node: HTMLInputElement | null }>({
     node: null,
   });
@@ -35,6 +56,7 @@ export const useFileInput = () => {
     forwardRef<HTMLInputElement, ComponentProps<'input'>>((props, ref) => (
       <input
         type="file"
+        accept={OCR_SUPPORTED_FORMATS.join(',')}
         ref={(node) => {
           if (typeof ref === 'function') ref(node);
           else if (ref) ref.current = node;
@@ -52,10 +74,29 @@ export const useFileInput = () => {
     ))
   );
 
+  const checkFileError = (file: File): string | null => {
+    if (!file) {
+      return t(i18n)`No file provided`;
+    }
+
+    if (!OCR_SUPPORTED_FORMATS.includes(file.type)) {
+      return t(i18n)`Unsupported file type for ${file.name}`;
+    }
+
+    if (file.size > maxFileSizeInKB) {
+      return t(
+        i18n
+      )`File ${file.name} size exceeds ${maxFileSizeInMB} MB limit.`;
+    }
+
+    return null;
+  };
+
   return {
     FileInput,
     openFileInput: () => {
       fileInputRef.current.node?.click();
     },
+    checkFileError,
   };
 };

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -30,7 +30,7 @@ msgstr "- they are already overdue."
 msgid "- they are due within 7 days."
 msgstr "- they are due within 7 days."
 
-#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:126
+#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:121
 msgid "(.pdf, .png, .jpg supported)"
 msgstr "(.pdf, .png, .jpg supported)"
 
@@ -53,7 +53,7 @@ msgstr "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has
 #: src/components/financing/components/FinanceDetails.tsx:186
 #: src/components/financing/components/FinanceFaqDetails.tsx:58
 #: src/components/financing/components/FinanceFaqDetails.tsx:62
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:104
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:90
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:20
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:114
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceRecurrenceCancelModal.tsx:89
@@ -190,7 +190,7 @@ msgstr "A counterpart with this name exists but has not been specified in the do
 msgid "A fully paid invoice can be updated to contain the amount paid and the amount due sum"
 msgstr "A fully paid invoice can be updated to contain the amount paid and the amount due sum"
 
-#: src/components/financing/components/FinanceBanner.tsx:191
+#: src/components/financing/components/FinanceBanner.tsx:198
 msgid "A provider can't offer you financing"
 msgstr "A provider can't offer you financing"
 
@@ -226,7 +226,7 @@ msgstr "Access Restricted"
 msgid "Account holder name"
 msgstr "Account holder name"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:129
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:115
 msgid "Account Holder Name"
 msgstr "Account Holder Name"
 
@@ -241,7 +241,7 @@ msgstr "Account name"
 msgid "Account number"
 msgstr "Account number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:138
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:124
 msgid "Account Number"
 msgstr "Account Number"
 
@@ -275,7 +275,7 @@ msgstr "Active"
 msgid "Add"
 msgstr "Add"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:181
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:185
 msgid "Add a bank to receive transfers of funds to your business."
 msgstr "Add a bank to receive transfers of funds to your business."
 
@@ -291,20 +291,20 @@ msgstr "Add a business owner"
 msgid "Add a date when the product will be delivered or the service provided"
 msgstr "Add a date when the product will be delivered or the service provided"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:94
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:98
 #: src/components/onboarding/OnboardingPersonList/OnboardingPersonList.tsx:176
 msgid "Add a director"
 msgstr "Add a director"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:97
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:101
 msgid "Add a person"
 msgstr "Add a person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:96
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:100
 msgid "Add an executive"
 msgstr "Add an executive"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:95
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:99
 msgid "Add an owner"
 msgstr "Add an owner"
 
@@ -358,8 +358,8 @@ msgstr "Add Discount"
 msgid "Add item"
 msgstr "Add item"
 
-#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:71
-#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:144
+#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:66
+#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:139
 #: src/components/payables/Payables.test.tsx:72
 #: src/components/payables/Payables.test.tsx:110
 #: src/components/payables/Payables.test.tsx:152
@@ -672,7 +672,7 @@ msgid "Apply for a monthly plan loans to manage your business more efficiently"
 msgstr "Apply for a monthly plan loans to manage your business more efficiently"
 
 #: src/components/financing/hooks/useFinancing.ts:182
-#: src/core/context/KanmonContext.tsx:118
+#: src/core/context/KanmonContext.tsx:125
 msgid "Apply for financing"
 msgstr "Apply for financing"
 
@@ -824,7 +824,7 @@ msgstr "Aruban Florin"
 msgid "At least 1 reminder is required"
 msgstr "At least 1 reminder is required"
 
-#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:183
+#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:145
 msgid "Attach a file"
 msgstr "Attach a file"
 
@@ -973,7 +973,7 @@ msgstr "Bangladesh"
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:112
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:549
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:289
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:122
@@ -1090,7 +1090,7 @@ msgstr "Bicycle Shops"
 msgid "Bill"
 msgstr "Bill"
 
-#: src/components/payables/Payables.tsx:200
+#: src/components/payables/Payables.tsx:190
 msgid "Bill #{payableId} has been deleted"
 msgstr "Bill #{payableId} has been deleted"
 
@@ -1225,15 +1225,15 @@ msgstr "Bus Lines"
 msgid "Business address"
 msgstr "Business address"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
 msgid "Business details"
 msgstr "Business details"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:110
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:114
 msgid "Business directors"
 msgstr "Business directors"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:111
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
 msgid "Business executives"
 msgstr "Business executives"
 
@@ -1245,7 +1245,7 @@ msgstr "Business Identification Number (Liechtenstein)"
 msgid "Business Number (Canada)"
 msgstr "Business Number (Canada)"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:109
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
 msgid "Business owners"
 msgstr "Business owners"
 
@@ -1550,7 +1550,7 @@ msgstr "Choose counterpart type:"
 msgid "Choose document"
 msgstr "Choose document"
 
-#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:195
+#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:161
 msgid "Choose from device"
 msgstr "Choose from device"
 
@@ -1583,7 +1583,7 @@ msgstr "Civic, Social, Fraternal Associations"
 msgid "Cleaning and Maintenance"
 msgstr "Cleaning and Maintenance"
 
-#: src/components/financing/components/FinanceBanner.tsx:262
+#: src/components/financing/components/FinanceBanner.tsx:269
 #: src/components/payables/PayableDetails/PayableDetailsCancelModal/PayableDetailsCancelModal.tsx:36
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:206
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceCancelModal.tsx:74
@@ -1681,7 +1681,7 @@ msgstr "Comoros"
 msgid "Companies"
 msgstr "Companies"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:106
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:110
 msgid "Company details"
 msgstr "Company details"
 
@@ -1807,6 +1807,7 @@ msgstr "Contact support"
 
 #: src/components/onboarding/hooks/useOnboardingActions.ts:126
 #: src/components/onboarding/hooks/useOnboardingActions.ts:134
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:44
 msgid "Continue"
 msgstr "Continue"
 
@@ -1944,7 +1945,7 @@ msgstr "Counterparts"
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:110
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:75
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:44
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:99
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:85
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:26
 #: src/components/onboarding/validators/validationSchemas.ts:115
 #: src/components/onboarding/validators/validationSchemas.ts:151
@@ -2164,7 +2165,7 @@ msgstr "Created by user"
 msgid "Created on"
 msgstr "Created on"
 
-#: src/core/componentSettings/index.ts:168
+#: src/core/componentSettings/index.ts:195
 msgid "Credit notes"
 msgstr "Credit notes"
 
@@ -2196,7 +2197,7 @@ msgstr "Cuba"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:20
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:114
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:81
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:67
 #: src/components/onboarding/validators/validationSchemas.ts:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:149
 #: src/components/products/ProductDetails/validation.ts:48
@@ -2648,11 +2649,11 @@ msgstr "Download PDF"
 msgid "Draft"
 msgstr "Draft"
 
-#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:190
+#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:152
 msgid "Drag & Drop it here to save for administrative purposes."
 msgstr "Drag & Drop it here to save for administrative purposes."
 
-#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:123
+#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:118
 msgid "Drag and drop files or click to upload"
 msgstr "Drag and drop files or click to upload"
 
@@ -2664,7 +2665,7 @@ msgstr "Drapery, Window Covering, and Upholstery Stores"
 msgid "Drinking Places"
 msgstr "Drinking Places"
 
-#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:172
+#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:134
 msgid "Drop the file here to upload"
 msgstr "Drop the file here to upload"
 
@@ -2708,16 +2709,16 @@ msgstr "Due Date"
 msgid "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 msgstr "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 
-#: src/components/financing/components/FinanceBanner.tsx:337
+#: src/components/financing/components/FinanceBanner.tsx:344
 #: src/components/financing/components/FinanceLimits.tsx:40
 msgid "Due to late payment your financing is currently on hold. Please, contact the provider for further details."
 msgstr "Due to late payment your financing is currently on hold. Please, contact the provider for further details."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:171
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:175
 msgid "Due to regulations, we’re required to collect information about a company’s directors."
 msgstr "Due to regulations, we’re required to collect information about a company’s directors."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:166
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:170
 msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 
@@ -2826,11 +2827,11 @@ msgstr "Edit Customer Close"
 msgid "Edit customer's profile"
 msgstr "Edit customer's profile"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:101
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:105
 msgid "Edit documents for person"
 msgstr "Edit documents for person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:105
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:109
 msgid "Edit individual"
 msgstr "Edit individual"
 
@@ -2995,7 +2996,7 @@ msgstr "Entity"
 msgid "Entity bank account"
 msgstr "Entity bank account"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:121
 msgid "Entity documents"
 msgstr "Entity documents"
 
@@ -3237,15 +3238,19 @@ msgstr "Fiji"
 msgid "Fijian Dollar"
 msgstr "Fijian Dollar"
 
+#: src/core/hooks/useFileInput.tsx:87
+msgid "File {0} size exceeds {maxFileSizeInMB} MB limit."
+msgstr "File {0} size exceeds {maxFileSizeInMB} MB limit."
+
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:201
 msgid "File is being processed..."
 msgstr "File is being processed..."
 
 #: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:120
-msgid "File size exceeds {maxFileSizeInMB}MB limit."
-msgstr "File size exceeds {maxFileSizeInMB}MB limit."
+#~ msgid "File size exceeds {maxFileSizeInMB}MB limit."
+#~ msgstr "File size exceeds {maxFileSizeInMB}MB limit."
 
-#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:131
+#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:97
 msgid "File successfully attached"
 msgstr "File successfully attached"
 
@@ -3254,11 +3259,11 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "Finance invoice"
 msgstr "Finance invoice"
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:269
+#: src/components/financing/components/FinancedInvoicesTable.tsx:268
 msgid "Financed invoices"
 msgstr "Financed invoices"
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:307
+#: src/components/financing/components/FinancedInvoicesTable.tsx:306
 msgid "Financed Invoices"
 msgstr "Financed Invoices"
 
@@ -3266,7 +3271,7 @@ msgstr "Financed Invoices"
 msgid "Financial Institutions"
 msgstr "Financial Institutions"
 
-#: src/components/financing/components/FinanceBanner.tsx:314
+#: src/components/financing/components/FinanceBanner.tsx:321
 msgid "financial plans enabled"
 msgstr "financial plans enabled"
 
@@ -3278,12 +3283,12 @@ msgstr "Financing"
 msgid "Financing date"
 msgstr "Financing date"
 
-#: src/components/financing/components/FinanceBanner.tsx:333
+#: src/components/financing/components/FinanceBanner.tsx:340
 #: src/components/financing/components/FinanceLimits.tsx:32
 msgid "Financing is blocked due to a violation of the agreed-upon terms. Please, contact the provider for further details."
 msgstr "Financing is blocked due to a violation of the agreed-upon terms. Please, contact the provider for further details."
 
-#: src/components/financing/components/FinanceBanner.tsx:329
+#: src/components/financing/components/FinanceBanner.tsx:336
 #: src/components/financing/components/FinanceLimits.tsx:36
 msgid "Financing is not available for your business anymore. Please, contact the provider for further details."
 msgstr "Financing is not available for your business anymore. Please, contact the provider for further details."
@@ -3446,7 +3451,7 @@ msgstr "Full name"
 msgid "Full Social Security Number"
 msgstr "Full Social Security Number"
 
-#: src/components/financing/components/FinanceBanner.tsx:141
+#: src/components/financing/components/FinanceBanner.tsx:148
 msgid "Fund your sales/purchases"
 msgstr "Fund your sales/purchases"
 
@@ -3506,7 +3511,7 @@ msgstr "Georgian Lari"
 msgid "Germany"
 msgstr "Germany"
 
-#: src/components/financing/components/FinanceBanner.tsx:145
+#: src/components/financing/components/FinanceBanner.tsx:152
 msgid "Get a small business loan plan to manage finances more efficiently."
 msgstr "Get a small business loan plan to manage finances more efficiently."
 
@@ -3705,7 +3710,7 @@ msgstr ""
 "Kind Regards,\n"
 "{1}"
 
-#: src/components/financing/components/FinanceBanner.tsx:262
+#: src/components/financing/components/FinanceBanner.tsx:269
 msgid "Hide"
 msgstr "Hide"
 
@@ -3790,7 +3795,7 @@ msgstr "I own 25% or more of the company."
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:130
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:8
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:90
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:120
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:106
 #: src/components/onboarding/validators/validationSchemas.ts:120
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:31
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:45
@@ -3934,7 +3939,7 @@ msgstr "Invalid issuance"
 msgid "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
 msgstr "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:308
+#: src/components/financing/components/FinancedInvoicesTable.tsx:307
 #: src/components/receivables/components/CreditNotesTable.tsx:214
 #: src/components/receivables/components/CreditNotesTable.tsx:216
 #: src/components/receivables/components/CreditNotesTable.tsx:284
@@ -4025,7 +4030,7 @@ msgid "Invoice will be issued with items in the selected currency"
 msgstr "Invoice will be issued with items in the selected currency"
 
 #: src/components/receivables/components/InvoicesTable.tsx:503
-#: src/core/componentSettings/index.ts:160
+#: src/core/componentSettings/index.ts:187
 msgid "Invoices"
 msgstr "Invoices"
 
@@ -4128,7 +4133,7 @@ msgstr "Issued documents"
 msgid "Issued on"
 msgstr "Issued on"
 
-#: src/components/financing/components/FinanceBanner.tsx:168
+#: src/components/financing/components/FinanceBanner.tsx:175
 msgid "It can take up to 48 hours. We'll notify you about the results."
 msgstr "It can take up to 48 hours. We'll notify you about the results."
 
@@ -4154,11 +4159,11 @@ msgstr "It must be in the \"Issued\" or \"Partially paid\" statuses and have mor
 msgid "It will remain in all the documents where it is added. You can’t undo this action."
 msgstr "It will remain in all the documents where it is added. You can’t undo this action."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:129
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:133
 msgid "It’s required to add any individual who is on the governing board of the company."
 msgstr "It’s required to add any individual who is on the governing board of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:144
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:148
 msgid "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 msgstr "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 
@@ -4825,7 +4830,7 @@ msgstr "Music Stores-Musical Instruments, Pianos, and Sheet Music"
 msgid "Must be a reachable, unique URL that describes the account's business."
 msgstr "Must be a reachable, unique URL that describes the account's business."
 
-#: src/components/financing/components/FinanceBanner.tsx:216
+#: src/components/financing/components/FinanceBanner.tsx:223
 #: src/components/financing/components/FinanceLimits.tsx:59
 msgid "My financing"
 msgstr "My financing"
@@ -5024,7 +5029,7 @@ msgstr "No Credit Notes"
 msgid "No default email for selected Counterpart. Reminders will not be sent."
 msgstr "No default email for selected Counterpart. Reminders will not be sent."
 
-#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:107
+#: src/core/hooks/useFileInput.tsx:79
 msgid "No file provided"
 msgstr "No file provided"
 
@@ -5153,7 +5158,7 @@ msgstr "Norwegian Krone"
 msgid "NOT allowed"
 msgstr "NOT allowed"
 
-#: src/components/financing/components/FinanceBanner.tsx:320
+#: src/components/financing/components/FinanceBanner.tsx:327
 #: src/components/financing/components/FinanceLimits.tsx:90
 msgid "Not available"
 msgstr "Not available"
@@ -5214,7 +5219,7 @@ msgstr "Omani Rial"
 msgid "Onboarding"
 msgstr "Onboarding"
 
-#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:31
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:30
 msgid "Onboarding Completed"
 msgstr "Onboarding Completed"
 
@@ -5234,7 +5239,7 @@ msgstr "Opticians, Eyeglasses"
 msgid "Optometrists, Ophthalmologist"
 msgstr "Optometrists, Ophthalmologist"
 
-#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:133
+#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:128
 msgid "Or add bill manually"
 msgstr "Or add bill manually"
 
@@ -5443,7 +5448,7 @@ msgstr "Payable \"{0}\" has been submitted"
 msgid "Payable \"{0}\" has been updated"
 msgstr "Payable \"{0}\" has been updated"
 
-#: src/components/payables/Payables.tsx:114
+#: src/components/payables/Payables.tsx:105
 msgid "Payable {0} uploaded successfully"
 msgstr "Payable {0} uploaded successfully"
 
@@ -5451,7 +5456,7 @@ msgstr "Payable {0} uploaded successfully"
 msgid "Payable not found"
 msgstr "Payable not found"
 
-#: src/components/payables/Payables.tsx:147
+#: src/components/payables/Payables.tsx:138
 msgid "Payables"
 msgstr "Payables"
 
@@ -5570,7 +5575,7 @@ msgstr "Permissions"
 msgid "Person"
 msgstr "Person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:114
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
 msgid "Persons review"
 msgstr "Persons review"
 
@@ -5656,11 +5661,11 @@ msgstr "Please accept Service Agreement to proceed."
 msgid "Please add any individual who owns 25% or more of the company."
 msgstr "Please add any individual who owns 25% or more of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:135
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:139
 msgid "Please add any individual who owns 25% or more of your business."
 msgstr "Please add any individual who owns 25% or more of your business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:187
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:191
 msgid "Please correct the errors in persons information."
 msgstr "Please correct the errors in persons information."
 
@@ -5691,7 +5696,7 @@ msgstr ""
 "Kind Regards,\n"
 "{0}"
 
-#: src/components/financing/components/FinanceBanner.tsx:208
+#: src/components/financing/components/FinanceBanner.tsx:215
 msgid "Please get in touch with the provider if you still wish to receive financing."
 msgstr "Please get in touch with the provider if you still wish to receive financing."
 
@@ -5708,11 +5713,11 @@ msgstr "Please list all individuals who are members of the governing board of th
 msgid "Please provide a valid date."
 msgstr "Please provide a valid date."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:140
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:144
 msgid "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 msgstr "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:184
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:188
 msgid "Please provide information about your business."
 msgstr "Please provide information about your business."
 
@@ -5720,8 +5725,8 @@ msgstr "Please provide information about your business."
 msgid "Please provide the following documents for the person"
 msgstr "Please provide the following documents for the person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:190
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:195
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:194
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:199
 msgid "Please review the terms and conditions and accept them to continue."
 msgstr "Please review the terms and conditions and accept them to continue."
 
@@ -5734,9 +5739,9 @@ msgstr "Please try again later."
 msgid "Please try to reload."
 msgstr "Please try to reload."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:151
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:153
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:200
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:157
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:204
 msgid "Please upload the required documents to continue."
 msgstr "Please upload the required documents to continue."
 
@@ -5761,7 +5766,7 @@ msgstr ""
 msgid "Please, check the list of products and services that will get deleted:"
 msgstr "Please, check the list of products and services that will get deleted:"
 
-#: src/components/financing/components/FinanceBanner.tsx:182
+#: src/components/financing/components/FinanceBanner.tsx:189
 msgid "Please, review the offered credit limit and approved financing plans."
 msgstr "Please, review the offered credit limit and approved financing plans."
 
@@ -5816,7 +5821,7 @@ msgstr "Postal code"
 msgid "Postal Services - Government Only"
 msgstr "Postal Services - Government Only"
 
-#: src/components/onboarding/components/OnboardingFooter/OnboardingFooter.tsx:41
+#: src/components/onboarding/components/OnboardingFooter/OnboardingFooter.tsx:29
 msgid "Powered by"
 msgstr "Powered by"
 
@@ -5945,7 +5950,7 @@ msgstr "Project"
 msgid "Provide documents"
 msgstr "Provide documents"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:102
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:106
 msgid "Provide documents for persons"
 msgstr "Provide documents for persons"
 
@@ -6011,7 +6016,7 @@ msgid "Quick Copy, Repro, and Blueprint"
 msgstr "Quick Copy, Repro, and Blueprint"
 
 #: src/components/receivables/components/QuotesTable.tsx:302
-#: src/core/componentSettings/index.ts:164
+#: src/core/componentSettings/index.ts:191
 msgid "Quotes"
 msgstr "Quotes"
 
@@ -6023,7 +6028,7 @@ msgstr "Railroads"
 msgid "Read more"
 msgstr "Read more"
 
-#: src/components/financing/components/FinanceBanner.tsx:155
+#: src/components/financing/components/FinanceBanner.tsx:162
 msgid "Read more >"
 msgstr "Read more >"
 
@@ -6158,7 +6163,7 @@ msgstr "Religious Organizations"
 msgid "Reload"
 msgstr "Reload"
 
-#: src/components/financing/components/FinanceBanner.tsx:290
+#: src/components/financing/components/FinanceBanner.tsx:297
 #: src/components/financing/components/FinanceLimits.tsx:72
 msgid "Remaining limit"
 msgstr "Remaining limit"
@@ -6242,6 +6247,10 @@ msgstr "Repayment sum"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:544
 msgid "Replace items"
 msgstr "Replace items"
+
+#: src/core/utils/getAPIErrorMessage.ts:18
+msgid "Request size limit exceeded"
+msgstr "Request size limit exceeded"
 
 #: src/components/approvalRequests/ApprovalRequests.tsx:48
 msgid "Request was approved"
@@ -6338,7 +6347,7 @@ msgstr "Roofing/Siding, Sheet Metal"
 msgid "Routing number"
 msgstr "Routing number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:147
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:133
 msgid "Routing Number"
 msgstr "Routing Number"
 
@@ -6519,7 +6528,7 @@ msgstr "Select customer"
 msgid "Select invoice currency"
 msgstr "Select invoice currency"
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:309
+#: src/components/financing/components/FinancedInvoicesTable.tsx:308
 msgid "Select invoices you would like to finance and send them for review."
 msgstr "Select invoices you would like to finance and send them for review."
 
@@ -6739,7 +6748,7 @@ msgstr "Something went wrong. Please try again"
 msgid "Sort code"
 msgstr "Sort code"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:156
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:142
 msgid "Sort Code"
 msgstr "Sort Code"
 
@@ -7077,7 +7086,7 @@ msgstr "Telecommunication Services"
 msgid "Telegraph Services"
 msgstr "Telegraph Services"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:158
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:162
 msgid "Tell us more about your business"
 msgstr "Tell us more about your business"
 
@@ -7089,8 +7098,8 @@ msgstr "Tent and Awning Shops"
 #~ msgid "Terms"
 #~ msgstr "Terms"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:119
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:120
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:621
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:640
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:106
@@ -7117,7 +7126,7 @@ msgstr "Thai Baht"
 msgid "Thailand"
 msgstr "Thailand"
 
-#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:32
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:31
 msgid "Thank you for completing onboarding for payments services. We will now review the information submitted."
 msgstr "Thank you for completing onboarding for payments services. We will now review the information submitted."
 
@@ -7225,10 +7234,10 @@ msgid "There was an error loading {0}."
 msgstr "There was an error loading {0}."
 
 #: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:138
-msgid "There was an issue reading the file."
-msgstr "There was an issue reading the file."
+#~ msgid "There was an issue reading the file."
+#~ msgstr "There was an issue reading the file."
 
-#: src/components/financing/components/FinanceBanner.tsx:195
+#: src/components/financing/components/FinanceBanner.tsx:202
 msgid "They will contact you if your credit score improves and you can reapply."
 msgstr "They will contact you if your credit score improves and you can reapply."
 
@@ -7241,7 +7250,7 @@ msgstr "They will contact you if your credit score improves and you can reapply.
 msgid "This action can't be undone."
 msgstr "This action can't be undone."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:161
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:165
 msgid "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 msgstr "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 
@@ -7253,7 +7262,7 @@ msgstr "This invoice can be financed"
 msgid "This invoice can't be financed"
 msgstr "This invoice can't be financed"
 
-#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:186
+#: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:148
 #: src/components/payables/PayableDetails/PayableDetailsNoAttachedFile/PayableDetailsNoAttachedFile.tsx:30
 msgid "This invoice doesn't have a file attached."
 msgstr "This invoice doesn't have a file attached."
@@ -7613,7 +7622,7 @@ msgstr "Units"
 #: src/core/hooks/useVatTypes.ts:16
 #: src/core/hooks/useVatTypes.ts:18
 #: src/core/hooks/useVatTypes.ts:211
-#: src/core/utils/getAPIErrorMessage.ts:18
+#: src/core/utils/getAPIErrorMessage.ts:21
 msgid "Unknown"
 msgstr "Unknown"
 
@@ -7632,12 +7641,16 @@ msgstr "Unspecified"
 
 #: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:53
 #: src/components/payables/Payables.tsx:104
-msgid "Unsupported file format for {0}"
-msgstr "Unsupported file format for {0}"
+#~ msgid "Unsupported file format for {0}"
+#~ msgstr "Unsupported file format for {0}"
 
 #: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:115
-msgid "Unsupported file type"
-msgstr "Unsupported file type"
+#~ msgid "Unsupported file type"
+#~ msgstr "Unsupported file type"
+
+#: src/core/hooks/useFileInput.tsx:83
+msgid "Unsupported file type for {0}"
+msgstr "Unsupported file type for {0}"
 
 #: src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyDetailsFormAdvanced/ApprovalPolicyDetailsFormAdvanced.tsx:280
 #: src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx:1180
@@ -7701,7 +7714,7 @@ msgstr "Updating the invoice"
 msgid "Upload a document here."
 msgstr "Upload a document here."
 
-#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:85
+#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:80
 msgid "Upload files"
 msgstr "Upload files"
 
@@ -7709,12 +7722,12 @@ msgstr "Upload files"
 msgid "Upload payable file"
 msgstr "Upload payable file"
 
-#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:152
-#: src/components/payables/Payables.tsx:173
+#: src/components/payables/CreatePayableMenu/CreatePayableMenu.tsx:146
+#: src/components/payables/Payables.tsx:163
 msgid "Upload payable files"
 msgstr "Upload payable files"
 
-#: src/components/payables/Payables.tsx:113
+#: src/components/payables/Payables.tsx:104
 msgid "Uploading {0}"
 msgstr "Uploading {0}"
 
@@ -7984,7 +7997,7 @@ msgstr "Venezuela"
 msgid "Verify identity"
 msgstr "Verify identity"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:108
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:112
 msgid "Verify you represent this business"
 msgstr "Verify you represent this business"
 
@@ -8027,7 +8040,7 @@ msgstr "View"
 msgid "View all"
 msgstr "View all"
 
-#: src/components/financing/components/FinanceBanner.tsx:258
+#: src/components/financing/components/FinanceBanner.tsx:265
 msgid "View details"
 msgstr "View details"
 
@@ -8051,7 +8064,7 @@ msgstr "Wallis And Futuna"
 msgid "Watch/Jewelry Repair"
 msgstr "Watch/Jewelry Repair"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:176
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:180
 msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 
@@ -8245,7 +8258,7 @@ msgstr "You don’t have permissions to view this page.<0/>Contact your system a
 msgid "You have unsaved changes"
 msgstr "You have unsaved changes"
 
-#: src/components/financing/components/FinanceBanner.tsx:204
+#: src/components/financing/components/FinanceBanner.tsx:211
 msgid "You haven't accepted the offer and it has expired"
 msgstr "You haven't accepted the offer and it has expired"
 
@@ -8257,11 +8270,11 @@ msgstr "You won't be able to use it to create new invoices, but it won't affect 
 msgid "Your amount available for financing additional invoices."
 msgstr "Your amount available for financing additional invoices."
 
-#: src/components/financing/components/FinanceBanner.tsx:164
+#: src/components/financing/components/FinanceBanner.tsx:171
 msgid "Your application is in review"
 msgstr "Your application is in review"
 
-#: src/components/financing/components/FinanceBanner.tsx:178
+#: src/components/financing/components/FinanceBanner.tsx:185
 msgid "Your application was approved"
 msgstr "Your application was approved"
 

--- a/packages/sdk-react/src/core/utils/getAPIErrorMessage.ts
+++ b/packages/sdk-react/src/core/utils/getAPIErrorMessage.ts
@@ -14,6 +14,9 @@ export const getAPIErrorMessage = (
   if ('error' in error && 'message' in error.error) return error.error.message;
   if ('detail' in error && Array.isArray(error.detail))
     return error.detail?.map((detail) => detail.msg).join(', ');
+  if ('message' in error && error.message === 'Request size limit exceeded') {
+    return t(i18n)`Request size limit exceeded`;
+  }
 
   return defaultMessage ?? t(i18n)`Unknown`;
 };

--- a/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
+++ b/packages/sdk-react/src/ui/FileViewer/FileViewer.tsx
@@ -2,12 +2,6 @@ import { useEffect, useRef } from 'react';
 
 import { embed } from 'pdfobject';
 
-export const SUPPORTED_MIME_TYPES = [
-  'image/png',
-  'image/jpeg',
-  'application/pdf',
-];
-
 interface FileViewerProps {
   url: string;
   mimetype: string;


### PR DESCRIPTION
# Scope

Improve Payables OCR file upload by handling error messages for file size limits.
Also, refactor the file input handling to reduce duplication and improve clarity and added file checking logic in the `useFileInput` hook. 

Jira issue: https://monite.atlassian.net/browse/DEV-12328


# Implementation

- Added handle specific error message for request size limit exceeded in `getAPIErrorMessage`.
- Enhanced `useFileInput` hook with file checking and constants for file formats and size limit.
- Improved file upload in `PayableDetailsAttachFile` with `useFileInput` usage similar to other places.
- Updated [supported OCR file formats list](https://monite.atlassian.net/browse/DEV-12328?focusedCommentId=39772) and max file size.

# Steps to test

1. Navigate to the Payables view.
2. Click "add new bill" button.
3. Click "Drag and drop files or click to upload", should open file browser dialog, should be limited to PDF and images (jpeg, png, gif).
4. Select one file.
5. If file is >20 MB, should see error toast message (and no network request on the devtools).
6. If file upload is ok, should succeed.