### PR TITLE
feat(DEV-14965): Bank account creation hotfixes

### DIFF
--- a/.changeset/polite-cobras-listen.md
+++ b/.changeset/polite-cobras-listen.md
@@ -1,0 +1,7 @@
+---
+'@monite/sdk-react': patch
+'@team-monite/sdk-demo': patch
+'@monite/sdk-drop-in': patch
+---
+
+Fixed invoice preview not showing bank account information and some other minor fixes to bank account creation

--- a/packages/sdk-demo/src/components/AppMoniteProvider.tsx
+++ b/packages/sdk-demo/src/components/AppMoniteProvider.tsx
@@ -35,6 +35,11 @@ const AppMoniteProvider = ({
         messages: i18n.messages[i18n.locale],
       }}
       theme={theme}
+      componentSettings={{
+        receivables: {
+          enableEntityBankAccount: true,
+        },
+      }}
     >
       {children}
     </MoniteProvider>

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx
@@ -6,6 +6,7 @@ import {
   isOrganizationCounterpart,
 } from '@/components/counterparts/helpers';
 import { MeasureUnit } from '@/components/MeasureUnit/MeasureUnit';
+import { useGetEntityBankAccountById } from '@/components/receivables/hooks';
 import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useCurrencies } from '@/core/hooks';
 import {
@@ -82,7 +83,10 @@ export const InvoicePreview = ({
   const fulfillmentDate = watch('fulfillment_date');
   const items = watch('line_items');
   const memo = watch('memo');
+  const entityBankAccountId = watch('entity_bank_account_id') ?? '';
   const counterpartName = counterpart ? getCounterpartName(counterpart) : '';
+  const { data: bankAccount } =
+    useGetEntityBankAccountById(entityBankAccountId);
 
   const dateTime = i18n.date(new Date(), locale.dateFormat);
 
@@ -158,6 +162,54 @@ export const InvoicePreview = ({
       }, 0);
       return { taxRate, totalTax };
     });
+  };
+
+  const renderBankAccountDetails = () => {
+    if (!bankAccount) {
+      return (
+        <div>
+          <span className="not-set">
+            {t(i18n)`Set up bank account to add payment info
+        and set a QR code`}{' '}
+          </span>
+        </div>
+      );
+    }
+
+    return (
+      <div className="mtw:flex mtw:flex-col">
+        {bankAccount?.bank_name && (
+          <p>
+            {t(i18n)`Bank name`}: {bankAccount?.bank_name}
+          </p>
+        )}
+        {bankAccount?.iban && (
+          <p>
+            {t(i18n)`IBAN`}: {bankAccount?.iban}
+          </p>
+        )}
+        {bankAccount?.bic && (
+          <p>
+            {t(i18n)`BIC`}: {bankAccount?.bic}
+          </p>
+        )}
+        {bankAccount?.account_number && (
+          <p>
+            {t(i18n)`Account number`}: {bankAccount?.account_number}
+          </p>
+        )}
+        {bankAccount?.routing_number && (
+          <p>
+            {t(i18n)`Routing number`}: {bankAccount?.routing_number}
+          </p>
+        )}
+        {bankAccount?.sort_code && (
+          <p>
+            {t(i18n)`Sort code`}: {bankAccount?.sort_code}
+          </p>
+        )}
+      </div>
+    );
   };
 
   const groupedItems = groupItemsByTaxRate(sanitizedItems);
