### PR TITLE
fix(DEV-14870): repopulate the bank account values after submission

### DIFF
--- a/.changeset/modern-dots-sneeze.md
+++ b/.changeset/modern-dots-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Fixed the issue with restoring values in the bank account onboarding after submission

--- a/packages/sdk-react/src/components/onboarding/hooks/useOnboardingBankAccount.ts
+++ b/packages/sdk-react/src/components/onboarding/hooks/useOnboardingBankAccount.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { type DefaultValues } from 'react-hook-form';
 import { toast } from 'react-hot-toast';
 
 import { components } from '@/api';
@@ -10,8 +11,8 @@ import {
   useOnboardingCurrencyToCountries,
 } from '@/core/queries/useOnboarding';
 import { getAPIErrorMessage } from '@/core/utils/getAPIErrorMessage';
-import { useLingui } from '@lingui/react';
 import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
 
 import {
   generateFieldsByMask,
@@ -20,7 +21,6 @@ import {
 } from '../transformers';
 import type { OnboardingFormType } from './useOnboardingForm';
 import { useOnboardingForm } from './useOnboardingForm';
-import { type DefaultValues } from 'react-hook-form';
 
 export type OnboardingBankAccountReturnType = {
   isPending: boolean;
@@ -169,7 +169,7 @@ export function useOnboardingBankAccount(): OnboardingBankAccountReturnType {
               bank_account_id: currentBankAccount.id,
             },
           });
-        } catch (error) {
+        } catch (_e) {
           // Error is already logged in the onError handler
         }
       }
