### PR TITLE
fix(DEV-14899): Auto select Counterpart bank account on Counterpat selection [main]

### DIFF
--- a/.changeset/mean-pumpkins-bow.md
+++ b/.changeset/mean-pumpkins-bow.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Automatically select the Counterpat default bank account when selecting a Counterpart on the Payable details form.

--- a/packages/sdk-react/src/components/counterparts/components/CounterpartAutocomplete.tsx
+++ b/packages/sdk-react/src/components/counterparts/components/CounterpartAutocomplete.tsx
@@ -134,7 +134,8 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
       } else {
         setValue(
           name,
-          newCounterpartId as PathValue<TFieldValues, FieldPath<TFieldValues>>
+          newCounterpartId as PathValue<TFieldValues, FieldPath<TFieldValues>>,
+          { shouldValidate: true }
         );
       }
     }
@@ -256,7 +257,11 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
                     setValue(
                       name,
                       (value as CounterpartsAutocompleteOptionProps | null)
-                        ?.id as PathValue<TFieldValues, FieldPath<TFieldValues>>
+                        ?.id as PathValue<
+                        TFieldValues,
+                        FieldPath<TFieldValues>
+                      >,
+                      { shouldValidate: true }
                     );
                   }
                 }}

--- a/packages/sdk-react/src/components/counterparts/components/CounterpartAutocomplete.tsx
+++ b/packages/sdk-react/src/components/counterparts/components/CounterpartAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, SetStateAction } from 'react';
 import {
   Controller,
   Control,
@@ -10,14 +10,12 @@ import {
 
 import { components } from '@/api';
 import { CreateCounterpartModal } from '@/components/counterparts/components';
-import { CounterpartDetails } from '@/components/counterparts/CounterpartDetails';
 import { getCounterpartName } from '@/components/counterparts/helpers';
 import type {
   CustomerTypes,
   DefaultValuesOCRIndividual,
   DefaultValuesOCROrganization,
 } from '@/components/counterparts/types';
-import { Dialog } from '@/components/Dialog';
 import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useRootElements } from '@/core/context/RootElementsProvider';
 import { useCounterpartList } from '@/core/queries';
@@ -65,6 +63,8 @@ interface CounterpartAutocompleteProps<TFieldValues extends FieldValues> {
   customerTypes?: CustomerTypes;
   counterpartMatchingToOCRFound?: components['schemas']['CounterpartResponse'];
   counterpartRawName?: string;
+  setShowEditCounterpartDialog?: (value: SetStateAction<boolean>) => void;
+  showEditCounterpartButton?: boolean;
 }
 
 export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
@@ -78,14 +78,14 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
   customerTypes,
   counterpartMatchingToOCRFound,
   counterpartRawName,
+  setShowEditCounterpartDialog,
+  showEditCounterpartButton = false,
 }: CounterpartAutocompleteProps<TFieldValues>) => {
   const { i18n } = useLingui();
   const { root } = useRootElements();
-  const { componentSettings, queryClient } = useMoniteContext();
+  const { componentSettings } = useMoniteContext();
   const { setValue, getValues } = useFormContext<TFieldValues>();
   const [isCreateCounterpartOpened, setIsCreateCounterpartOpened] =
-    useState<boolean>(false);
-  const [isEditCounterpartOpened, setIsEditCounterpartOpened] =
     useState<boolean>(false);
   const [newCounterpartId, setNewCounterpartId] = useState<string | null>(null);
 
@@ -185,29 +185,6 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
         }
       />
 
-      <Dialog
-        alignDialog="right"
-        open={isEditCounterpartOpened}
-        container={root}
-        onClose={() => setIsEditCounterpartOpened(false)}
-      >
-        <CounterpartDetails
-          id={currentValue}
-          onUpdate={() => {
-            queryClient.invalidateQueries({
-              queryKey: [
-                'api.counterparts.getCounterparts',
-                { counterpart_name__icontains: counterpartRawName },
-              ],
-            });
-            setIsEditCounterpartOpened(false);
-          }}
-          customerTypes={
-            customerTypes || componentSettings?.counterparts?.customerTypes
-          }
-        />
-      </Dialog>
-
       <Controller
         control={control}
         name={name}