@@ -389,7 +441,7 @@ export const InvoicePreview = ({
           </div>
         </article>
         <footer>
-          <section>
+          <section style={{ gap: '15mm' }}>
             <aside className="footer-aside footer-aside__start">
               <div className="block-entity-info">
                 <div>
@@ -426,14 +478,9 @@ export const InvoicePreview = ({
               <aside>
                 <div>
                   <div>
-                    <span>{t(i18n)`Payment Details`}:</span>
+                    <span>{t(i18n)`Payment Details`}</span>
                   </div>
-                  <div>
-                    <span className="not-set">
-                      {t(i18n)`Set up bank account to add payment info
-                  and set a QR code`}{' '}
-                    </span>
-                  </div>
+                  {renderBankAccountDetails()}
                 </div>
               </aside>
               <aside>

--- a/packages/sdk-react/src/components/receivables/components/BankAccountDeleteModal.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountDeleteModal.tsx
@@ -1,14 +1,7 @@
 import { useRootElements } from '@/core/context/RootElementsProvider';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import {
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Divider,
-} from '@mui/material';
+import { Box, Button, Dialog, Typography } from '@mui/material';
 
 interface BankAccountDeleteModalProps {
   open: boolean;
@@ -35,13 +28,37 @@ export const BankAccountDeleteModal = ({
       maxWidth="sm"
       fullWidth
     >
-      <DialogTitle variant="h3">{t(i18n)`Delete bank account?`}</DialogTitle>
-      <DialogContent>{t(
-        i18n
-      )`You might need to update draft documents created with this bank account to ensure a correct payment.`}</DialogContent>
-      <Divider />
-      <DialogActions>
-        <Button variant="outlined" onClick={onClose} color="inherit">{t(
+      <Box px={4} pt={4} pb={3}>
+        <Typography
+          variant="h3"
+          fontWeight={600}
+          fontSize={24}
+          lineHeight="32px"
+        >
+          {t(i18n)`Delete bank account?`}
+        </Typography>
+      </Box>
+      <Box px={4}>
+        <Typography variant="body1">
+          {t(
+            i18n
+          )`Draft or already issued invoices will keep this bank account. If required, you will need to manually update those invoices with new account information.`}
+        </Typography>
+      </Box>
+
+      <Box
+        height={96}
+        px={4}
+        pt={2}
+        pb={2}
+        sx={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          gap: 2,
+        }}
+      >
+        <Button variant="text" onClick={onClose} color="primary">{t(
           i18n
         )`Cancel`}</Button>
         <Button
@@ -51,7 +68,7 @@ export const BankAccountDeleteModal = ({
           onClick={handleDelete}
           autoFocus
         >{t(i18n)`Delete`}</Button>
-      </DialogActions>
+      </Box>
     </Dialog>
   );
 };

--- a/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
@@ -59,7 +59,7 @@ export const BankAccountFormContent = ({
   const currentEntityCurrency = countryCurrencyList?.find(
     (item) => item.country === entity?.address?.country
   );
-  const { mutate: setAsDefault } = useSetDefaultBankAccount(false);
+  const { mutate: setAsDefault } = useSetDefaultBankAccount(false, false);
 
   const countryOptions = useMemo(
     () =>
@@ -72,7 +72,7 @@ export const BankAccountFormContent = ({
   );
 
   const defaultValues: EntityBankAccountFields = {
-    is_default_for_currency: bankAccount?.is_default_for_currency ?? false,
+    is_default_for_currency: false,
     country:
       bankAccount?.country ??
       (currentEntityCurrency?.country as components['schemas']['AllowedCountries']),

--- a/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
@@ -1,5 +1,4 @@
-// import { useEffect } from 'react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { components } from '@/api';
@@ -12,9 +11,7 @@ import { MoniteCurrency } from '@/ui/Currency';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
 import {
-  Alert,
   Box,
   FormControl,
   FormHelperText,
@@ -62,7 +59,6 @@ export const BankAccountFormContent = ({
   const currentEntityCurrency = countryCurrencyList?.find(
     (item) => item.country === entity?.address?.country
   );
-  const [shouldDisplayWarning, setShouldDisplayWarning] = useState(true);
   const { mutate: setAsDefault } = useSetDefaultBankAccount(false);
 
   const countryOptions = useMemo(
@@ -151,18 +147,6 @@ export const BankAccountFormContent = ({
   return (
     <form id={formId} onSubmit={handleSubmit(submitForm)} noValidate>
       <Stack spacing={2}>
-        {bankAccount?.is_default_for_currency && shouldDisplayWarning && (
-          <Alert
-            icon={<WarningAmberRoundedIcon />}
-            severity="error"
-            onClose={() => setShouldDisplayWarning(false)}
-          >
-            {t(
-              i18n
-            )`You can't delete a default account. To delete a default bank account, you must first assign a new default account for the same currency.`}
-          </Alert>
-        )}
-
         <Typography fontWeight={400} variant="body1">{t(
           i18n
         )`This bank account will receive payments for your invoices`}</Typography>

--- a/packages/sdk-react/src/components/receivables/components/BankAccountFormDialog.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountFormDialog.tsx
@@ -103,6 +103,9 @@ const BankAccountFormDialogBase = ({
   const isMutating =
     isCreatingBankAccount || isUpdatingBankAccount || isDeletingBankAccount;
 
+  const shouldEnableDelete =
+    bankAccount && !bankAccount?.is_default_for_currency;
+
   const createBankAccount = (
     payload: components['schemas']['CreateEntityBankAccountRequest']
   ) => {
@@ -154,10 +157,10 @@ const BankAccountFormDialogBase = ({
         <DialogActions
           sx={{
             display: 'flex',
-            justifyContent: bankAccount ? 'space-between' : 'flex-end',
+            justifyContent: shouldEnableDelete ? 'space-between' : 'flex-end',
           }}
         >
-          {bankAccount && (
+          {shouldEnableDelete && (
             <Button
               type="button"
               variant="text"
@@ -193,7 +196,7 @@ const BankAccountFormDialogBase = ({
         </DialogActions>
       </Dialog>
 
-      {isDeleteModalOpen && bankAccount && (
+      {isDeleteModalOpen && shouldEnableDelete && (
         <BankAccountDeleteModal
           open={isDeleteModalOpen}
           onClose={() => setIsDeleteModalOpen(false)}
@@ -203,18 +206,14 @@ const BankAccountFormDialogBase = ({
               path: { bank_account_id: bankAccount?.id },
             });
 
-            if (!bankAccount?.is_default_for_currency) {
-              const foundDefaultBank = bankAccounts?.find((bank) => {
-                bank?.currency === bankAccount?.currency &&
-                  bank?.is_default_for_currency;
-              });
+            const foundDefaultBank = bankAccounts?.find((bank) => {
+              bank?.currency === bankAccount?.currency &&
+                bank?.is_default_for_currency;
+            });
 
-              handleSelectBankAfterDeletion?.(
-                foundDefaultBank ? foundDefaultBank?.id : ''
-              );
-
-              return;
-            }
+            handleSelectBankAfterDeletion?.(
+              foundDefaultBank ? foundDefaultBank?.id : ''
+            );
           }}
         />
       )}

--- a/packages/sdk-react/src/components/receivables/components/BankAccountSection.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountSection.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from 'react-hook-form';
 
+import { components } from '@/api';
 import { CreateReceivablesFormProps } from '@/components/receivables/InvoiceDetails/CreateReceivable/validation';
 import { RHFTextField } from '@/components/RHF/RHFTextField';
 import { t } from '@lingui/macro';
@@ -19,11 +20,13 @@ import { useGetEntityBankAccounts } from '../hooks';
 type Props = {
   disabled?: boolean;
   handleOpenBankModal: (id?: string) => void;
+  entityCurrency?: components['schemas']['CurrencyEnum'];
 };
 
 export const BankAccountSection = ({
   disabled,
   handleOpenBankModal,
+  entityCurrency,
 }: Props) => {
   const { i18n } = useLingui();
   const theme = useTheme();
@@ -120,7 +123,7 @@ export const BankAccountSection = ({
               </Box>
 
               <Box display="flex" alignItems="center" gap={2}>
-                {is_default_for_currency && (
+                {entityCurrency === currency && is_default_for_currency && (
                   <Chip
                     label={t(i18n)`Default`}
                     sx={{

--- a/packages/sdk-react/src/components/receivables/components/BankAccountSection.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountSection.tsx
@@ -75,6 +75,7 @@ export const BankAccountSection = ({
             currency,
             account_number,
             is_default_for_currency,
+            iban,
           }) => (
             <MenuItem
               key={id}
@@ -108,9 +109,9 @@ export const BankAccountSection = ({
                   {display_name && `${display_name} `}
 
                   <Typography component="span" color={theme.palette.grey[400]}>
-                    {`${display_name && '|'} ${
-                      bank_name && bank_name
-                    } ****${account_number
+                    {`${display_name && '|'} ${bank_name && bank_name} ****${(
+                      account_number || iban
+                    )
                       ?.split('')
                       ?.slice(-4, undefined)
                       ?.join('')}, ${currency}`}

--- a/packages/sdk-react/src/components/receivables/hooks/useCreateEntityBankAccount.ts
+++ b/packages/sdk-react/src/components/receivables/hooks/useCreateEntityBankAccount.ts
@@ -17,8 +17,10 @@ export const useCreateEntityBankAccount = (onCreate?: (id: string) => void) => {
       );
     },
 
-    onError: () => {
-      toast.error(t(i18n)`Failed to create Bank Account.`);
+    onError: (error: any) => {
+      toast.error(
+        error?.detail?.[0]?.msg || t(i18n)`Failed to create Bank Account.`
+      );
     },
   });
 };

--- a/packages/sdk-react/src/components/receivables/hooks/useSetDefaultBankAccount.ts
+++ b/packages/sdk-react/src/components/receivables/hooks/useSetDefaultBankAccount.ts
@@ -4,7 +4,10 @@ import { useMoniteContext } from '@/core/context/MoniteContext';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
-export const useSetDefaultBankAccount = (shouldInvalidate = true) => {
+export const useSetDefaultBankAccount = (
+  shouldInvalidate = true,
+  shouldDisplaySuccessToast = true
+) => {
   const { i18n } = useLingui();
   const { api, queryClient } = useMoniteContext();
 
@@ -13,7 +16,10 @@ export const useSetDefaultBankAccount = (shouldInvalidate = true) => {
       if (shouldInvalidate) {
         await api.bankAccounts.getBankAccounts.invalidateQueries(queryClient);
       }
-      toast.success(t(i18n)`Bank Account has been set as default.`);
+
+      if (shouldDisplaySuccessToast) {
+        toast.success(t(i18n)`Bank Account has been set as default.`);
+      }
     },
 
     onError: () => {

--- a/packages/sdk-react/src/components/receivables/hooks/useUpdateEntityBankAccount.ts
+++ b/packages/sdk-react/src/components/receivables/hooks/useUpdateEntityBankAccount.ts
@@ -14,19 +14,7 @@ export const useUpdateEntityBankAccount = (onUpdate?: () => void) => {
         t(i18n)`Bank Account “${bank.display_name}” has been updated.`
       );
 
-      api.bankAccounts.getBankAccountsId.setQueryData(
-        {
-          path: {
-            bank_account_id: bank.id,
-          },
-        },
-        (prevBankAccount) => ({
-          ...prevBankAccount,
-          ...bank,
-        }),
-        queryClient
-      );
-
+      await api.bankAccounts.getBankAccountsId.invalidateQueries(queryClient);
       await api.bankAccounts.getBankAccounts.invalidateQueries(queryClient);
       onUpdate && onUpdate();
     },

--- a/packages/sdk-react/src/components/receivables/utils/prepareBankAccountPayload.ts
+++ b/packages/sdk-react/src/components/receivables/utils/prepareBankAccountPayload.ts
@@ -29,7 +29,7 @@ export const prepareBankAccountCreatePayload = (
         };
       case 'EUR':
         return {
-          bic: reqPayload?.bic,
+          bic: reqPayload?.bic || undefined,
           iban: reqPayload?.iban,
         };
 

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -288,7 +288,7 @@ msgstr "Add a business executive"
 msgid "Add a business owner"
 msgstr "Add a business owner"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:596
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:628
 msgid "Add a date when the product will be delivered or the service provided"
 msgstr "Add a date when the product will be delivered or the service provided"
 
@@ -360,7 +360,7 @@ msgid "Add item"
 msgstr "Add item"
 
 #: src/components/receivables/components/BankAccountFormDialog.tsx:141
-#: src/components/receivables/components/BankAccountSection.tsx:65
+#: src/components/receivables/components/BankAccountSection.tsx:68
 msgid "Add new bank account"
 msgstr "Add new bank account"
 
@@ -523,7 +523,7 @@ msgstr "All invoices"
 msgid "All items"
 msgstr "All items"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:520
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:552
 msgid "All items in the invoice must be in this currency. Remove items that don’t match it."
 msgstr "All items in the invoice must be in this currency. Remove items that don’t match it."
 
@@ -561,7 +561,7 @@ msgstr "Allowed"
 msgid "Already updated PDFs can't be reverted to the default view"
 msgstr "Already updated PDFs can't be reverted to the default view"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:708
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:740
 msgid "Always display selected fields on the form (where available)"
 msgstr "Always display selected fields on the form (where available)"
 
@@ -1016,7 +1016,7 @@ msgstr "Bank account delete confirmation"
 msgid "Bank Account has been deleted."
 msgstr "Bank Account has been deleted."
 
-#: src/components/receivables/hooks/useSetDefaultBankAccount.ts:16
+#: src/components/receivables/hooks/useSetDefaultBankAccount.ts:21
 msgid "Bank Account has been set as default."
 msgstr "Bank Account has been set as default."
 
@@ -1369,8 +1369,8 @@ msgstr "Canadian Dollar"
 #: src/components/receivables/components/BankAccountDeleteModal.tsx:61
 #: src/components/receivables/components/BankAccountFormDialog.tsx:183
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:541
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:543
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:730
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:575
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:762
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:445
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:40
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:87
@@ -1527,7 +1527,7 @@ msgstr "CFP Franc"
 msgid "Chad"
 msgstr "Chad"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:494
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:526
 msgid "Change document currency"
 msgstr "Change document currency"
 
@@ -2091,7 +2091,7 @@ msgstr "Create customer"
 msgid "Create from email"
 msgstr "Create from email"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:771
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:803
 msgid "Create invoice"
 msgstr "Create invoice"
 
@@ -2238,7 +2238,7 @@ msgstr "Cuba"
 #: src/components/onboarding/validators/validationSchemas.ts:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:149
 #: src/components/products/ProductDetails/validation.ts:48
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:466
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:498
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:13
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:85
 #: src/components/receivables/validation.ts:31
@@ -2357,7 +2357,7 @@ msgid "default"
 msgstr "default"
 
 #: src/components/documentDesign/components/DocumentDesignTemplate/DocumentDesignTemplate.tsx:59
-#: src/components/receivables/components/BankAccountSection.tsx:125
+#: src/components/receivables/components/BankAccountSection.tsx:128
 msgid "Default"
 msgstr "Default"
 
@@ -2544,7 +2544,7 @@ msgstr "Description is required"
 
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:453
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:221
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:799
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:831
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:45
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:19
 msgid "Details"
@@ -2831,7 +2831,7 @@ msgstr "Ecuador"
 #: src/components/products/Products.test.tsx:175
 #: src/components/products/Products.test.tsx:272
 #: src/components/products/ProductsTable/ProductsTable.test.tsx:246
-#: src/components/receivables/components/BankAccountSection.tsx:142
+#: src/components/receivables/components/BankAccountSection.tsx:145
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/CounterpartSelector.tsx:270
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderSection/RemindersSection.tsx:413
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrence.tsx:94
@@ -3038,8 +3038,8 @@ msgstr "Employment/Temp Agencies"
 msgid "Enable email reminders"
 msgstr "Enable email reminders"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:470
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:577
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:502
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:609
 msgid "Enable more fields"
 msgstr "Enable more fields"
 
@@ -3232,7 +3232,7 @@ msgstr "Failed to load PDF Viewer"
 msgid "Failed to mark invoice as paid: {errorMessage}"
 msgstr "Failed to mark invoice as paid: {errorMessage}"
 
-#: src/components/receivables/hooks/useSetDefaultBankAccount.ts:20
+#: src/components/receivables/hooks/useSetDefaultBankAccount.ts:26
 msgid "Failed to set Bank Account as default."
 msgstr "Failed to set Bank Account as default."
 
@@ -3244,7 +3244,7 @@ msgstr "Failed to update"
 msgid "Failed to update Address."
 msgstr "Failed to update Address."
 
-#: src/components/receivables/hooks/useUpdateEntityBankAccount.ts:35
+#: src/components/receivables/hooks/useUpdateEntityBankAccount.ts:23
 #: src/core/queries/useCounterpart.ts:156
 msgid "Failed to update Bank Account."
 msgstr "Failed to update Bank Account."
@@ -3496,8 +3496,8 @@ msgstr "Front of your identity document"
 msgid "Fuel Dealers (Non Automotive)"
 msgstr "Fuel Dealers (Non Automotive)"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:593
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:612
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:625
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:644
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:153
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:293
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:139
@@ -4095,7 +4095,7 @@ msgstr "Invoice to “{0}” was created"
 msgid "Invoice total"
 msgstr "Invoice total"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:497
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:529
 msgid "Invoice will be issued with items in the selected currency"
 msgstr "Invoice will be issued with items in the selected currency"
 
@@ -6041,8 +6041,8 @@ msgstr "Public Warehousing and Storage - Farm Products, Refrigerated Goods, Hous
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:631
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:650
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:663
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:682
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:74
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:141
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:195
@@ -6124,7 +6124,7 @@ msgstr "Receivable type not supported"
 msgid "Receivables tabs"
 msgstr "Receivables tabs"
 
-#: src/components/receivables/components/BankAccountSection.tsx:39
+#: src/components/receivables/components/BankAccountSection.tsx:42
 msgid "Receive payments to"
 msgstr "Receive payments to"
 
@@ -6528,8 +6528,8 @@ msgstr "Saudi Riyal"
 #: src/components/payables/PayableDetails/PayableDetails.test.tsx:347
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:82
 #: src/components/receivables/components/BankAccountFormDialog.tsx:193
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:549
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:736
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:581
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:768
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:451
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:40
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceForm.tsx:352
@@ -6542,7 +6542,7 @@ msgstr "Saudi Riyal"
 msgid "Save"
 msgstr "Save"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:752
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:784
 msgid "Save and continue"
 msgstr "Save and continue"
 
@@ -7199,8 +7199,8 @@ msgstr "Tent and Awning Shops"
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:123
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:124
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:669
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:688
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:701
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:720
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:106
 msgid "Terms and conditions"
 msgstr "Terms and conditions"
@@ -8232,7 +8232,7 @@ msgstr "Yemeni Rial"
 msgid "Yes"
 msgstr "Yes"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:634
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:666
 msgid "You can add a document number to have it in the PDF"
 msgstr "You can add a document number to have it in the PDF"
 
@@ -8280,7 +8280,7 @@ msgstr "You can create your first tag."
 msgid "You can disable it later in the PDF settings"
 msgstr "You can disable it later in the PDF settings"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:672
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:704
 msgid "You can include details about the warranty, insurance, liability, late payment fees and any other important notes"
 msgstr "You can include details about the warranty, insurance, liability, late payment fees and any other important notes"
 

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -72,7 +72,7 @@ msgstr "{0} - {1}"
 msgid "{0} ({code})"
 msgstr "{0} ({code})"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:291
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:343
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:47
 msgid "{0} days"
 msgstr "{0} days"
@@ -101,7 +101,7 @@ msgstr "{0}% advance rate"
 msgid "{0}% advance rate, Pay in {1} days, {2}% fee"
 msgstr "{0}% advance rate, Pay in {1} days, {2}% fee"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:266
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:318
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:32
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:40
 msgid "{0}% discount"
@@ -111,7 +111,7 @@ msgstr "{0}% discount"
 msgid "{0}% fee"
 msgstr "{0}% fee"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:281
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:333
 msgid "{0}%discount"
 msgstr "{0}%discount"
 
@@ -232,6 +232,7 @@ msgstr "Account name"
 #: src/components/receivables/components/BankAccountCustomFields.tsx:79
 #: src/components/receivables/components/BankAccountCustomFields.tsx:139
 #: src/components/receivables/components/BankAccountCustomFields.tsx:238
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:198
 #: src/components/receivables/validation.ts:45
 msgid "Account number"
 msgstr "Account number"
@@ -265,7 +266,7 @@ msgstr "Active"
 #: src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx:1180
 #: src/components/onboarding/hooks/useOnboardingActions.ts:136
 #: src/components/products/ProductDetails/components/ManageMeasureUnitsForm/components/MeasureUnitsFormRow/MeasureUnitsFormRow.tsx:216
-#: src/components/receivables/components/BankAccountFormDialog.tsx:190
+#: src/components/receivables/components/BankAccountFormDialog.tsx:193
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:544
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.test.tsx:142
 msgid "Add"
@@ -358,7 +359,7 @@ msgstr "Add Discount"
 msgid "Add item"
 msgstr "Add item"
 
-#: src/components/receivables/components/BankAccountFormDialog.tsx:138
+#: src/components/receivables/components/BankAccountFormDialog.tsx:141
 #: src/components/receivables/components/BankAccountSection.tsx:65
 msgid "Add new bank account"
 msgstr "Add new bank account"
@@ -1002,11 +1003,11 @@ msgstr "Bank Account “{0}” has been created."
 msgid "Bank Account “{0}” has been updated."
 msgstr "Bank Account “{0}” has been updated."
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:88
+#: src/components/receivables/components/BankAccountFormContent.tsx:84
 msgid "Bank account {0}"
 msgstr "Bank account {0}"
 
-#: src/components/receivables/components/BankAccountDeleteModal.tsx:34
+#: src/components/receivables/components/BankAccountDeleteModal.tsx:27
 msgid "Bank account delete confirmation"
 msgstr "Bank account delete confirmation"
 
@@ -1027,7 +1028,8 @@ msgstr "Bank account holder name"
 msgid "Bank accounts"
 msgstr "Bank accounts"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:245
+#: src/components/receivables/components/BankAccountFormContent.tsx:229
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:183
 #: src/components/receivables/validation.ts:35
 msgid "Bank name"
 msgstr "Bank name"
@@ -1101,6 +1103,7 @@ msgid "Bhutanese Ngultrum"
 msgstr "Bhutanese Ngultrum"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:190
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:193
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:36
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:37
 msgid "BIC"
@@ -1363,8 +1366,8 @@ msgstr "Canadian Dollar"
 #: src/components/products/ProductDetails/components/ConfirmDeleteMeasureUnitDialogue/ConfirmDeleteMeasureUnitDialogue.tsx:134
 #: src/components/products/ProductDetails/ProductCreate/CreateProduct.tsx:182
 #: src/components/products/ProductDetails/ProductEditForm/ProductEditForm.tsx:256
-#: src/components/receivables/components/BankAccountDeleteModal.tsx:44
-#: src/components/receivables/components/BankAccountFormDialog.tsx:180
+#: src/components/receivables/components/BankAccountDeleteModal.tsx:61
+#: src/components/receivables/components/BankAccountFormDialog.tsx:183
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:541
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:543
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:730
@@ -1980,8 +1983,8 @@ msgstr "Counterparts"
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:26
 #: src/components/onboarding/validators/validationSchemas.ts:115
 #: src/components/onboarding/validators/validationSchemas.ts:155
-#: src/components/receivables/components/BankAccountFormContent.tsx:182
-#: src/components/receivables/components/BankAccountFormContent.tsx:185
+#: src/components/receivables/components/BankAccountFormContent.tsx:166
+#: src/components/receivables/components/BankAccountFormContent.tsx:169
 #: src/components/receivables/validation.ts:27
 msgid "Country"
 msgstr "Country"
@@ -2264,7 +2267,7 @@ msgstr "Current status"
 #: src/components/receivables/components/QuotesTable.tsx:190
 #: src/components/receivables/components/ReceivableFilters.tsx:104
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/CounterpartSelector.tsx:199
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:186
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:238
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/OverviewTabPanel.tsx:139
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewCustomerSection.tsx:56
 msgid "Customer"
@@ -2354,11 +2357,11 @@ msgid "default"
 msgstr "default"
 
 #: src/components/documentDesign/components/DocumentDesignTemplate/DocumentDesignTemplate.tsx:59
-#: src/components/receivables/components/BankAccountSection.tsx:124
+#: src/components/receivables/components/BankAccountSection.tsx:125
 msgid "Default"
 msgstr "Default"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:277
+#: src/components/receivables/components/BankAccountFormContent.tsx:261
 msgid "Default currency switch"
 msgstr "Default currency switch"
 
@@ -2386,8 +2389,8 @@ msgstr "Default currency switch"
 #: src/components/products/Products.test.tsx:203
 #: src/components/products/Products.test.tsx:235
 #: src/components/products/ProductsTable/ProductsTable.test.tsx:270
-#: src/components/receivables/components/BankAccountDeleteModal.tsx:53
-#: src/components/receivables/components/BankAccountFormDialog.tsx:168
+#: src/components/receivables/components/BankAccountDeleteModal.tsx:70
+#: src/components/receivables/components/BankAccountFormDialog.tsx:171
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:48
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DiscountForm.tsx:80
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:84
@@ -2634,7 +2637,7 @@ msgstr "Discount Stores"
 msgid "Discounted subtotal"
 msgstr "Discounted subtotal"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:228
+#: src/components/receivables/components/BankAccountFormContent.tsx:212
 #: src/components/receivables/validation.ts:14
 #: src/components/receivables/validation.ts:40
 msgid "Display name"
@@ -2701,6 +2704,10 @@ msgstr "Download PDF"
 msgid "Draft"
 msgstr "Draft"
 
+#: src/components/receivables/components/BankAccountDeleteModal.tsx:43
+msgid "Draft or already issued invoices will keep this bank account. If required, you will need to manually update those invoices with new account information."
+msgstr "Draft or already issued invoices will keep this bank account. If required, you will need to manually update those invoices with new account information."
+
 #: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:158
 msgid "Drag & Drop it here to save for administrative purposes."
 msgstr "Drag & Drop it here to save for administrative purposes."
@@ -2740,7 +2747,7 @@ msgstr "Dry Cleaners"
 #: src/components/receivables/components/InvoicesTable.tsx:355
 #: src/components/receivables/components/QuotesTable.tsx:200
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:110
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:231
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:283
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:235
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:420
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/reminderCardTermsHelpers.tsx:45
@@ -2824,7 +2831,7 @@ msgstr "Ecuador"
 #: src/components/products/Products.test.tsx:175
 #: src/components/products/Products.test.tsx:272
 #: src/components/products/ProductsTable/ProductsTable.test.tsx:246
-#: src/components/receivables/components/BankAccountSection.tsx:141
+#: src/components/receivables/components/BankAccountSection.tsx:142
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/CounterpartSelector.tsx:270
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderSection/RemindersSection.tsx:413
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrence.tsx:94
@@ -2860,7 +2867,7 @@ msgstr "Edit {0} profile"
 msgid "Edit Approval Policy"
 msgstr "Edit Approval Policy"
 
-#: src/components/receivables/components/BankAccountFormDialog.tsx:137
+#: src/components/receivables/components/BankAccountFormDialog.tsx:140
 msgid "Edit bank account"
 msgstr "Edit bank account"
 
@@ -3159,7 +3166,7 @@ msgstr "Failed to a create payment link. Please try again."
 msgid "Failed to create"
 msgstr "Failed to create"
 
-#: src/components/receivables/hooks/useCreateEntityBankAccount.ts:21
+#: src/components/receivables/hooks/useCreateEntityBankAccount.ts:22
 #: src/core/queries/useCounterpart.ts:98
 msgid "Failed to create Bank Account."
 msgstr "Failed to create Bank Account."
@@ -3492,7 +3499,7 @@ msgstr "Fuel Dealers (Non Automotive)"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:593
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:612
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:153
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:241
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:293
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:139
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:193
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:30
@@ -3858,6 +3865,7 @@ msgstr "I own 25% or more of the company."
 #: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:133
 #: src/components/onboarding/validators/validationSchemas.ts:122
 #: src/components/receivables/components/BankAccountCustomFields.tsx:199
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:188
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:31
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:45
 #: src/components/receivables/validation.ts:79
@@ -4010,7 +4018,7 @@ msgstr "Invalid website URL. Please ensure it starts with 'http://' or 'https://
 #: src/components/receivables/components/QuotesTable.tsx:238
 #: src/components/receivables/components/QuotesTable.tsx:304
 #: src/components/receivables/components/QuotesTable.tsx:306
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:171
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:223
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/EditInvoiceDetails.tsx:314
 msgid "Invoice"
 msgstr "Invoice"
@@ -4162,7 +4170,7 @@ msgstr "Issue at"
 #: src/components/receivables/components/CreditNotesTable.tsx:155
 #: src/components/receivables/components/InvoicesTable.tsx:329
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:85
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:228
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:280
 msgid "Issue date"
 msgstr "Issue date"
 
@@ -5100,7 +5108,7 @@ msgstr "No default email for selected Counterpart. Reminders will not be sent."
 msgid "No file provided"
 msgstr "No file provided"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:350
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:402
 msgid "No items"
 msgstr "No items"
 
@@ -5108,7 +5116,7 @@ msgstr "No items"
 msgid "No items yet"
 msgstr "No items yet"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:179
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:231
 msgid "No logo"
 msgstr "No logo"
 
@@ -5231,9 +5239,9 @@ msgid "Not available"
 msgstr "Not available"
 
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:405
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:190
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:235
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:254
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:242
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:287
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:306
 #: src/components/tags/TagFormModal/TagFormModal.tsx:204
 msgid "Not set"
 msgstr "Not set"
@@ -5471,8 +5479,8 @@ msgstr "Pay in"
 msgid "Pay in {0} days"
 msgstr "Pay in {0} days"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:260
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:275
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:312
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:327
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:31
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:39
 msgid "Pay in the first {0} days"
@@ -5540,12 +5548,12 @@ msgstr "Payment"
 msgid "Payment details"
 msgstr "Payment details"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:429
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:481
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:23
 msgid "Payment Details"
 msgstr "Payment Details"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:290
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:342
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsForm.tsx:153
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:46
 msgid "Payment due"
@@ -5593,7 +5601,7 @@ msgstr "Payment term successfully deleted"
 msgid "Payment term updated"
 msgstr "Payment term updated"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:249
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:301
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/PaymentSection.tsx:73
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:157
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:210
@@ -5914,7 +5922,7 @@ msgstr "Previous page"
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:449
 #: src/components/payables/PayableDetails/PayableLineItemsForm/PayableLineItemsForm.tsx:107
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:127
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:313
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:365
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:487
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:89
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:92
@@ -5946,7 +5954,7 @@ msgstr "Processing..."
 #: src/components/products/ProductDetails/components/ProductType/ProductType.tsx:17
 #: src/components/products/ProductsTable/ProductsTable.tsx:315
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTableFilters.tsx:72
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:309
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:361
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:73
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:104
 #: src/components/userRoles/consts.ts:43
@@ -6050,7 +6058,7 @@ msgstr "Qatar"
 msgid "Qatari Rial"
 msgstr "Qatari Rial"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:310
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:362
 msgid "Qty"
 msgstr "Qty"
 
@@ -6414,6 +6422,7 @@ msgstr "Roofing/Siding, Sheet Metal"
 #: src/components/receivables/components/BankAccountCustomFields.tsx:99
 #: src/components/receivables/components/BankAccountCustomFields.tsx:277
 #: src/components/receivables/components/BankAccountCustomFields.tsx:291
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:203
 #: src/components/receivables/validation.ts:61
 msgid "Routing number"
 msgstr "Routing number"
@@ -6518,7 +6527,7 @@ msgstr "Saudi Riyal"
 #: src/components/payables/PayableDetails/PayableDetails.test.tsx:280
 #: src/components/payables/PayableDetails/PayableDetails.test.tsx:347
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:82
-#: src/components/receivables/components/BankAccountFormDialog.tsx:190
+#: src/components/receivables/components/BankAccountFormDialog.tsx:193
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:549
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:736
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:451
@@ -6679,7 +6688,7 @@ msgstr "Set a recurrence period to issue invoices automatically"
 msgid "Set as default"
 msgstr "Set as default"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:279
+#: src/components/receivables/components/BankAccountFormContent.tsx:263
 msgid "Set as default for this currency"
 msgstr "Set as default for this currency"
 
@@ -6700,7 +6709,7 @@ msgstr "Set reminders"
 msgid "Set this counterpart as:"
 msgstr "Set this counterpart as:"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:433
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:172
 msgid ""
 "Set up bank account to add payment info\n"
 "and set a QR code"
@@ -6828,6 +6837,7 @@ msgstr "Something went wrong. Please try again"
 #: src/components/receivables/components/BankAccountCustomFields.tsx:159
 #: src/components/receivables/components/BankAccountCustomFields.tsx:279
 #: src/components/receivables/components/BankAccountCustomFields.tsx:309
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:208
 #: src/components/receivables/validation.ts:70
 msgid "Sort code"
 msgstr "Sort code"
@@ -6971,7 +6981,7 @@ msgstr "Submit invoice"
 
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:728
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:497
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:361
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:413
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:748
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:158
 #: src/components/receivables/InvoiceDetails/InvoiceTotal/InvoiceTotal.tsx:31
@@ -7087,7 +7097,7 @@ msgstr "Tanzania"
 msgid "Tanzanian Shilling"
 msgstr "Tanzanian Shilling"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:315
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:367
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:491
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:53
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:61
@@ -7105,8 +7115,8 @@ msgstr "Tax ID"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:217
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:381
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:398
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:214
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:413
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:266
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:465
 msgid "TAX ID"
 msgstr "TAX ID"
 
@@ -7339,7 +7349,7 @@ msgstr "They will contact you if your credit score improves and you can reapply.
 msgid "This action can't be undone."
 msgstr "This action can't be undone."
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:166
+#: src/components/receivables/components/BankAccountFormContent.tsx:150
 msgid "This bank account will receive payments for your invoices"
 msgstr "This bank account will receive payments for your invoices"
 
@@ -7453,7 +7463,7 @@ msgstr "Tongan Paʻanga"
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:825
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:336
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:535
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:380
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:432
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/ItemsSection.tsx:762
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewItemsSection.tsx:173
 #: src/components/receivables/InvoiceDetails/InvoiceItems/InvoiceItems.tsx:38
@@ -7476,7 +7486,7 @@ msgstr "Total Amount"
 msgid "Total amount for <0>{totalPendingInvoices}</0> canceled {invoicesPluralForm}: <1>{pendingInvoicesTotalAmountWithCreditNotes}</1>"
 msgstr "Total amount for <0>{totalPendingInvoices}</0> canceled {invoicesPluralForm}: <1>{pendingInvoicesTotalAmountWithCreditNotes}</1>"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:369
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:421
 msgid "Total Tax"
 msgstr "Total Tax"
 
@@ -7710,7 +7720,7 @@ msgstr "United States Outlying Islands"
 
 #: src/components/products/ProductDetails/validation.ts:31
 #: src/components/products/ProductsTable/components/Filters/Filters.tsx:88
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:311
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:363
 msgid "Units"
 msgstr "Units"
 
@@ -8004,8 +8014,8 @@ msgstr "Vat ID"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:222
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:342
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:348
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:219
-#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:418
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:271
+#: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:470
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/VatAndTaxValidator.tsx:49
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:131
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:134
@@ -8287,8 +8297,8 @@ msgid "You can set up to 2 early payment discounts per invoice."
 msgstr "You can set up to 2 early payment discounts per invoice."
 
 #: src/components/receivables/components/BankAccountFormContent.tsx:160
-msgid "You can't delete a default account. To delete a default bank account, you must first assign a new default account for the same currency."
-msgstr "You can't delete a default account. To delete a default bank account, you must first assign a new default account for the same currency."
+#~ msgid "You can't delete a default account. To delete a default bank account, you must first assign a new default account for the same currency."
+#~ msgstr "You can't delete a default account. To delete a default bank account, you must first assign a new default account for the same currency."
 
 #: src/components/userRoles/UserRoleDetails/UserRoleDeleteDialog/UserRoleDeleteDialog.tsx:71
 msgid "You can’t undo this action."
@@ -8356,8 +8366,8 @@ msgid "You haven't accepted the offer and it has expired"
 msgstr "You haven't accepted the offer and it has expired"
 
 #: src/components/receivables/components/BankAccountDeleteModal.tsx:39
-msgid "You might need to update draft documents created with this bank account to ensure a correct payment."
-msgstr "You might need to update draft documents created with this bank account to ensure a correct payment."
+#~ msgid "You might need to update draft documents created with this bank account to ensure a correct payment."
+#~ msgstr "You might need to update draft documents created with this bank account to ensure a correct payment."
 
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:35
 msgid "You won't be able to use it to create new invoices, but it won't affect the existing invoices with this term and their future copies."


### PR DESCRIPTION
- Added proper error handling on bank account creation when it fails displaying the actual error message instead of a generic one

- Updated invoice preview with bank account information (This is probably a temporary fix because we might replace the current preview with the new templates)

- Updated delete bank account modal visuals to be more like the figma version

- Fixed issue displaying undefined when the account was EUR, it was undefined because it was trying to read account number but EUR accounts only have IBAN

- Removed alert message and delete button from default bank account edit states