@@ -177,7 +177,7 @@ export function useOnboardingBankAccount(): OnboardingBankAccountReturnType {
       const bankAccountDataForPatch = prepareBankAccountDataForPatch(
         payload,
         response.id,
-        mask,
+        mask
       );
 
       await patchOnboardingRequirements({
@@ -186,12 +186,12 @@ export function useOnboardingBankAccount(): OnboardingBankAccountReturnType {
           bank_accounts: [bankAccountDataForPatch],
         },
       });
-      
+
       setFields(bankAccountDataForPatch);
 
-      const formValues = generateValuesByFields<DefaultValues<CreateEntityBankAccountRequest>>(
-          bankAccountDataForPatch
-      );
+      const formValues = generateValuesByFields<
+        DefaultValues<CreateEntityBankAccountRequest>
+      >(bankAccountDataForPatch);
       reset(formValues);
 
       return response;

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -53,7 +53,7 @@ msgstr "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has
 #: src/components/financing/components/FinanceDetails.tsx:186
 #: src/components/financing/components/FinanceFaqDetails.tsx:58
 #: src/components/financing/components/FinanceFaqDetails.tsx:62
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:104
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:87
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:20
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:114
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceRecurrenceCancelModal.tsx:89
@@ -190,7 +190,7 @@ msgstr "A counterpart with this name exists but has not been specified in the do
 msgid "A fully paid invoice can be updated to contain the amount paid and the amount due sum"
 msgstr "A fully paid invoice can be updated to contain the amount paid and the amount due sum"
 
-#: src/components/financing/components/FinanceBanner.tsx:191
+#: src/components/financing/components/FinanceBanner.tsx:198
 msgid "A provider can't offer you financing"
 msgstr "A provider can't offer you financing"
 
@@ -226,7 +226,7 @@ msgstr "Access Restricted"
 msgid "Account holder name"
 msgstr "Account holder name"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:129
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:112
 msgid "Account Holder Name"
 msgstr "Account Holder Name"
 
@@ -241,7 +241,7 @@ msgstr "Account name"
 msgid "Account number"
 msgstr "Account number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:138
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:121
 msgid "Account Number"
 msgstr "Account Number"
 
@@ -275,7 +275,7 @@ msgstr "Active"
 msgid "Add"
 msgstr "Add"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:181
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:185
 msgid "Add a bank to receive transfers of funds to your business."
 msgstr "Add a bank to receive transfers of funds to your business."
 
@@ -291,20 +291,20 @@ msgstr "Add a business owner"
 msgid "Add a date when the product will be delivered or the service provided"
 msgstr "Add a date when the product will be delivered or the service provided"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:94
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:98
 #: src/components/onboarding/OnboardingPersonList/OnboardingPersonList.tsx:176
 msgid "Add a director"
 msgstr "Add a director"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:97
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:101
 msgid "Add a person"
 msgstr "Add a person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:96
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:100
 msgid "Add an executive"
 msgstr "Add an executive"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:95
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:99
 msgid "Add an owner"
 msgstr "Add an owner"
 
@@ -396,7 +396,7 @@ msgstr "Add text"
 msgid "Add VAT ID"
 msgstr "Add VAT ID"
 
-#: src/components/payables/PayablesTable/PayablesTable.tsx:550
+#: src/components/payables/PayablesTable/PayablesTable.tsx:560
 msgid "Add your first bill"
 msgstr "Add your first bill"
 
@@ -672,7 +672,7 @@ msgid "Apply for a monthly plan loans to manage your business more efficiently"
 msgstr "Apply for a monthly plan loans to manage your business more efficiently"
 
 #: src/components/financing/hooks/useFinancing.ts:182
-#: src/core/context/KanmonContext.tsx:118
+#: src/core/context/KanmonContext.tsx:125
 msgid "Apply for financing"
 msgstr "Apply for financing"
 
@@ -973,7 +973,7 @@ msgstr "Bangladesh"
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:112
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:549
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:289
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:122
@@ -1225,15 +1225,15 @@ msgstr "Bus Lines"
 msgid "Business address"
 msgstr "Business address"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
 msgid "Business details"
 msgstr "Business details"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:110
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:114
 msgid "Business directors"
 msgstr "Business directors"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:111
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
 msgid "Business executives"
 msgstr "Business executives"
 
@@ -1245,7 +1245,7 @@ msgstr "Business Identification Number (Liechtenstein)"
 msgid "Business Number (Canada)"
 msgstr "Business Number (Canada)"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:109
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
 msgid "Business owners"
 msgstr "Business owners"
 
@@ -1583,7 +1583,7 @@ msgstr "Civic, Social, Fraternal Associations"
 msgid "Cleaning and Maintenance"
 msgstr "Cleaning and Maintenance"
 
-#: src/components/financing/components/FinanceBanner.tsx:262
+#: src/components/financing/components/FinanceBanner.tsx:269
 #: src/components/payables/PayableDetails/PayableDetailsCancelModal/PayableDetailsCancelModal.tsx:36
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:206
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceCancelModal.tsx:74
@@ -1681,7 +1681,7 @@ msgstr "Comoros"
 msgid "Companies"
 msgstr "Companies"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:106
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:110
 msgid "Company details"
 msgstr "Company details"
 
@@ -1807,6 +1807,7 @@ msgstr "Contact support"
 
 #: src/components/onboarding/hooks/useOnboardingActions.ts:126
 #: src/components/onboarding/hooks/useOnboardingActions.ts:134
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:44
 msgid "Continue"
 msgstr "Continue"
 
@@ -1870,6 +1871,10 @@ msgstr "Costa Rican Colón"
 #: src/core/utils/countries.ts:72
 msgid "Cote D\"Ivoire"
 msgstr "Cote D\"Ivoire"
+
+#: src/components/onboarding/hooks/useOnboardingBankAccount.ts:76
+msgid "Could not remove previous bank account details."
+msgstr "Could not remove previous bank account details."
 
 #: src/components/onboarding/dicts/mccCodes.ts:383
 msgid "Counseling Services"
@@ -1944,7 +1949,7 @@ msgstr "Counterparts"
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:110
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:75
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:44
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:99
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:82
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:26
 #: src/components/onboarding/validators/validationSchemas.ts:115
 #: src/components/onboarding/validators/validationSchemas.ts:151
@@ -2164,7 +2169,7 @@ msgstr "Created by user"
 msgid "Created on"
 msgstr "Created on"
 
-#: src/core/componentSettings/index.ts:168
+#: src/core/componentSettings/index.ts:195
 msgid "Credit notes"
 msgstr "Credit notes"
 
@@ -2196,7 +2201,7 @@ msgstr "Cuba"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:20
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:114
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:81
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:64
 #: src/components/onboarding/validators/validationSchemas.ts:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:149
 #: src/components/products/ProductDetails/validation.ts:48
@@ -2708,16 +2713,16 @@ msgstr "Due Date"
 msgid "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 msgstr "Due to an error, the OCR failed to read the data from the document. Please input the data manually."
 
-#: src/components/financing/components/FinanceBanner.tsx:337
+#: src/components/financing/components/FinanceBanner.tsx:344
 #: src/components/financing/components/FinanceLimits.tsx:40
 msgid "Due to late payment your financing is currently on hold. Please, contact the provider for further details."
 msgstr "Due to late payment your financing is currently on hold. Please, contact the provider for further details."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:171
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:175
 msgid "Due to regulations, we’re required to collect information about a company’s directors."
 msgstr "Due to regulations, we’re required to collect information about a company’s directors."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:166
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:170
 msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 
@@ -2826,11 +2831,11 @@ msgstr "Edit Customer Close"
 msgid "Edit customer's profile"
 msgstr "Edit customer's profile"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:101
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:105
 msgid "Edit documents for person"
 msgstr "Edit documents for person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:105
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:109
 msgid "Edit individual"
 msgstr "Edit individual"
 
@@ -2995,7 +3000,7 @@ msgstr "Entity"
 msgid "Entity bank account"
 msgstr "Entity bank account"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:121
 msgid "Entity documents"
 msgstr "Entity documents"
 
@@ -3254,11 +3259,11 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "Finance invoice"
 msgstr "Finance invoice"
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:269
+#: src/components/financing/components/FinancedInvoicesTable.tsx:268
 msgid "Financed invoices"
 msgstr "Financed invoices"
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:307
+#: src/components/financing/components/FinancedInvoicesTable.tsx:306
 msgid "Financed Invoices"
 msgstr "Financed Invoices"
 
@@ -3266,7 +3271,7 @@ msgstr "Financed Invoices"
 msgid "Financial Institutions"
 msgstr "Financial Institutions"
 
-#: src/components/financing/components/FinanceBanner.tsx:314
+#: src/components/financing/components/FinanceBanner.tsx:321
 msgid "financial plans enabled"
 msgstr "financial plans enabled"
 
@@ -3278,12 +3283,12 @@ msgstr "Financing"
 msgid "Financing date"
 msgstr "Financing date"
 
-#: src/components/financing/components/FinanceBanner.tsx:333
+#: src/components/financing/components/FinanceBanner.tsx:340
 #: src/components/financing/components/FinanceLimits.tsx:32
 msgid "Financing is blocked due to a violation of the agreed-upon terms. Please, contact the provider for further details."
 msgstr "Financing is blocked due to a violation of the agreed-upon terms. Please, contact the provider for further details."
 
-#: src/components/financing/components/FinanceBanner.tsx:329
+#: src/components/financing/components/FinanceBanner.tsx:336
 #: src/components/financing/components/FinanceLimits.tsx:36
 msgid "Financing is not available for your business anymore. Please, contact the provider for further details."
 msgstr "Financing is not available for your business anymore. Please, contact the provider for further details."
@@ -3446,7 +3451,7 @@ msgstr "Full name"
 msgid "Full Social Security Number"
 msgstr "Full Social Security Number"
 
-#: src/components/financing/components/FinanceBanner.tsx:141
+#: src/components/financing/components/FinanceBanner.tsx:148
 msgid "Fund your sales/purchases"
 msgstr "Fund your sales/purchases"
 
@@ -3506,7 +3511,7 @@ msgstr "Georgian Lari"
 msgid "Germany"
 msgstr "Germany"
 
-#: src/components/financing/components/FinanceBanner.tsx:145
+#: src/components/financing/components/FinanceBanner.tsx:152
 msgid "Get a small business loan plan to manage finances more efficiently."
 msgstr "Get a small business loan plan to manage finances more efficiently."
 
@@ -3705,7 +3710,7 @@ msgstr ""
 "Kind Regards,\n"
 "{1}"
 
-#: src/components/financing/components/FinanceBanner.tsx:262
+#: src/components/financing/components/FinanceBanner.tsx:269
 msgid "Hide"
 msgstr "Hide"
 
@@ -3790,7 +3795,7 @@ msgstr "I own 25% or more of the company."
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:130
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:8
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:90
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:120
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:103
 #: src/components/onboarding/validators/validationSchemas.ts:120
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:31
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:45
@@ -3934,7 +3939,7 @@ msgstr "Invalid issuance"
 msgid "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
 msgstr "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:308
+#: src/components/financing/components/FinancedInvoicesTable.tsx:307
 #: src/components/receivables/components/CreditNotesTable.tsx:214
 #: src/components/receivables/components/CreditNotesTable.tsx:216
 #: src/components/receivables/components/CreditNotesTable.tsx:284
@@ -4025,7 +4030,7 @@ msgid "Invoice will be issued with items in the selected currency"
 msgstr "Invoice will be issued with items in the selected currency"
 
 #: src/components/receivables/components/InvoicesTable.tsx:503
-#: src/core/componentSettings/index.ts:160
+#: src/core/componentSettings/index.ts:187
 msgid "Invoices"
 msgstr "Invoices"
 
@@ -4128,7 +4133,7 @@ msgstr "Issued documents"
 msgid "Issued on"
 msgstr "Issued on"
 
-#: src/components/financing/components/FinanceBanner.tsx:168
+#: src/components/financing/components/FinanceBanner.tsx:175
 msgid "It can take up to 48 hours. We'll notify you about the results."
 msgstr "It can take up to 48 hours. We'll notify you about the results."
 
@@ -4154,11 +4159,11 @@ msgstr "It must be in the \"Issued\" or \"Partially paid\" statuses and have mor
 msgid "It will remain in all the documents where it is added. You can’t undo this action."
 msgstr "It will remain in all the documents where it is added. You can’t undo this action."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:129
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:133
 msgid "It’s required to add any individual who is on the governing board of the company."
 msgstr "It’s required to add any individual who is on the governing board of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:144
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:148
 msgid "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 msgstr "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 
@@ -4825,7 +4830,7 @@ msgstr "Music Stores-Musical Instruments, Pianos, and Sheet Music"
 msgid "Must be a reachable, unique URL that describes the account's business."
 msgstr "Must be a reachable, unique URL that describes the account's business."
 
-#: src/components/financing/components/FinanceBanner.tsx:216
+#: src/components/financing/components/FinanceBanner.tsx:223
 #: src/components/financing/components/FinanceLimits.tsx:59
 msgid "My financing"
 msgstr "My financing"
@@ -4999,11 +5004,11 @@ msgstr "No Approval Policies"
 msgid "No Approval Requests"
 msgstr "No Approval Requests"
 
-#: src/components/payables/PayablesTable/PayablesTable.tsx:551
+#: src/components/payables/PayablesTable/PayablesTable.tsx:561
 msgid "No bills found"
 msgstr "No bills found"
 
-#: src/components/payables/PayablesTable/PayablesTable.tsx:548
+#: src/components/payables/PayablesTable/PayablesTable.tsx:558
 msgid "No bills yet"
 msgstr "No bills yet"
 
@@ -5153,7 +5158,7 @@ msgstr "Norwegian Krone"
 msgid "NOT allowed"
 msgstr "NOT allowed"
 
-#: src/components/financing/components/FinanceBanner.tsx:320
+#: src/components/financing/components/FinanceBanner.tsx:327
 #: src/components/financing/components/FinanceLimits.tsx:90
 msgid "Not available"
 msgstr "Not available"
@@ -5214,7 +5219,7 @@ msgstr "Omani Rial"
 msgid "Onboarding"
 msgstr "Onboarding"
 
-#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:31
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:30
 msgid "Onboarding Completed"
 msgstr "Onboarding Completed"
 
@@ -5410,7 +5415,7 @@ msgstr "Pay in the first {0} days"
 msgid "Pay out the financed sum:"
 msgstr "Pay out the financed sum:"
 
-#: src/components/payables/PayablesTable/PayablesTable.tsx:565
+#: src/components/payables/PayablesTable/PayablesTable.tsx:575
 #: src/components/userRoles/consts.ts:38
 msgid "Payable"
 msgstr "Payable"
@@ -5570,7 +5575,7 @@ msgstr "Permissions"
 msgid "Person"
 msgstr "Person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:114
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
 msgid "Persons review"
 msgstr "Persons review"
 
@@ -5656,11 +5661,11 @@ msgstr "Please accept Service Agreement to proceed."
 msgid "Please add any individual who owns 25% or more of the company."
 msgstr "Please add any individual who owns 25% or more of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:135
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:139
 msgid "Please add any individual who owns 25% or more of your business."
 msgstr "Please add any individual who owns 25% or more of your business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:187
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:191
 msgid "Please correct the errors in persons information."
 msgstr "Please correct the errors in persons information."
 
@@ -5691,7 +5696,7 @@ msgstr ""
 "Kind Regards,\n"
 "{0}"
 
-#: src/components/financing/components/FinanceBanner.tsx:208
+#: src/components/financing/components/FinanceBanner.tsx:215
 msgid "Please get in touch with the provider if you still wish to receive financing."
 msgstr "Please get in touch with the provider if you still wish to receive financing."
 
@@ -5708,11 +5713,11 @@ msgstr "Please list all individuals who are members of the governing board of th
 msgid "Please provide a valid date."
 msgstr "Please provide a valid date."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:140
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:144
 msgid "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 msgstr "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:184
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:188
 msgid "Please provide information about your business."
 msgstr "Please provide information about your business."
 
@@ -5720,8 +5725,8 @@ msgstr "Please provide information about your business."
 msgid "Please provide the following documents for the person"
 msgstr "Please provide the following documents for the person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:190
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:195
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:194
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:199
 msgid "Please review the terms and conditions and accept them to continue."
 msgstr "Please review the terms and conditions and accept them to continue."
 
@@ -5734,9 +5739,9 @@ msgstr "Please try again later."
 msgid "Please try to reload."
 msgstr "Please try to reload."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:151
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:153
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:200
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:157
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:204
 msgid "Please upload the required documents to continue."
 msgstr "Please upload the required documents to continue."
 
@@ -5761,7 +5766,7 @@ msgstr ""
 msgid "Please, check the list of products and services that will get deleted:"
 msgstr "Please, check the list of products and services that will get deleted:"
 
-#: src/components/financing/components/FinanceBanner.tsx:182
+#: src/components/financing/components/FinanceBanner.tsx:189
 msgid "Please, review the offered credit limit and approved financing plans."
 msgstr "Please, review the offered credit limit and approved financing plans."
 
@@ -5816,7 +5821,7 @@ msgstr "Postal code"
 msgid "Postal Services - Government Only"
 msgstr "Postal Services - Government Only"
 
-#: src/components/onboarding/components/OnboardingFooter/OnboardingFooter.tsx:41
+#: src/components/onboarding/components/OnboardingFooter/OnboardingFooter.tsx:29
 msgid "Powered by"
 msgstr "Powered by"
 
@@ -5945,7 +5950,7 @@ msgstr "Project"
 msgid "Provide documents"
 msgstr "Provide documents"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:102
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:106
 msgid "Provide documents for persons"
 msgstr "Provide documents for persons"
 
@@ -6011,7 +6016,7 @@ msgid "Quick Copy, Repro, and Blueprint"
 msgstr "Quick Copy, Repro, and Blueprint"
 
 #: src/components/receivables/components/QuotesTable.tsx:302
-#: src/core/componentSettings/index.ts:164
+#: src/core/componentSettings/index.ts:191
 msgid "Quotes"
 msgstr "Quotes"
 
@@ -6023,7 +6028,7 @@ msgstr "Railroads"
 msgid "Read more"
 msgstr "Read more"
 
-#: src/components/financing/components/FinanceBanner.tsx:155
+#: src/components/financing/components/FinanceBanner.tsx:162
 msgid "Read more >"
 msgstr "Read more >"
 
@@ -6158,7 +6163,7 @@ msgstr "Religious Organizations"
 msgid "Reload"
 msgstr "Reload"
 
-#: src/components/financing/components/FinanceBanner.tsx:290
+#: src/components/financing/components/FinanceBanner.tsx:297
 #: src/components/financing/components/FinanceLimits.tsx:72
 msgid "Remaining limit"
 msgstr "Remaining limit"
@@ -6338,7 +6343,7 @@ msgstr "Roofing/Siding, Sheet Metal"
 msgid "Routing number"
 msgstr "Routing number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:147
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:130
 msgid "Routing Number"
 msgstr "Routing Number"
 
@@ -6519,7 +6524,7 @@ msgstr "Select customer"
 msgid "Select invoice currency"
 msgstr "Select invoice currency"
 
-#: src/components/financing/components/FinancedInvoicesTable.tsx:309
+#: src/components/financing/components/FinancedInvoicesTable.tsx:308
 msgid "Select invoices you would like to finance and send them for review."
 msgstr "Select invoices you would like to finance and send them for review."
 
@@ -6739,7 +6744,7 @@ msgstr "Something went wrong. Please try again"
 msgid "Sort code"
 msgstr "Sort code"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:156
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:139
 msgid "Sort Code"
 msgstr "Sort Code"
 
@@ -7077,7 +7082,7 @@ msgstr "Telecommunication Services"
 msgid "Telegraph Services"
 msgstr "Telegraph Services"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:158
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:162
 msgid "Tell us more about your business"
 msgstr "Tell us more about your business"
 
@@ -7089,8 +7094,8 @@ msgstr "Tent and Awning Shops"
 #~ msgid "Terms"
 #~ msgstr "Terms"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:119
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:120
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:621
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:640
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:106
@@ -7117,7 +7122,7 @@ msgstr "Thai Baht"
 msgid "Thailand"
 msgstr "Thailand"
 
-#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:32
+#: src/components/onboarding/OnboardingCompleted/OnboardingCompleted.tsx:31
 msgid "Thank you for completing onboarding for payments services. We will now review the information submitted."
 msgstr "Thank you for completing onboarding for payments services. We will now review the information submitted."
 
@@ -7228,7 +7233,7 @@ msgstr "There was an error loading {0}."
 msgid "There was an issue reading the file."
 msgstr "There was an issue reading the file."
 
-#: src/components/financing/components/FinanceBanner.tsx:195
+#: src/components/financing/components/FinanceBanner.tsx:202
 msgid "They will contact you if your credit score improves and you can reapply."
 msgstr "They will contact you if your credit score improves and you can reapply."
 
@@ -7241,7 +7246,7 @@ msgstr "They will contact you if your credit score improves and you can reapply.
 msgid "This action can't be undone."
 msgstr "This action can't be undone."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:161
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:165
 msgid "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 msgstr "This form must be filled out by someone with significant control and management of your business. If that’s not you, make sure to ask the right person to continue."
 
@@ -7984,7 +7989,7 @@ msgstr "Venezuela"
 msgid "Verify identity"
 msgstr "Verify identity"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:108
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:112
 msgid "Verify you represent this business"
 msgstr "Verify you represent this business"
 
@@ -8027,7 +8032,7 @@ msgstr "View"
 msgid "View all"
 msgstr "View all"
 
-#: src/components/financing/components/FinanceBanner.tsx:258
+#: src/components/financing/components/FinanceBanner.tsx:265
 msgid "View details"
 msgstr "View details"
 
@@ -8051,7 +8056,7 @@ msgstr "Wallis And Futuna"
 msgid "Watch/Jewelry Repair"
 msgstr "Watch/Jewelry Repair"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:176
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:180
 msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 
@@ -8200,7 +8205,7 @@ msgstr "You don’t have any approval policies yet."
 msgid "You don’t have any approval requests yet."
 msgstr "You don’t have any approval requests yet."
 
-#: src/components/payables/PayablesTable/PayablesTable.tsx:549
+#: src/components/payables/PayablesTable/PayablesTable.tsx:559
 msgid "You don’t have any bills yet"
 msgstr "You don’t have any bills yet"
 
@@ -8245,7 +8250,7 @@ msgstr "You don’t have permissions to view this page.<0/>Contact your system a
 msgid "You have unsaved changes"
 msgstr "You have unsaved changes"
 
-#: src/components/financing/components/FinanceBanner.tsx:204
+#: src/components/financing/components/FinanceBanner.tsx:211
 msgid "You haven't accepted the offer and it has expired"
 msgstr "You haven't accepted the offer and it has expired"
 
@@ -8257,11 +8262,11 @@ msgstr "You won't be able to use it to create new invoices, but it won't affect 
 msgid "Your amount available for financing additional invoices."
 msgstr "Your amount available for financing additional invoices."
 
-#: src/components/financing/components/FinanceBanner.tsx:164
+#: src/components/financing/components/FinanceBanner.tsx:171
 msgid "Your application is in review"
 msgstr "Your application is in review"
 
-#: src/components/financing/components/FinanceBanner.tsx:178
+#: src/components/financing/components/FinanceBanner.tsx:185
 msgid "Your application was approved"
 msgstr "Your application was approved"
 


### PR DESCRIPTION
**Changes**

*   **Fixed Field Reset on Submit:** Resolved an issue where Country and IBAN fields would reset after submitting the bank account form. This was achieved by:
    *   Ensuring the data transformation (`prepareBankAccountDataForPatch`) correctly uses the API mask.
    *   Explicitly resetting the React Hook Form state using `reset(formValues)` at the end of the `primaryAction` callback. This ensures the form's internal state reflects the submitted values even if subsequent effects modify the hook's local state.
*   **Improved Deletion Error Handling:** Added a `toast.error` notification in the `onError` handler for the `deleteBankAccountMutation` to provide user feedback if deleting a previous bank account fails (which can be expected during onboarding). Kept the `try...catch` block within `primaryAction` to allow the submission process to continue despite deletion errors
