### PR TITLE
feat(DEV-14979): Business website -> URL, upd alert info

### DIFF
--- a/.changeset/tough-pans-retire.md
+++ b/.changeset/tough-pans-retire.md
@@ -1,0 +1,6 @@
+---
+'@monite/sdk-react': patch
+'@monite/sdk-drop-in': patch
+---
+
+Business website field renamed to URL, alert info updated to reflect the change

--- a/packages/sdk-react/src/components/onboarding/OnboardingBusinessProfile/OnboardingBusinessProfile.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingBusinessProfile/OnboardingBusinessProfile.tsx
@@ -76,7 +76,7 @@ export const OnboardingBusinessProfile = () => {
           <Box sx={{ width: '100%' }}>
             <RHFTextField
               disabled={isPending}
-              label={t(i18n)`Business website`}
+              label={t(i18n)`Business URL`}
               name="url"
               type="url"
               control={control}
@@ -91,7 +91,7 @@ export const OnboardingBusinessProfile = () => {
             >
               {t(
                 i18n
-              )`Must be a reachable, unique URL that describes the account's business.`}
+              )`This can be a website, social media profile link or any other unique reachable URL that describes the account's business nature.`}
             </Alert>
           </Box>
         )}

--- a/packages/sdk-react/src/components/onboarding/validators/validationSchemas.ts
+++ b/packages/sdk-react/src/components/onboarding/validators/validationSchemas.ts
@@ -130,11 +130,11 @@ export const businessProfileSchema = (
 ): ValidationSchema<BusinessProfile> => ({
   mcc: stringValidator().label(t(i18n)`Industry`),
   url: stringValidator()
-    .label(t(i18n)`Business website`)
+    .label(t(i18n)`Business URL`)
     .url(
       t(
         i18n
-      )`Invalid website URL. Please ensure it starts with 'http://' or 'https://'.`
+      )`Invalid URL. Please ensure it starts with 'http://' or 'https://'.`
     ),
 });
 

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -271,11 +271,11 @@ msgstr "Active"
 msgid "Add"
 msgstr "Add"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:160
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:120
 msgid "Add a bank account to receive payments"
 msgstr "Add a bank account to receive payments"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:229
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:189
 msgid "Add a bank account to receive transfers of funds to your business."
 msgstr "Add a bank account to receive transfers of funds to your business."
 
@@ -291,20 +291,20 @@ msgstr "Add a business owner"
 msgid "Add a date when the product will be delivered or the service provided"
 msgstr "Add a date when the product will be delivered or the service provided"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:141
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:101
 #: src/components/onboarding/OnboardingPersonList/OnboardingPersonList.tsx:176
 msgid "Add a director"
 msgstr "Add a director"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:144
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:104
 msgid "Add a person"
 msgstr "Add a person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:143
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:103
 msgid "Add an executive"
 msgstr "Add an executive"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:142
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:102
 msgid "Add an owner"
 msgstr "Add an owner"
 
@@ -1250,16 +1250,15 @@ msgstr "Bus Lines"
 msgid "Business address"
 msgstr "Business address"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:161
-#: src/components/onboarding/OnboardingContent/TestBusinessProfile.tsx:38
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:121
 msgid "Business details"
 msgstr "Business details"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:157
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
 msgid "Business directors"
 msgstr "Business directors"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:158
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
 msgid "Business executives"
 msgstr "Business executives"
 
@@ -1271,7 +1270,7 @@ msgstr "Business Identification Number (Liechtenstein)"
 msgid "Business Number (Canada)"
 msgstr "Business Number (Canada)"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:156
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
 msgid "Business owners"
 msgstr "Business owners"
 
@@ -1716,7 +1715,7 @@ msgstr "Comoros"
 msgid "Companies"
 msgstr "Companies"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:153
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
 msgid "Company details"
 msgstr "Company details"
 
@@ -2771,20 +2770,20 @@ msgid "Due to late payment your financing is currently on hold. Please, contact 
 msgstr "Due to late payment your financing is currently on hold. Please, contact the provider for further details."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:219