@@ -276,7 +253,9 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
                         ...params.InputProps,
                         endAdornment: (
                           <>
-                            {!multiple &&
+                            {showEditCounterpartButton &&
+                              setShowEditCounterpartDialog &&
+                              !multiple &&
                               selectedCounterpartOption &&
                               currentValue && (
                                 <Button
@@ -284,7 +263,7 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
                                   sx={{ minWidth: 0, px: 1, mr: 1 }}
                                   onClick={(event) => {
                                     event.preventDefault();
-                                    setIsEditCounterpartOpened(true);
+                                    setShowEditCounterpartDialog(true);
                                   }}
                                 >
                                   {t(i18n)`Edit`}
@@ -322,7 +301,8 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
                       )}
                     {counterpartMatchingToOCRFound &&
                       currentValue == counterpartMatchingToOCRFound.id &&
-                      !multiple && (
+                      !multiple &&
+                      setShowEditCounterpartDialog && (
                         <Alert
                           severity="warning"
                           icon={false}
@@ -338,7 +318,7 @@ export const CounterpartAutocomplete = <TFieldValues extends FieldValues>({
                             inheritColor
                             onClick={(event) => {
                               event.preventDefault();
-                              setIsEditCounterpartOpened(true);
+                              setShowEditCounterpartDialog(true);
                             }}
                           >{t(i18n)`Edit ${getCounterpartName(
                             counterpartMatchingToOCRFound

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -285,10 +285,19 @@ const PayableDetailsFormBase = forwardRef<
       context: formContext,
       defaultValues,
     });
-    const { control, handleSubmit, watch, reset, trigger, resetField } =
-      methods;
+    const {
+      control,
+      handleSubmit,
+      watch,
+      reset,
+      trigger,
+      setValue,
+      getValues,
+      getFieldState,
+    } = methods;
     const { dirtyFields } = useFormState({ control });
     const currentCounterpart = watch('counterpart');
+    const currentCounterpartBankAccount = watch('counterpartBankAccount');
     const currentInvoiceDate = watch('invoiceDate');
     const currentDueDate = watch('dueDate');
     const currentCurrency = watch('currency');
@@ -347,17 +356,16 @@ const PayableDetailsFormBase = forwardRef<
     }, [payable, formatFromMinorUnits, reset, lineItems]);
 
     useEffect(() => {
+      if (!currentCounterpart && !!currentCounterpartBankAccount) {
+        setValue('counterpartBankAccount', '', { shouldValidate: true });
+      }
+    }, [currentCounterpart, currentCounterpartBankAccount, setValue]);
+
+    useEffect(() => {
       if (!matchingToOCRCounterpartId) return;
-      const getFieldState = methods.getFieldState;
       if (getFieldState('counterpart').isTouched) return;
-      const setValue = methods.setValue;
       setValue('counterpart', matchingToOCRCounterpartId);
-    }, [
-      matchingToOCRCounterpartId,
-      methods.resetField,
-      methods.getFieldState,
-      methods.setValue,
-    ]);
+    }, [matchingToOCRCounterpartId, getFieldState, setValue]);
 
     useEffect(() => {
       if (
@@ -368,23 +376,21 @@ const PayableDetailsFormBase = forwardRef<
           counterpartBankAccountQuery.data.data,
           currentCurrency
         );
-
-        // Only reset if the value is different
-        const currentValue = methods.getValues('counterpartBankAccount');
+        const currentValue = getValues('counterpartBankAccount');
         if (currentValue !== defaultBankAccount) {
-          resetField('counterpartBankAccount', {
-            defaultValue: defaultBankAccount,
-            keepTouched: true,
+          setValue('counterpartBankAccount', defaultBankAccount, {
+            shouldDirty: true,
+            shouldTouch: true,
+            shouldValidate: true,
           });
         }
       }
     }, [
       counterpartBankAccountQuery.data,
-      currentCurrency,
-      resetField,
-      methods.getValues,
       counterpartBankAccountQuery.isSuccess,
-      methods,
+      currentCurrency,
+      getValues,
+      setValue,
     ]);
 
     useEffect(() => {

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -572,6 +572,19 @@ const PayableDetailsFormBase = forwardRef<
                                   .length === 0
                               }
                             >
+                              <Button
+                                variant="text"
+                                startIcon={<AddIcon />}
+                                fullWidth
+                                sx={{
+                                  justifyContent: 'flex-start',
+                                  px: 2,
+                                  py: 1,
+                                }}
+                                onClick={() => setIsEditCounterpartOpened(true)}
+                              >
+                                {t(i18n)`Add new bank account`}
+                              </Button>
                               {counterpartBankAccountQuery?.data?.data.map(
                                 (bankAccount) => (
                                   <MenuItem

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -255,6 +255,8 @@ const PayableDetailsFormBase = forwardRef<
   ) => {
     const { i18n } = useLingui();
     const { api } = useMoniteContext();
+    const { root } = useRootElements();
+    const className = 'Monite-PayableDetailsForm';
 
     const {
       formatFromMinorUnits,
@@ -300,40 +302,6 @@ const PayableDetailsFormBase = forwardRef<
         : null
     );
 
-    useEffect(() => {
-      reset(prepareDefaultValues(formatFromMinorUnits, payable, lineItems));
-    }, [payable, formatFromMinorUnits, reset, lineItems]);
-
-    const { data: matchingToOCRCounterpart } =
-      api.counterparts.getCounterparts.useQuery(
-        {
-          query: {
-            counterpart_name__icontains: payable?.counterpart_raw_data?.name,
-            limit: 1,
-          },
-        },
-        {
-          enabled: Boolean(
-            !payable?.counterpart_id && payable?.counterpart_raw_data?.name
-          ),
-          select: (data) => data.data.at(0),
-        }
-      );
-    const matchingToOCRCounterpartId = matchingToOCRCounterpart?.id;
-
-    useEffect(() => {
-      if (!matchingToOCRCounterpartId) return;
-      const getFieldState = methods.getFieldState;
-      if (getFieldState('counterpart').isTouched) return;
-      const setValue = methods.setValue;
-      setValue('counterpart', matchingToOCRCounterpartId);
-    }, [
-      matchingToOCRCounterpartId,
-      methods.resetField,
-      methods.getFieldState,
-      methods.setValue,
-    ]);
-
     const { tagQuery, counterpartQuery, counterpartBankAccountQuery } =
       usePayableDetailsForm({
         currentCounterpartId: currentCounterpart,
@@ -357,9 +325,39 @@ const PayableDetailsFormBase = forwardRef<
 
     const isSubmittedByKeyboardRef = useRef(false);
 
-    const { root } = useRootElements();
+    const { data: matchingToOCRCounterpart } =
+      api.counterparts.getCounterparts.useQuery(
+        {
+          query: {
+            counterpart_name__icontains: payable?.counterpart_raw_data?.name,
+            limit: 1,
+          },
+        },
+        {
+          enabled: Boolean(
+            !payable?.counterpart_id && payable?.counterpart_raw_data?.name
+          ),
+          select: (data) => data.data.at(0),
+        }
+      );
+    const matchingToOCRCounterpartId = matchingToOCRCounterpart?.id;
 
-    const className = 'Monite-PayableDetailsForm';
+    useEffect(() => {
+      reset(prepareDefaultValues(formatFromMinorUnits, payable, lineItems));
+    }, [payable, formatFromMinorUnits, reset, lineItems]);
+
+    useEffect(() => {
+      if (!matchingToOCRCounterpartId) return;
+      const getFieldState = methods.getFieldState;
+      if (getFieldState('counterpart').isTouched) return;
+      const setValue = methods.setValue;
+      setValue('counterpart', matchingToOCRCounterpartId);
+    }, [
+      matchingToOCRCounterpartId,
+      methods.resetField,
+      methods.getFieldState,
+      methods.setValue,
+    ]);
 
     useEffect(() => {
       if (


### PR DESCRIPTION
> [!NOTE]
> This PR is a duplicate from https://github.com/team-monite/monite-sdk/pull/703, no code changes from it.
> The only difference is this PR targets the `main` branch; the other PR was incorrectly merged into another branch not main.
> Original PR description follows.

# Scope

Automatically select the Counterpart default bank account when selecting a Counterpart on the Payable details form. Add button to add bank account on bank account select input.

Jira ticket: https://monite.atlassian.net/browse/DEV-14899

# Implementation

- Changed useEffects in PayableDetailsForm to auto select bank account.
- Added button to "add bank account" on bank account select input of PayableDetailsForm. 
- Added trigger form validation on value changes on CounterpartAutocomplete.
- Moved CounterpartDetails dialog from CounterpartAutocomplete to PayableDetailsForm.
- Organized useEffects order in PayableDetailsForm.

# Steps to test

1. Open a new Payable, select one Counterpart, should automatically select the default bank account, if the currency matches.
2. If currency does not match, change the payable currency to the currency of the bank account, should auto select the bank account.
3. Open the bank account select input, should see a "create bank account" button and list of bank accounts.
4. Should be able to change the bank account to one that is not the default.
5. Clear the counterpart, the bank account should also be cleared.
6. Click the "create bank account" button, should see a side modal to edit the counterpart and its bank accounts.
