### PR TITLE
fix(DEV-14898): Counterpart bank account selection show bank account name

### DIFF
--- a/.changeset/few-fireants-kick.md
+++ b/.changeset/few-fireants-kick.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Fix Payable Counterpart Bank Account selection to show Bank Account name

--- a/packages/sdk-react/src/core/utils/getBankAccountName.tsx
+++ b/packages/sdk-react/src/core/utils/getBankAccountName.tsx
@@ -6,7 +6,7 @@ import { t } from '@lingui/macro';
 
 export const getBankAccountName = (
   i18n: I18n,
-  bankAccount: components['schemas']['EntityBankAccountResponse']
+  bankAccount: components['schemas']['CounterpartBankAccountResponse']
 ) => {
   const bankAccountName = getBankAccountBaseName(i18n, bankAccount);
 
@@ -19,14 +19,10 @@ export const getBankAccountName = (
 
 const getBankAccountBaseName = (
   i18n: I18n,
-  bankAccount: components['schemas']['EntityBankAccountResponse']
+  bankAccount: components['schemas']['CounterpartBankAccountResponse']
 ) => {
-  if (bankAccount.display_name) {
-    return bankAccount.display_name;
-  }
-
-  if (bankAccount.bank_name) {
-    return bankAccount.bank_name;
+  if (bankAccount.name) {
+    return bankAccount.name;
   }
 
   if (bankAccount.country && bankAccount.currency) {


### PR DESCRIPTION
# Scope

Fix Payable Counterpart Bank Account selection to show Bank Account name.

Jira ticket: https://monite.atlassian.net/browse/DEV-14898

# Implementation

- Changed util `getBankAccountName`:
  - correct type of variable bankAccount;
  - return the name property of bankAccount.

# Steps to test

1. Open a Payable, edit, select a vendor/counterpart.
2. On the bank account field, it should show the bank account name. If the bank account is the default for the currency, the bank account name should also be appended with "(default)".