-msgid "Due to regulations, we're required to collect information about a company's directors."
-msgstr "Due to regulations, we're required to collect information about a company's directors."
+#~ msgid "Due to regulations, we're required to collect information about a company's directors."
+#~ msgstr "Due to regulations, we're required to collect information about a company's directors."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:179
-#~ msgid "Due to regulations, we’re required to collect information about a company’s directors."
-#~ msgstr "Due to regulations, we’re required to collect information about a company’s directors."
+msgid "Due to regulations, we’re required to collect information about a company’s directors."
+msgstr "Due to regulations, we’re required to collect information about a company’s directors."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:214
-msgid "Due to regulatory guidelines, we're required to collect information on anyone who has significant ownership of your business."
-msgstr "Due to regulatory guidelines, we're required to collect information on anyone who has significant ownership of your business."
+#~ msgid "Due to regulatory guidelines, we're required to collect information on anyone who has significant ownership of your business."
+#~ msgstr "Due to regulatory guidelines, we're required to collect information on anyone who has significant ownership of your business."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:174
-#~ msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
-#~ msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
+msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
+msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 
 #: src/components/onboarding/dicts/mccCodes.ts:545
 msgid "Durable Goods (Not Elsewhere Classified)"
@@ -2896,11 +2895,11 @@ msgstr "Edit Customer Close"
 msgid "Edit customer's profile"
 msgstr "Edit customer's profile"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:148
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:108
 msgid "Edit documents for person"
 msgstr "Edit documents for person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:152
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:112
 msgid "Edit individual"
 msgstr "Edit individual"
 
@@ -3065,7 +3064,7 @@ msgstr "Entity"
 msgid "Entity bank account"
 msgstr "Entity bank account"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:165
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:125
 msgid "Entity documents"
 msgstr "Entity documents"
 
@@ -4233,11 +4232,11 @@ msgstr "It must be in the \"Issued\" or \"Partially paid\" statuses and have mor
 msgid "It will remain in all the documents where it is added. You can’t undo this action."
 msgstr "It will remain in all the documents where it is added. You can’t undo this action."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:177
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:137
 msgid "It’s required to add any individual who is on the governing board of the company."
 msgstr "It’s required to add any individual who is on the governing board of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:192
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:152
 msgid "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 msgstr "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 
@@ -5650,7 +5649,7 @@ msgstr "Permissions"
 msgid "Person"
 msgstr "Person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:162
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:122
 msgid "Persons review"
 msgstr "Persons review"
 
@@ -5736,11 +5735,11 @@ msgstr "Please accept Service Agreement to proceed."
 msgid "Please add any individual who owns 25% or more of the company."
 msgstr "Please add any individual who owns 25% or more of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:183
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:143
 msgid "Please add any individual who owns 25% or more of your business."
 msgstr "Please add any individual who owns 25% or more of your business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:237
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:197
 msgid "Please correct the errors in persons information."
 msgstr "Please correct the errors in persons information."
 
@@ -5788,12 +5787,11 @@ msgstr "Please list all individuals who are members of the governing board of th
 msgid "Please provide a valid date."
 msgstr "Please provide a valid date."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:188
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:148
 msgid "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 msgstr "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:234
-#: src/components/onboarding/OnboardingContent/TestBusinessProfile.tsx:39
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:194
 msgid "Please provide information about your business."
 msgstr "Please provide information about your business."
 
@@ -5801,8 +5799,8 @@ msgstr "Please provide information about your business."
 msgid "Please provide the following documents for the person"
 msgstr "Please provide the following documents for the person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:240
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:245
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:200
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:205
 msgid "Please review the terms and conditions and accept them to continue."
 msgstr "Please review the terms and conditions and accept them to continue."
 
@@ -5815,9 +5813,9 @@ msgstr "Please try again later."
 msgid "Please try to reload."
 msgstr "Please try to reload."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:199
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:201
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:250
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:159
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:161
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:210
 msgid "Please upload the required documents to continue."
 msgstr "Please upload the required documents to continue."
 
@@ -6022,7 +6020,7 @@ msgstr "Project"
 msgid "Provide documents"
 msgstr "Provide documents"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:149
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:109
 msgid "Provide documents for persons"
 msgstr "Provide documents for persons"
 
@@ -7192,7 +7190,7 @@ msgstr "Telecommunication Services"
 msgid "Telegraph Services"
 msgstr "Telegraph Services"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:206
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:166
 msgid "Tell us more about your business"
 msgstr "Tell us more about your business"
 
@@ -7200,8 +7198,8 @@ msgstr "Tell us more about your business"
 msgid "Tent and Awning Shops"
 msgstr "Tent and Awning Shops"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:163
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:164
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:123
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:124
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:669
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:688
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:106
@@ -7361,12 +7359,12 @@ msgid "This can be a website, social media profile link or any other unique reac
 msgstr "This can be a website, social media profile link or any other unique reachable URL that describes the account's business nature."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:209
-msgid "This form must be completed by someone with control and management of your business. If that's not you, ask the right person."
-msgstr "This form must be completed by someone with control and management of your business. If that's not you, ask the right person."
+#~ msgid "This form must be completed by someone with control and management of your business. If that's not you, ask the right person."
+#~ msgstr "This form must be completed by someone with control and management of your business. If that's not you, ask the right person."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:169
-#~ msgid "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
-#~ msgstr "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
+msgid "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
+msgstr "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
 
 #: src/components/financing/components/FinanceInvoice.tsx:144
 msgid "This invoice can be financed"
@@ -8107,7 +8105,7 @@ msgstr "Venezuela"
 msgid "Verify identity"
 msgstr "Verify identity"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
 msgid "Verify that you represent this business"
 msgstr "Verify that you represent this business"
 
@@ -8175,12 +8173,12 @@ msgid "Watch/Jewelry Repair"
 msgstr "Watch/Jewelry Repair"
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:224
-msgid "We're required to collect information about any executives or senior managers who have significant management responsibility for this business."
-msgstr "We're required to collect information about any executives or senior managers who have significant management responsibility for this business."
+#~ msgid "We're required to collect information about any executives or senior managers who have significant management responsibility for this business."
+#~ msgstr "We're required to collect information about any executives or senior managers who have significant management responsibility for this business."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:184
-#~ msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
-#~ msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
+msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
+msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 
 #: src/components/onboarding/dicts/mccCodes.ts:1430
 msgid "Welding Repair"

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -1288,12 +1288,13 @@ msgid "Business Registration Number (South Korea)"
 msgstr "Business Registration Number (South Korea)"
 
 #: src/components/onboarding/OnboardingBusinessProfile/OnboardingBusinessProfile.tsx:79
+#: src/components/onboarding/validators/validationSchemas.ts:133
 msgid "Business URL"
 msgstr "Business URL"
 
 #: src/components/onboarding/validators/validationSchemas.ts:133
-msgid "Business website"
-msgstr "Business website"
+#~ msgid "Business website"
+#~ msgstr "Business website"
 
 #: src/components/onboarding/dicts/mccCodes.ts:194
 msgid "Business/Secretarial Schools"
@@ -4009,8 +4010,12 @@ msgid "Invalid issuance"
 msgstr "Invalid issuance"
 
 #: src/components/onboarding/validators/validationSchemas.ts:135
-msgid "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
-msgstr "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
+msgid "Invalid URL. Please ensure it starts with 'http://' or 'https://'."
+msgstr "Invalid URL. Please ensure it starts with 'http://' or 'https://'."
+
+#: src/components/onboarding/validators/validationSchemas.ts:135
+#~ msgid "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
+#~ msgstr "Invalid website URL. Please ensure it starts with 'http://' or 'https://'."
 
 #: src/components/financing/components/FinancedInvoicesTable.tsx:311
 #: src/components/receivables/components/CreditNotesTable.tsx:214

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -271,11 +271,11 @@ msgstr "Active"
 msgid "Add"
 msgstr "Add"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:120
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:160
 msgid "Add a bank account to receive payments"
 msgstr "Add a bank account to receive payments"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:189
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:229
 msgid "Add a bank account to receive transfers of funds to your business."
 msgstr "Add a bank account to receive transfers of funds to your business."
 
@@ -291,20 +291,20 @@ msgstr "Add a business owner"
 msgid "Add a date when the product will be delivered or the service provided"
 msgstr "Add a date when the product will be delivered or the service provided"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:101
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:141
 #: src/components/onboarding/OnboardingPersonList/OnboardingPersonList.tsx:176
 msgid "Add a director"
 msgstr "Add a director"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:104
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:144
 msgid "Add a person"
 msgstr "Add a person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:103
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:143
 msgid "Add an executive"
 msgstr "Add an executive"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:102
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:142
 msgid "Add an owner"
 msgstr "Add an owner"
 
@@ -1250,15 +1250,16 @@ msgstr "Bus Lines"
 msgid "Business address"
 msgstr "Business address"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:121
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:161
+#: src/components/onboarding/OnboardingContent/TestBusinessProfile.tsx:38
 msgid "Business details"
 msgstr "Business details"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:117
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:157
 msgid "Business directors"
 msgstr "Business directors"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:118
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:158
 msgid "Business executives"
 msgstr "Business executives"
 
@@ -1270,7 +1271,7 @@ msgstr "Business Identification Number (Liechtenstein)"
 msgid "Business Number (Canada)"
 msgstr "Business Number (Canada)"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:116
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:156
 msgid "Business owners"
 msgstr "Business owners"
 
@@ -1288,6 +1289,9 @@ msgid "Business Registration Number (South Korea)"
 msgstr "Business Registration Number (South Korea)"
 
 #: src/components/onboarding/OnboardingBusinessProfile/OnboardingBusinessProfile.tsx:79
+msgid "Business URL"
+msgstr "Business URL"
+
 #: src/components/onboarding/validators/validationSchemas.ts:133
 msgid "Business website"
 msgstr "Business website"
@@ -1712,7 +1716,7 @@ msgstr "Comoros"
 msgid "Companies"
 msgstr "Companies"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:113
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:153
 msgid "Company details"
 msgstr "Company details"
 
@@ -2766,13 +2770,21 @@ msgstr "Due to an error, the OCR failed to read the data from the document. Plea
 msgid "Due to late payment your financing is currently on hold. Please, contact the provider for further details."
 msgstr "Due to late payment your financing is currently on hold. Please, contact the provider for further details."
 
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:219
+msgid "Due to regulations, we're required to collect information about a company's directors."
+msgstr "Due to regulations, we're required to collect information about a company's directors."
+
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:179
-msgid "Due to regulations, we’re required to collect information about a company’s directors."
-msgstr "Due to regulations, we’re required to collect information about a company’s directors."
+#~ msgid "Due to regulations, we’re required to collect information about a company’s directors."
+#~ msgstr "Due to regulations, we’re required to collect information about a company’s directors."
+
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:214
+msgid "Due to regulatory guidelines, we're required to collect information on anyone who has significant ownership of your business."
+msgstr "Due to regulatory guidelines, we're required to collect information on anyone who has significant ownership of your business."
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:174
-msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
-msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
+#~ msgid "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
+#~ msgstr "Due to regulatory guidelines, we’re required to collect information on anyone who has significant ownership of your business."
 
 #: src/components/onboarding/dicts/mccCodes.ts:545
 msgid "Durable Goods (Not Elsewhere Classified)"
@@ -2884,11 +2896,11 @@ msgstr "Edit Customer Close"
 msgid "Edit customer's profile"
 msgstr "Edit customer's profile"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:108
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:148
 msgid "Edit documents for person"
 msgstr "Edit documents for person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:112
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:152
 msgid "Edit individual"
 msgstr "Edit individual"
 
@@ -3053,7 +3065,7 @@ msgstr "Entity"
 msgid "Entity bank account"
 msgstr "Entity bank account"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:125
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:165
 msgid "Entity documents"
 msgstr "Entity documents"
 
@@ -4221,11 +4233,11 @@ msgstr "It must be in the \"Issued\" or \"Partially paid\" statuses and have mor
 msgid "It will remain in all the documents where it is added. You can’t undo this action."
 msgstr "It will remain in all the documents where it is added. You can’t undo this action."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:137
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:177
 msgid "It’s required to add any individual who is on the governing board of the company."
 msgstr "It’s required to add any individual who is on the governing board of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:152
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:192
 msgid "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 msgstr "It’s required to add any individual who is on the governing board, owns 25% or more of the company or otherwise has significant management control of the company."
 
@@ -4889,8 +4901,8 @@ msgid "Music Stores-Musical Instruments, Pianos, and Sheet Music"
 msgstr "Music Stores-Musical Instruments, Pianos, and Sheet Music"
 
 #: src/components/onboarding/OnboardingBusinessProfile/OnboardingBusinessProfile.tsx:92
-msgid "Must be a reachable, unique URL that describes the account's business."
-msgstr "Must be a reachable, unique URL that describes the account's business."
+#~ msgid "Must be a reachable, unique URL that describes the account's business."
+#~ msgstr "Must be a reachable, unique URL that describes the account's business."
 
 #: src/components/receivables/components/BankAccountCustomFields.tsx:120
 #: src/components/receivables/components/BankAccountCustomFields.tsx:180
@@ -5638,7 +5650,7 @@ msgstr "Permissions"
 msgid "Person"
 msgstr "Person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:122
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:162
 msgid "Persons review"
 msgstr "Persons review"
 
@@ -5724,11 +5736,11 @@ msgstr "Please accept Service Agreement to proceed."
 msgid "Please add any individual who owns 25% or more of the company."
 msgstr "Please add any individual who owns 25% or more of the company."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:143
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:183
 msgid "Please add any individual who owns 25% or more of your business."
 msgstr "Please add any individual who owns 25% or more of your business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:197
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:237
 msgid "Please correct the errors in persons information."
 msgstr "Please correct the errors in persons information."
 
@@ -5776,11 +5788,12 @@ msgstr "Please list all individuals who are members of the governing board of th
 msgid "Please provide a valid date."
 msgstr "Please provide a valid date."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:148
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:188
 msgid "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 msgstr "Please provide information about an executive or senior manager who has significant management responsibility for this business."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:194
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:234
+#: src/components/onboarding/OnboardingContent/TestBusinessProfile.tsx:39
 msgid "Please provide information about your business."
 msgstr "Please provide information about your business."
 
@@ -5788,8 +5801,8 @@ msgstr "Please provide information about your business."
 msgid "Please provide the following documents for the person"
 msgstr "Please provide the following documents for the person"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:200
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:205
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:240
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:245
 msgid "Please review the terms and conditions and accept them to continue."
 msgstr "Please review the terms and conditions and accept them to continue."
 
@@ -5802,9 +5815,9 @@ msgstr "Please try again later."
 msgid "Please try to reload."
 msgstr "Please try to reload."
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:159
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:161
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:210
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:199
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:201
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:250
 msgid "Please upload the required documents to continue."
 msgstr "Please upload the required documents to continue."
 
@@ -6009,7 +6022,7 @@ msgstr "Project"
 msgid "Provide documents"
 msgstr "Provide documents"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:109
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:149
 msgid "Provide documents for persons"
 msgstr "Provide documents for persons"
 
@@ -7179,7 +7192,7 @@ msgstr "Telecommunication Services"
 msgid "Telegraph Services"
 msgstr "Telegraph Services"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:166
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:206
 msgid "Tell us more about your business"
 msgstr "Tell us more about your business"
 
@@ -7187,8 +7200,8 @@ msgstr "Tell us more about your business"
 msgid "Tent and Awning Shops"
 msgstr "Tent and Awning Shops"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:123
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:124
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:163
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:164
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:669
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:688
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:106
@@ -7343,9 +7356,17 @@ msgstr "This action can't be undone."
 msgid "This bank account will receive payments for your invoices"
 msgstr "This bank account will receive payments for your invoices"
 
+#: src/components/onboarding/OnboardingBusinessProfile/OnboardingBusinessProfile.tsx:92
+msgid "This can be a website, social media profile link or any other unique reachable URL that describes the account's business nature."
+msgstr "This can be a website, social media profile link or any other unique reachable URL that describes the account's business nature."
+
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:209
+msgid "This form must be completed by someone with control and management of your business. If that's not you, ask the right person."
+msgstr "This form must be completed by someone with control and management of your business. If that's not you, ask the right person."
+
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:169
-msgid "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
-msgstr "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
+#~ msgid "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
+#~ msgstr "This form must be completed by someone with control and management of your business. If that’s not you, ask the right person."
 
 #: src/components/financing/components/FinanceInvoice.tsx:144
 msgid "This invoice can be financed"
@@ -8086,7 +8107,7 @@ msgstr "Venezuela"
 msgid "Verify identity"
 msgstr "Verify identity"
 
-#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:115
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:155
 msgid "Verify that you represent this business"
 msgstr "Verify that you represent this business"
 
@@ -8153,9 +8174,13 @@ msgstr "Wallis And Futuna"
 msgid "Watch/Jewelry Repair"
 msgstr "Watch/Jewelry Repair"
 
+#: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:224
+msgid "We're required to collect information about any executives or senior managers who have significant management responsibility for this business."
+msgstr "We're required to collect information about any executives or senior managers who have significant management responsibility for this business."
+
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:184
-msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
-msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
+#~ msgid "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
+#~ msgstr "We’re required to collect information about any executives or senior managers who have significant management responsibility for this business."
 
 #: src/components/onboarding/dicts/mccCodes.ts:1430
 msgid "Welding Repair"


### PR DESCRIPTION
## Changes
* Changed the field label from "URL" to "Business URL" to make the purpose clearer
* Updated the tooltip text to: "This can be a website, social media profile link or any other unique reachable URL that describes the account's business nature."

These changes guide users to understand they can provide social media profiles or other online presence links instead of a formal business website.