### PR TITLE
fix(DEV-14226): country selector

### DIFF
--- a/.changeset/little-peaches-vanish.md
+++ b/.changeset/little-peaches-vanish.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Coutry selector component refactored and updated

--- a/packages/sdk-react/src/components/RHF/RHFAutocomplete/CountryOption/CountryOption.tsx
+++ b/packages/sdk-react/src/components/RHF/RHFAutocomplete/CountryOption/CountryOption.tsx
@@ -1,34 +1,4 @@
-import { HTMLAttributes } from 'react';
-
-import { CountryType } from '@/core/utils';
-import { css } from '@emotion/react';
-import { AutocompleteRenderOptionState } from '@mui/material/Autocomplete/Autocomplete';
-
-export type CountryOptionProps = {
-  option: CountryType;
-  props: HTMLAttributes<HTMLLIElement>;
-  state: AutocompleteRenderOptionState;
-};
-
-export function CountryOption({ option, props }: CountryOptionProps) {
-  return (
-    <li
-      css={css`
-        & > img {
-          margin-right: 8px;
-          flex-shrink: 0;
-        }
-      `}
-      {...props}
-    >
-      <img
-        loading="lazy"
-        width="20"
-        src={`https://flagcdn.com/w20/${option.code.toLowerCase()}.png`}
-        srcSet={`https://flagcdn.com/w40/${option.code.toLowerCase()}.png 2x`}
-        alt={option.label}
-      />
-      {`${option.label}`}
-    </li>
-  );
-}
+export {
+  CountryOption,
+  type CountryOptionProps,
+} from '@/ui/Country/CountryOption';

--- a/packages/sdk-react/src/components/RHF/RHFAutocomplete/CountryOption/index.ts
+++ b/packages/sdk-react/src/components/RHF/RHFAutocomplete/CountryOption/index.ts
@@ -1,0 +1,1 @@
+export { CountryOption } from '@/ui/Country/CountryOption';

--- a/packages/sdk-react/src/components/RHF/RHFAutocomplete/RHFAutocomplete.tsx
+++ b/packages/sdk-react/src/components/RHF/RHFAutocomplete/RHFAutocomplete.tsx
@@ -26,7 +26,7 @@ interface RHFAutocompleteBaseProps<
   label: string;
 }
 
-interface RenderInputParams {
+export interface RenderInputParams {
   error?: FieldError;
   label: string;
   required?: boolean;
@@ -38,6 +38,15 @@ type RenderInputFunction = ((
 ) => React.ReactNode) &
   ((params: AutocompleteRenderInputParams) => React.ReactNode);
 
+type AutocompleteOnChangeHandler<TOption> = NonNullable<
+  AutocompleteProps<
+    TOption,
+    boolean | undefined,
+    boolean | undefined,
+    boolean | undefined
+  >['onChange']
+>;
+
 export type RHFAutocompleteProps<
   TFieldValues extends FieldValues,
   TName extends FieldPath<TFieldValues>,
@@ -45,7 +54,8 @@ export type RHFAutocompleteProps<
 > = RHFAutocompleteBaseProps<TFieldValues, TName> &
   Optional<CustomAutocompleteProps<TOption>, 'renderInput'> & {
     renderInput?: RenderInputFunction;
-  } & TextFieldProps;
+    onChange?: AutocompleteOnChangeHandler<TOption>;
+  } & Omit<TextFieldProps, 'onChange'>;
 
 interface CustomAutocompleteProps<TOption>
   extends AutocompleteProps<

--- a/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx
@@ -1,20 +1,9 @@
-import { Controller, useFormContext, FieldPath } from 'react-hook-form';
+import { Controller, FieldPath, useFormContext } from 'react-hook-form';
 
-import { useRootElements } from '@/core/context/RootElementsProvider';
-import { getCountries } from '@/core/utils/countries';
-import { countriesToSelect } from '@/core/utils/selectHelpers';
+import { MoniteCountry } from '@/ui/Country';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import {
-  FormControl,
-  FormHelperText,
-  InputLabel,
-  MenuItem,
-  Paper,
-  Select,
-  Stack,
-  TextField,
-} from '@mui/material';
+import { Paper, Stack, TextField } from '@mui/material';
 
 import { CounterpartAddressFormFields } from './helpers';
 
@@ -30,7 +19,6 @@ export const CounterpartAddressForm = ({
     : CounterpartAddressFormFields;
 
   const { control } = useFormContext<Form>();
-  const { root } = useRootElements();
 
   const fieldPath = (
     path: FieldPath<CounterpartAddressFormFields>
@@ -125,34 +113,11 @@ export const CounterpartAddressForm = ({
             />
           )}
         />
-        <Controller
+        <MoniteCountry
           name={fieldPath('country')}
           control={control}
-          render={({ field, fieldState: { error } }) => (
-            <FormControl
-              variant="standard"
-              fullWidth
-              required
-              error={Boolean(error)}
-            >
-              <InputLabel htmlFor={field.name}>{t(i18n)`Country`}</InputLabel>
-              <Select
-                id={field.name}
-                labelId={field.name}
-                label={t(i18n)`Country`}
-                MenuProps={{ container: root }}
-                {...field}
-                value={field.value ?? ''}
-              >
-                {countriesToSelect(getCountries(i18n)).map((country) => (
-                  <MenuItem key={country.value} value={country.value}>
-                    {country.label}
-                  </MenuItem>
-                ))}
-              </Select>
-              {error && <FormHelperText>{error.message}</FormHelperText>}
-            </FormControl>
-          )}
+          required
+          fullWidth
         />
       </Stack>
     </Paper>

--- a/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx
@@ -1,24 +1,17 @@
 import { useId } from 'react';
 import { Controller } from 'react-hook-form';
 
-import { useRootElements } from '@/core/context/RootElementsProvider';
-import { getCountries } from '@/core/utils/countries';
-import { countriesToSelect } from '@/core/utils/selectHelpers';
+import { MoniteCountry } from '@/ui/Country';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import {
+  Button,
+  DialogActions,
   DialogContent,
   Divider,
+  Stack,
   TextField,
   Typography,
-  Stack,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  FormHelperText,
-  DialogActions,
-  Button,
 } from '@mui/material';
 
 import { prepareCounterpartAddressSubmit } from '../CounterpartAddressForm';
@@ -36,8 +29,6 @@ export const CounterpartAddressFormUpdate = (
     updateAddress,
     isLoading,
   } = useCounterpartAddressFormUpdate(props);
-  const { root } = useRootElements();
-
   // eslint-disable-next-line lingui/no-unlocalized-strings
   const formName = `Monite-Form-counterpartAddress-${useId()}`;
 
@@ -134,36 +125,7 @@ export const CounterpartAddressFormUpdate = (
                 />
               )}
             />
-            <Controller
-              name="country"
-              control={control}
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  variant="standard"
-                  fullWidth
-                  required
-                  error={Boolean(error)}
-                >
-                  <InputLabel htmlFor={field.name}>
-                    {t(i18n)`Country`}
-                  </InputLabel>
-                  <Select
-                    id={field.name}
-                    labelId={field.name}
-                    label={t(i18n)`Country`}
-                    MenuProps={{ container: root }}
-                    {...field}
-                  >
-                    {countriesToSelect(getCountries(i18n)).map((country) => (
-                      <MenuItem key={country.value} value={country.value}>
-                        {country.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  {error && <FormHelperText>{error.message}</FormHelperText>}
-                </FormControl>
-              )}
-            />
+            <MoniteCountry name="country" control={control} required />
           </Stack>
         </form>
       </DialogContent>

--- a/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx
@@ -1,28 +1,20 @@
 import { useEffect } from 'react';
 import { Controller } from 'react-hook-form';
 
-import { useRootElements } from '@/core/context/RootElementsProvider';
-import { useProductCurrencyGroups } from '@/core/hooks/useProductCurrencyGroups';
-import { getCountries } from '@/core/utils/countries';
-import { countriesToSelect } from '@/core/utils/selectHelpers';
+import { MoniteCountry } from '@/ui/Country';
 import { MoniteCurrency } from '@/ui/Currency';
 import { LoadingPage } from '@/ui/loadingPage';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
 import {
-  Typography,
-  Stack,
-  Divider,
-  DialogContent,
-  TextField,
-  DialogActions,
   Button,
-  FormControl,
-  InputLabel,
-  FormHelperText,
-  Select,
-  MenuItem,
+  DialogActions,
+  DialogContent,
+  Divider,
+  Stack,
+  TextField,
+  Typography,
 } from '@mui/material';
 
 import { getCounterpartName } from '../../helpers';
@@ -41,7 +33,6 @@ export const CounterpartBankForm = (props: CounterpartBankFormProps) => {
     saveBank,
     isLoading,
   } = useCounterpartBankForm(props);
-  const { root } = useRootElements();
   const country = watch('country');
 
   const { currencyGroups, isLoadingCurrencyGroups } =
@@ -200,40 +191,8 @@ export const CounterpartBankForm = (props: CounterpartBankFormProps) => {
                 />
               )}
             />
-            <Controller
-              name="country"
-              control={control}
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  variant="standard"
-                  fullWidth
-                  required
-                  error={Boolean(error)}
-                >
-                  <InputLabel id={field.name}>{t(i18n)`Country`}</InputLabel>
-                  <Select
-                    labelId={field.name}
-                    label={t(i18n)`Country`}
-                    MenuProps={{ container: root }}
-                    {...field}
-                  >
-                    {countriesToSelect(getCountries(i18n)).map((country) => (
-                      <MenuItem key={country.value} value={country.value}>
-                        {country.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                  {error && <FormHelperText>{error.message}</FormHelperText>}
-                </FormControl>
-              )}
-            />
-            <MoniteCurrency
-              name="currency"
-              control={control}
-              required
-              groups={currencyGroups}
-              disabled={isLoadingCurrencyGroups}
-            />
+            <MoniteCountry name="country" control={control} required />
+            <MoniteCurrency name="currency" control={control} required />
           </Stack>
         </form>
       </DialogContent>

--- a/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Controller } from 'react-hook-form';
 
+import { useProductCurrencyGroups } from '@/core/hooks/useProductCurrencyGroups';
 import { MoniteCountry } from '@/ui/Country';
 import { MoniteCurrency } from '@/ui/Currency';
 import { LoadingPage } from '@/ui/loadingPage';
@@ -192,7 +193,13 @@ export const CounterpartBankForm = (props: CounterpartBankFormProps) => {
               )}
             />
             <MoniteCountry name="country" control={control} required />
-            <MoniteCurrency name="currency" control={control} required />
+            <MoniteCurrency
+              name="currency"
+              control={control}
+              required
+              groups={currencyGroups}
+              disabled={isLoadingCurrencyGroups}
+            />
           </Stack>
         </form>
       </DialogContent>

--- a/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx
@@ -1,12 +1,9 @@
 import { useId } from 'react';
 
-import {
-  CountryOption,
-  RHFAutocomplete,
-} from '@/components/RHF/RHFAutocomplete';
+import { RHFAutocomplete } from '@/components/RHF/RHFAutocomplete';
 import { RHFTextField } from '@/components/RHF/RHFTextField';
 import { useVatTypes } from '@/core/hooks/useVatTypes';
-import { getCountriesArray } from '@/core/utils/countries';
+import { MoniteCountry } from '@/ui/Country';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import ArrowForwardIcon from '@mui/icons-material/ArrowForward';
@@ -62,22 +59,11 @@ export const CounterpartVatForm = (props: CounterpartVatFormProps) => {
       <DialogContent>
         <form id={formName} onSubmit={handleSubmit(saveVat)}>
           <Stack spacing={3}>
-            <RHFAutocomplete
+            <MoniteCountry
               name="country"
-              disabled={isLoading}
               control={control}
-              label={t(i18n)`Country`}
-              options={getCountriesArray(i18n)}
-              optionKey="code"
-              labelKey="label"
-              renderOption={(props, option, state) => (
-                <CountryOption
-                  key={option.code}
-                  props={props}
-                  option={option}
-                  state={state}
-                />
-              )}
+              disabled={isLoading}
+              required
             />
 
             <RHFAutocomplete

--- a/packages/sdk-react/src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx
@@ -1,17 +1,12 @@
 import { useFormContext } from 'react-hook-form';
 
-import {
-  CountryOption,
-  RHFAutocomplete,
-} from '@/components/RHF/RHFAutocomplete';
 import { RHFTextField } from '@/components/RHF/RHFTextField';
-import { AllowedCountries } from '@/enums/AllowedCountries';
+import { MoniteCountry } from '@/ui/Country';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
 import { OnboardingStepContent, OnboardingSubTitle } from '../OnboardingLayout';
 import { OnboardingAddressType } from '../types';
-import { getRegionName } from '../utils';
 
 type AddressType = { address: OnboardingAddressType };
 
@@ -37,25 +32,11 @@ export const OnboardingAddress = ({
       <OnboardingSubTitle>{title}</OnboardingSubTitle>
 
       {checkValue('country') && (
-        <RHFAutocomplete
+        <MoniteCountry
           disabled={isLoading}
           name="address.country"
           control={control}
-          label={t(i18n)`Country`}
-          optionKey="code"
-          labelKey="label"
-          options={AllowedCountries.map((code) => ({
-            code,
-            label: t(i18n)`${getRegionName(code)} (${code})`,
-          }))}
-          renderOption={(props, option, state) => (
-            <CountryOption
-              key={option.code}
-              props={props}
-              option={option}
-              state={state}
-            />
-          )}
+          required
         />
       )}
 

--- a/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
+++ b/packages/sdk-react/src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx
@@ -2,12 +2,8 @@ import { useEffect, useMemo } from 'react';
 
 import { components } from '@/api';
 import { useOnboardingBankAccount } from '@/components/onboarding/hooks/useOnboardingBankAccount';
-import { getRegionName } from '@/components/onboarding/utils';
-import {
-  CountryOption,
-  RHFAutocomplete,
-} from '@/components/RHF/RHFAutocomplete';
 import { RHFTextField } from '@/components/RHF/RHFTextField';
+import { MoniteCountry } from '@/ui/Country';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import { MenuItem } from '@mui/material';
@@ -67,20 +63,6 @@ export const OnboardingBankAccount = ({
     return currencies;
   }, [allowedCurrencies, currencies]);
 
-  const filteredCountryOptions = useMemo(() => {
-    const codesToUse =
-      allowedCountries && allowedCountries.length > 0
-        ? Object.values(countries).filter((code) =>
-            allowedCountries.includes(code)
-          )
-        : Object.values(countries);
-
-    return codesToUse.map((code) => ({
-      code,
-      label: t(i18n)`${getRegionName(code)}`,
-    }));
-  }, [allowedCountries, countries, i18n]);
-
   if (isLoading) return null;
 
   return (
@@ -106,24 +88,14 @@ export const OnboardingBankAccount = ({
           </RHFTextField>
         )}
 
-        {checkValue('country') && !!filteredCountryOptions.length && (
-          <RHFAutocomplete
-            disabled={isPending}
+        {checkValue('country') && (
+          <MoniteCountry
             name="country"
             control={control}
+            disabled={isPending}
             defaultValue={allowedCountries?.[0]}
-            label={t(i18n)`Country`}
-            optionKey="code"
-            labelKey="label"
-            options={filteredCountryOptions}
-            renderOption={(props, option, state) => (
-              <CountryOption
-                key={option.code}
-                props={props}
-                option={option}
-                state={state}
-              />
-            )}
+            allowedCountries={allowedCountries}
+            required
           />
         )}
 

--- a/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
+++ b/packages/sdk-react/src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx
@@ -542,7 +542,6 @@ const CreateReceivablesBase = ({
                             hideLabel
                             groups={currencyGroups}
                             disabled={isLoadingCurrencyGroups}
-                            // @ts-expect-error -> Overloaded function args not inferred correctly (https://github.com/microsoft/TypeScript/issues/54539)
                             onChange={(_event, value) => {
                               if (
                                 value &&

--- a/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
@@ -1,10 +1,15 @@
+import type { SyntheticEvent } from 'react';
 import { useMemo } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 import { components } from '@/api';
 import { useMoniteContext } from '@/core/context/MoniteContext';
 import { useMyEntity } from '@/core/queries';
-import { countryCurrencyList, getCountriesArray } from '@/core/utils/countries';
+import {
+  countryCurrencyList,
+  getCountriesArray,
+  CountryType,
+} from '@/core/utils/countries';
 import { MoniteCountry } from '@/ui/Country';
 import { MoniteCurrency } from '@/ui/Currency';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -94,15 +99,18 @@ export const BankAccountFormContent = ({
     (bank) => bank?.currency === (bankAccount?.currency || currency)
   );
 
-  const handleCountryChange = (_event: any, value: any) => {
-    if (!value) return;
+  const handleCountryChange = (
+    _event: SyntheticEvent,
+    value: (CountryType | string) | (CountryType | string)[] | null
+  ) => {
+    if (Array.isArray(value) || !value) return;
 
-    let countryCode: string | undefined;
+    let countryCode: CountryType['code'] | undefined;
 
-    if (value && typeof value === 'object' && 'code' in value) {
+    if (typeof value === 'string') {
+      countryCode = value as CountryType['code'];
+    } else if (typeof value === 'object' && value !== null && 'code' in value) {
       countryCode = value.code;
-    } else if (typeof value === 'string') {
-      countryCode = value;
     }
 
     if (countryCode) {

--- a/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
+++ b/packages/sdk-react/src/components/receivables/components/BankAccountFormContent.tsx
@@ -3,26 +3,14 @@ import { Controller, useForm } from 'react-hook-form';
 
 import { components } from '@/api';
 import { useMoniteContext } from '@/core/context/MoniteContext';
-import { useRootElements } from '@/core/context/RootElementsProvider';
 import { useMyEntity } from '@/core/queries';
-import { getCountries, countryCurrencyList } from '@/core/utils/countries';
-import { countriesToSelect } from '@/core/utils/selectHelpers';
+import { countryCurrencyList, getCountriesArray } from '@/core/utils/countries';
+import { MoniteCountry } from '@/ui/Country';
 import { MoniteCurrency } from '@/ui/Currency';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import {
-  Box,
-  FormControl,
-  FormHelperText,
-  InputLabel,
-  MenuItem,
-  Select,
-  Stack,
-  Switch,
-  TextField,
-  Typography,
-} from '@mui/material';
+import { Box, Stack, Switch, TextField, Typography } from '@mui/material';
 
 import { useSetDefaultBankAccount } from '../hooks';
 import { EntityBankAccountFields } from '../types';
@@ -32,6 +20,7 @@ import {
 } from '../utils';
 import { getEntityBankAccountValidationSchema } from '../validation';
 import { BankAccountCustomFields } from './BankAccountCustomFields';
+import { FormSelect } from './FormSelect';
 
 type Props = {
   bankAccount?: components['schemas']['EntityBankAccountResponse'];
@@ -53,7 +42,6 @@ export const BankAccountFormContent = ({
   updateBankAccount,
 }: Props) => {
   const { i18n } = useLingui();
-  const { root } = useRootElements();
   const { componentSettings } = useMoniteContext();
   const { data: entity } = useMyEntity();
   const currentEntityCurrency = countryCurrencyList?.find(
@@ -63,9 +51,9 @@ export const BankAccountFormContent = ({
 
   const countryOptions = useMemo(
     () =>
-      countriesToSelect(getCountries(i18n)).filter((countryItem) =>
+      getCountriesArray(i18n).filter((countryItem) =>
         componentSettings?.receivables?.bankAccountCountries?.includes(
-          countryItem?.value as components['schemas']['AllowedCountries']
+          countryItem?.code as components['schemas']['AllowedCountries']
         )
       ),
     [componentSettings, i18n]
@@ -105,6 +93,32 @@ export const BankAccountFormContent = ({
   const filteredBanksByCurrency = bankAccounts?.filter(
     (bank) => bank?.currency === (bankAccount?.currency || currency)
   );
+
+  const handleCountryChange = (_event: any, value: any) => {
+    if (!value) return;
+
+    let countryCode: string | undefined;
+
+    if (value && typeof value === 'object' && 'code' in value) {
+      countryCode = value.code;
+    } else if (typeof value === 'string') {
+      countryCode = value;
+    }
+
+    if (countryCode) {
+      const currentCountry = countryCurrencyList?.find(
+        (item) => item.country === countryCode
+      );
+
+      if (currentCountry?.currency) {
+        setValue(
+          'currency',
+          currentCountry.currency as components['schemas']['CurrencyEnum']
+        );
+        clearErrors('currency');
+      }
+    }
+  };
 
   const submitForm = (values: EntityBankAccountFields) => {
     if (bankAccount) {
@@ -151,55 +165,31 @@ export const BankAccountFormContent = ({
           i18n
         )`This bank account will receive payments for your invoices`}</Typography>
 
-        <Box display="flex" gap={2} width="100%">
-          <Controller
-            name="country"
-            control={control}
-            disabled={countryOptions?.length === 1 || !!bankAccount}
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                variant="standard"
-                fullWidth
-                required
-                error={Boolean(error)}
-              >
-                <InputLabel id={field.name}>{t(i18n)`Country`}</InputLabel>
-                <Select
-                  labelId={field.name}
-                  label={t(i18n)`Country`}
-                  MenuProps={{ container: root }}
-                  {...field}
-                  onChange={(e) => {
-                    const currentValue = countryCurrencyList?.find(
-                      (item) => item.country === e.target.value
-                    );
-                    setValue(
-                      'currency',
-                      currentValue?.currency as components['schemas']['CurrencyEnum']
-                    );
-                    clearErrors();
-                    field.onChange(e);
-                  }}
-                >
-                  {countryOptions.map((country) => (
-                    <MenuItem key={country.value} value={country.value}>
-                      {country.label}
-                    </MenuItem>
-                  ))}
-                </Select>
-                {error && <FormHelperText>{error.message}</FormHelperText>}
-              </FormControl>
-            )}
-          />
+        <Box sx={{ display: 'flex', gap: 2, width: '100%' }}>
+          <FormSelect>
+            <MoniteCountry
+              name="country"
+              control={control}
+              disabled={countryOptions?.length === 1 || !!bankAccount}
+              required
+              fullWidth
+              allowedCountries={
+                componentSettings?.receivables?.bankAccountCountries
+              }
+              onChange={handleCountryChange}
+            />
+          </FormSelect>
 
-          <MoniteCurrency
-            name="currency"
-            control={control}
-            required
-            disabled={!!bankAccount}
-            fullWidth
-            shouldDisplayCustomList
-          />
+          <FormSelect>
+            <MoniteCurrency
+              name="currency"
+              control={control}
+              required
+              disabled={!!bankAccount}
+              fullWidth
+              shouldDisplayCustomList
+            />
+          </FormSelect>
         </Box>
 
         <Box display="flex" gap={2} width="100%">

--- a/packages/sdk-react/src/components/receivables/components/FormSelect.tsx
+++ b/packages/sdk-react/src/components/receivables/components/FormSelect.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+
+import { Box, SxProps, Theme } from '@mui/material';
+
+type FormSelectProps = {
+  children: ReactNode;
+  sx?: SxProps<Theme>;
+};
+
+export const FormSelect = ({ children, sx }: FormSelectProps) => {
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        '& .MuiInputBase-root': {
+          height: '56px',
+        },
+        '& .MuiOutlinedInput-root': {
+          paddingRight: '14px',
+        },
+        '& .MuiInputAdornment-positionEnd': {
+          marginLeft: 0,
+        },
+        ...sx,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -34,7 +34,7 @@ msgstr "- they are due within 7 days."
 msgid "(.pdf, .png, .jpg supported)"
 msgstr "(.pdf, .png, .jpg supported)"
 
-#: src/components/aiAssistant/components/FeedbackForm/FeedbackForm.tsx:141
+#: src/components/aiAssistant/components/FeedbackForm/FeedbackForm.tsx:146
 msgid "(Optional) Feel free to add specific details"
 msgstr "(Optional) Feel free to add specific details"
 
@@ -405,7 +405,7 @@ msgstr "Add text"
 msgid "Add to prompts"
 msgstr "Add to prompts"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:58
+#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:55
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartView.tsx:275
 msgid "Add VAT ID"
 msgstr "Add VAT ID"
@@ -474,7 +474,7 @@ msgstr "Agree & Submit"
 msgid "Agricultural Cooperative"
 msgstr "Agricultural Cooperative"
 
-#: src/components/aiAssistant/AIAssistant.tsx:21
+#: src/components/aiAssistant/AIAssistant.tsx:61
 msgid "AI Assistant"
 msgstr "AI Assistant"
 
@@ -959,7 +959,7 @@ msgstr "Back of your identity document"
 msgid "Back to edit"
 msgstr "Back to edit"
 
-#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:129
+#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:133
 msgid "Bad response"
 msgstr "Bad response"
 
@@ -1559,8 +1559,8 @@ msgstr "Change document currency"
 msgid "Charitable and Social Service Organizations - Fundraising"
 msgstr "Charitable and Social Service Organizations - Fundraising"
 
-#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:166
-#: src/components/aiAssistant/components/SearchChatModal/SearchChatModal.tsx:127
+#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:189
+#: src/components/aiAssistant/components/SearchChatModal/SearchChatModal.tsx:123
 msgid "Chat {id}"
 msgstr "Chat {id}"
 
@@ -1655,7 +1655,7 @@ msgstr "Cleaning and Maintenance"
 msgid "Close"
 msgstr "Close"
 
-#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:108
+#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:134
 msgid "Close AI Sidebar"
 msgstr "Close AI Sidebar"
 
@@ -1910,11 +1910,11 @@ msgstr "Convert this invoice into recurring template"
 msgid "Cook Islands"
 msgstr "Cook Islands"
 
-#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:94
+#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:98
 msgid "Copied!"
 msgstr "Copied!"
 
-#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:94
+#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:98
 msgid "Copy"
 msgstr "Copy"
 
@@ -1923,7 +1923,7 @@ msgctxt "InvoicesTableRowActionMenu"
 msgid "Copy payment link"
 msgstr "Copy payment link"
 
-#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:92
+#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:96
 msgid "copy text"
 msgstr "copy text"
 
@@ -3210,7 +3210,7 @@ msgstr "Every last day of the month"
 msgid "Example: NET 30, –2%/10 days, –1%/20 days"
 msgstr "Example: NET 30, –2%/10 days, –1%/20 days"
 
-#: src/components/aiAssistant/components/AIStartScreen/AIStartScreen.tsx:44
+#: src/components/aiAssistant/components/AIStartScreen/AIStartScreen.tsx:36
 msgid "Examples"
 msgstr "Examples"
 
@@ -3226,7 +3226,7 @@ msgstr "Executive"
 msgid "Expired"
 msgstr "Expired"
 
-#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:122
+#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:148
 msgid "Explore"
 msgstr "Explore"
 
@@ -3721,7 +3721,7 @@ msgstr "Go to Docs"
 msgid "Golf Courses - Public"
 msgstr "Golf Courses - Public"
 
-#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:111
+#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:115
 msgid "Good response"
 msgstr "Good response"
 
@@ -5091,7 +5091,7 @@ msgstr "New"
 msgid "New Caledonia"
 msgstr "New Caledonia"
 
-#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:76
+#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:103
 msgid "New chat"
 msgstr "New chat"
 
@@ -6130,11 +6130,11 @@ msgstr "Professional Services"
 msgid "Project"
 msgstr "Project"
 
-#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:133
+#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:158
 msgid "Prompt Library"
 msgstr "Prompt Library"
 
-#: src/components/aiAssistant/components/AIPrompts/AIPrompts.tsx:26
+#: src/components/aiAssistant/components/AIPrompts/AIPrompts.tsx:23
 msgid "Prompts"
 msgstr "Prompts"
 
@@ -6717,11 +6717,11 @@ msgstr "Search by name"
 msgid "Search by number or vendor"
 msgstr "Search by number or vendor"
 
-#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:84
+#: src/components/aiAssistant/components/AISidebar/AISidebar.tsx:110
 msgid "Search chats"
 msgstr "Search chats"
 
-#: src/components/aiAssistant/components/SearchChatModal/SearchChatModal.tsx:101
+#: src/components/aiAssistant/components/SearchChatModal/SearchChatModal.tsx:95
 msgid "Search chats..."
 msgstr "Search chats..."
 
@@ -7334,7 +7334,7 @@ msgstr "Telecommunication Services"
 msgid "Telegraph Services"
 msgstr "Telegraph Services"
 
-#: src/components/aiAssistant/components/FeedbackForm/FeedbackForm.tsx:122
+#: src/components/aiAssistant/components/FeedbackForm/FeedbackForm.tsx:124
 msgid "Tell us more"
 msgstr "Tell us more"
 
@@ -7378,7 +7378,7 @@ msgstr "Thailand"
 msgid "Thank you for completing onboarding for payments services. We will review the information submitted, and notify you when complete."
 msgstr "Thank you for completing onboarding for payments services. We will review the information submitted, and notify you when complete."
 
-#: src/components/aiAssistant/components/FeedbackForm/FeedbackForm.tsx:92
+#: src/components/aiAssistant/components/FeedbackForm/FeedbackForm.tsx:96
 msgid "Thank you for your feedback!"
 msgstr "Thank you for your feedback!"
 
@@ -7567,11 +7567,11 @@ msgstr "This person is an executive or senior manager with significant managemen
 msgid "This person owns 25% or more of the company."
 msgstr "This person owns 25% or more of the company."
 
-#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:127
+#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:131
 msgid "thumb down"
 msgstr "thumb down"
 
-#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:109
+#: src/components/aiAssistant/components/AssistantButtons/AssistantButtons.tsx:113
 msgid "thumb up"
 msgstr "thumb up"
 
@@ -8380,7 +8380,7 @@ msgstr "West African CFA Franc"
 msgid "Western Sahara"
 msgstr "Western Sahara"
 
-#: src/components/aiAssistant/components/AIStartScreen/AIStartScreen.tsx:37
+#: src/components/aiAssistant/components/AIStartScreen/AIStartScreen.tsx:29
 msgid "What can I help with?"
 msgstr "What can I help with?"
 

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -224,12 +224,12 @@ msgstr "Account holder name"
 msgid "Account Holder Name"
 msgstr "Account Holder Name"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:104
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:95
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:82
 msgid "Account name"
 msgstr "Account name"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:149
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:140
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:94
 #: src/components/onboarding/validators/validationSchemas.ts:118
 #: src/components/receivables/components/BankAccountCustomFields.tsx:79
@@ -291,7 +291,7 @@ msgstr "Add a business executive"
 msgid "Add a business owner"
 msgstr "Add a business owner"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:635
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:634
 msgid "Add a date when the product will be delivered or the service provided"
 msgstr "Add a date when the product will be delivered or the service provided"
 
@@ -329,8 +329,8 @@ msgstr "Add another owner"
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.test.tsx:165
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.test.tsx:212
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.test.tsx:259
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:91
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:252
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:82
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:211
 #: src/components/counterparts/CounterpartDetails/CounterpartTestHelpers.ts:128
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartView.tsx:344
 msgid "Add bank account"
@@ -424,7 +424,7 @@ msgstr "Added by"
 msgid "Added on"
 msgstr "Added on"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:47
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:38
 #: src/components/counterparts/CounterpartDetails/CounterpartContactForm/CounterpartContactForm.tsx:146
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartIndividualForm/CounterpartIndividualForm.tsx:379
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartContactView/CounterpartContactView.tsx:188
@@ -438,8 +438,8 @@ msgstr "Address"
 msgid "Address “{0}” has been updated."
 msgstr "Address “{0}” has been updated."
 
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:50
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:64
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:38
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:55
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:22
 msgid "Address line 1"
 msgstr "Address line 1"
@@ -448,8 +448,8 @@ msgstr "Address line 1"
 msgid "Address line 1 is required"
 msgstr "Address line 1 is required"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:67
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:80
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:55
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:71
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:26
 msgid "Address line 2"
 msgstr "Address line 2"
@@ -535,7 +535,7 @@ msgstr "All invoices"
 msgid "All items"
 msgstr "All items"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:559
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:558
 msgid "All items in the invoice must be in this currency. Remove items that don’t match it."
 msgstr "All items in the invoice must be in this currency. Remove items that don’t match it."
 
@@ -573,7 +573,7 @@ msgstr "Allowed"
 msgid "Already updated PDFs can't be reverted to the default view"
 msgstr "Already updated PDFs can't be reverted to the default view"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:747
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:746
 msgid "Always display selected fields on the form (where available)"
 msgstr "Always display selected fields on the form (where available)"
 
@@ -1040,7 +1040,7 @@ msgstr "Bank Account has been deleted."
 msgid "Bank Account has been set as default."
 msgstr "Bank Account has been set as default."
 
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:119
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:110
 msgid "Bank account holder name"
 msgstr "Bank account holder name"
 
@@ -1122,7 +1122,7 @@ msgstr "Bhutan"
 msgid "Bhutanese Ngultrum"
 msgstr "Bhutanese Ngultrum"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:194
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:185
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:193
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewPaymentDetailsSection.tsx:36
 #: src/components/receivables/InvoiceDetails/InvoicePaymentDetails/InvoicePaymentDetails.tsx:37
@@ -1373,9 +1373,9 @@ msgstr "Canadian Dollar"
 #: src/components/counterparts/components/ConfirmDeleteDialog.test.tsx:53
 #: src/components/counterparts/components/ConfirmDeleteDialog.tsx:54
 #: src/components/counterparts/components/CreateCounterpartDialog.tsx:139
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:173
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:135
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.test.tsx:124
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:243
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:202
 #: src/components/counterparts/CounterpartDetails/CounterpartContactForm/CounterpartContactForm.tsx:161
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartIndividualForm/CounterpartIndividualForm.tsx:436
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:439
@@ -1393,8 +1393,8 @@ msgstr "Canadian Dollar"
 #: src/components/receivables/components/BankAccountDeleteModal.tsx:61
 #: src/components/receivables/components/BankAccountFormDialog.tsx:183
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTable.tsx:547
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:582
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:769
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:581
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:768
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:445
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/DeletePaymentTerms.tsx:40
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:87
@@ -1625,8 +1625,8 @@ msgstr "Christmas Island"
 msgid "Cigar Stores and Stands"
 msgstr "Cigar Stores and Stands"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:83
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:95
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:71
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:86
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:30
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:64
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:29
@@ -2015,12 +2015,6 @@ msgstr "Counterpart VAT ID"
 msgid "Counterparts"
 msgstr "Counterparts"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:138
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:142
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:148
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:153
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:213
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:216
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:16
 #: src/components/counterparts/CounterpartDetails/CounterpartVatForm/validation.tsx:10
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:42
@@ -2136,7 +2130,7 @@ msgstr "Create customer"
 msgid "Create from email"
 msgstr "Create from email"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:810
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:809
 msgid "Create invoice"
 msgstr "Create invoice"
 
@@ -2598,7 +2592,7 @@ msgstr "Description is required"
 
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:464
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:221
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:838
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:837
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/Overview.tsx:45
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:19
 msgid "Details"
@@ -3111,7 +3105,7 @@ msgid "Enable email reminders"
 msgstr "Enable email reminders"
 
 #: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:506
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:616
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:615
 msgid "Enable more fields"
 msgstr "Enable more fields"
 
@@ -3576,8 +3570,8 @@ msgstr "Front of your identity document"
 msgid "Fuel Dealers (Non Automotive)"
 msgstr "Fuel Dealers (Non Automotive)"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:632
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:651
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:631
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:650
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:153
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:293
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:139
@@ -3951,7 +3945,7 @@ msgstr "I confirm that any person owning 25% or more of {entityName} or any pers
 msgid "I own 25% or more of the company."
 msgstr "I own 25% or more of the company."
 
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:134
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:125
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:8
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:90
 #: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:105
@@ -6166,8 +6160,8 @@ msgstr "Public Warehousing and Storage - Farm Products, Refrigerated Goods, Hous
 msgid "Puerto Rico"
 msgstr "Puerto Rico"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:670
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:689
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:669
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:688
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:74
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:141
 #: src/components/receivables/InvoiceDetails/CreateReceivable/validation.ts:195
@@ -6540,7 +6534,7 @@ msgstr "Romanian Leu"
 msgid "Roofing/Siding, Sheet Metal"
 msgstr "Roofing/Siding, Sheet Metal"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:179
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:170
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:13
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:106
 #: src/components/onboarding/validators/validationSchemas.ts:125
@@ -6653,8 +6647,8 @@ msgstr "Saudi Riyal"
 #: src/components/payables/PayableDetails/PayableDetails.test.tsx:347
 #: src/components/payables/PayableDetails/PayableDetailsHeader/PayableDetailsHeader.tsx:82
 #: src/components/receivables/components/BankAccountFormDialog.tsx:193
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:588
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:775
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:587
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:774
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/EditCounterpartModal.tsx:451
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsDialog.tsx:40
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceForm.tsx:352
@@ -6667,7 +6661,7 @@ msgstr "Saudi Riyal"
 msgid "Save"
 msgstr "Save"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:791
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:790
 msgid "Save and continue"
 msgstr "Save and continue"
 
@@ -6975,7 +6969,7 @@ msgstr ""
 msgid "Something went wrong. Please try again"
 msgstr "Something went wrong. Please try again"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:164
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:155
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:12
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:102
 #: src/components/onboarding/validators/validationSchemas.ts:121
@@ -7067,8 +7061,8 @@ msgstr "Start date"
 msgid "State"
 msgstr "State"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:117
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:127
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:105
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:118
 msgid "State / Area / Province"
 msgstr "State / Area / Province"
 
@@ -7348,8 +7342,8 @@ msgstr "Tent and Awning Shops"
 
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:123
 #: src/components/onboarding/OnboardingContent/OnboardingContent.tsx:124
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:708
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:727
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:707
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:726
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/EntitySection.tsx:106
 msgid "Terms and conditions"
 msgstr "Terms and conditions"
@@ -7946,7 +7940,7 @@ msgstr "Unsupported file type for {0}"
 
 #: src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyDetailsFormAdvanced/ApprovalPolicyDetailsFormAdvanced.tsx:280
 #: src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx:1180
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:182
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:144
 #: src/components/counterparts/CounterpartDetails/CounterpartTestHelpers.ts:47
 #: src/components/products/ProductDetails/ProductEditForm/ProductEditForm.tsx:266
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/ReminderForm/BeforeDueDateReminderForm.tsx:469
@@ -7972,7 +7966,7 @@ msgstr "Update Approval Policy"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.test.tsx:99
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.test.tsx:319
-#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:252
+#: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:211
 #: src/components/counterparts/CounterpartDetails/CounterpartDetails.test.tsx:296
 msgid "Update bank account"
 msgstr "Update bank account"
@@ -8445,7 +8439,7 @@ msgstr "Yemeni Rial"
 msgid "Yes"
 msgstr "Yes"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:673
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:672
 msgid "You can add a document number to have it in the PDF"
 msgstr "You can add a document number to have it in the PDF"
 
@@ -8493,7 +8487,7 @@ msgstr "You can create your first tag."
 msgid "You can disable it later in the PDF settings"
 msgstr "You can disable it later in the PDF settings"
 
-#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:711
+#: src/components/receivables/InvoiceDetails/CreateReceivable/CreateReceivables.tsx:710
 msgid "You can include details about the warranty, insurance, liability, late payment fees and any other important notes"
 msgstr "You can include details about the warranty, insurance, liability, late payment fees and any other important notes"
 
@@ -8633,8 +8627,8 @@ msgstr "Zambian Kwacha"
 msgid "Zimbabwe"
 msgstr "Zimbabwe"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:100
-#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:111
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:88
+#: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:102
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:34
 msgid "ZIP code"
 msgstr "ZIP code"

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -57,7 +57,6 @@ msgstr "{0, select, credit_note {Credit Note has been sent} invoice {Invoice has
 #: src/components/financing/components/FinanceDetails.tsx:186
 #: src/components/financing/components/FinanceFaqDetails.tsx:58
 #: src/components/financing/components/FinanceFaqDetails.tsx:62
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:80
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:20
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/FullfillmentSummary.tsx:114
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/InvoiceRecurrenceCancelModal.tsx:89
@@ -73,8 +72,8 @@ msgid "{0} - {1}"
 msgstr "{0} - {1}"
 
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:49
-msgid "{0} ({code})"
-msgstr "{0} ({code})"
+#~ msgid "{0} ({code})"
+#~ msgstr "{0} ({code})"
 
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:343
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/PaymentTerms/PaymentTermsSummary.tsx:47
@@ -221,7 +220,7 @@ msgstr "Access Restricted"
 msgid "Account holder name"
 msgstr "Account holder name"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:142
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:114
 msgid "Account Holder Name"
 msgstr "Account Holder Name"
 
@@ -241,7 +240,7 @@ msgstr "Account name"
 msgid "Account number"
 msgstr "Account number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:151
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:123
 msgid "Account Number"
 msgstr "Account Number"
 
@@ -1024,7 +1023,7 @@ msgstr "Bank Account “{0}” has been created."
 msgid "Bank Account “{0}” has been updated."
 msgstr "Bank Account “{0}” has been updated."
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:84
+#: src/components/receivables/components/BankAccountFormContent.tsx:72
 msgid "Bank account {0}"
 msgstr "Bank account {0}"
 
@@ -1049,7 +1048,7 @@ msgstr "Bank account holder name"
 msgid "Bank accounts"
 msgstr "Bank accounts"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:229
+#: src/components/receivables/components/BankAccountFormContent.tsx:219
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:183
 #: src/components/receivables/validation.ts:35
 msgid "Bank name"
@@ -1381,7 +1380,7 @@ msgstr "Canadian Dollar"
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartIndividualForm/CounterpartIndividualForm.tsx:436
 #: src/components/counterparts/CounterpartDetails/CounterpartForm/CounterpartOrganizationForm/CounterpartOrganizationForm.tsx:439
 #: src/components/counterparts/CounterpartDetails/CounterpartTestHelpers.ts:27
-#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:105
+#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:91
 #: src/components/counterparts/CounterpartsTable/CounterpartsTable.tsx:462
 #: src/components/onboarding/hooks/useOnboardingActions.ts:130
 #: src/components/payables/PayableDetails/PayableDetails.test.tsx:86
@@ -1629,7 +1628,7 @@ msgstr "Cigar Stores and Stands"
 #: src/components/counterparts/CounterpartDetails/CounterpartAddressForm/CounterpartAddressForm.tsx:83
 #: src/components/counterparts/CounterpartDetails/CounterpartAddressFormUpdate/CounterpartAddressFormUpdate.tsx:95
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:30
-#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:83
+#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:64
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:29
 #: src/components/onboarding/validators/validationSchemas.ts:158
 msgid "City"
@@ -2023,19 +2022,15 @@ msgstr "Counterparts"
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:213
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:216
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:16
-#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:69
 #: src/components/counterparts/CounterpartDetails/CounterpartVatForm/validation.tsx:10
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:42
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:110
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:75
-#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:44
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:115
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:26
 #: src/components/onboarding/validators/validationSchemas.ts:115
 #: src/components/onboarding/validators/validationSchemas.ts:155
-#: src/components/receivables/components/BankAccountFormContent.tsx:166
-#: src/components/receivables/components/BankAccountFormContent.tsx:169
 #: src/components/receivables/validation.ts:27
+#: src/ui/Country/MoniteCountry.tsx:69
 msgid "Country"
 msgstr "Country"
 
@@ -2222,7 +2217,7 @@ msgstr "Create Quote"
 msgid "Create User Role"
 msgstr "Create User Role"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:114
+#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:100
 msgid "Create Vat Id"
 msgstr "Create Vat Id"
 
@@ -2289,7 +2284,7 @@ msgstr "Cuba"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:20
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:114
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:95
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:77
 #: src/components/onboarding/validators/validationSchemas.ts:116
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:152
 #: src/components/products/ProductDetails/validation.ts:48
@@ -2416,7 +2411,7 @@ msgstr "default"
 msgid "Default"
 msgstr "Default"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:261
+#: src/components/receivables/components/BankAccountFormContent.tsx:251
 msgid "Default currency switch"
 msgstr "Default currency switch"
 
@@ -2700,7 +2695,7 @@ msgstr "Discount Stores"
 msgid "Discounted subtotal"
 msgstr "Discounted subtotal"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:212
+#: src/components/receivables/components/BankAccountFormContent.tsx:202
 #: src/components/receivables/validation.ts:14
 #: src/components/receivables/validation.ts:40
 msgid "Display name"
@@ -3959,7 +3954,7 @@ msgstr "I own 25% or more of the company."
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx:134
 #: src/components/counterparts/CounterpartDetails/CounterpartBankForm/validation.tsx:8
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartBankView/CounterpartBankView.tsx:90
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:133
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:105
 #: src/components/onboarding/validators/validationSchemas.ts:122
 #: src/components/receivables/components/BankAccountCustomFields.tsx:199
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/InvoicePreview.tsx:188
@@ -4613,13 +4608,13 @@ msgstr "Libyan Dinar"
 msgid "Liechtenstein"
 msgstr "Liechtenstein"
 
-#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:65
+#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:46
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:27
 #: src/components/onboarding/validators/validationSchemas.ts:156
 msgid "Line 1"
 msgstr "Line 1"
 
-#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:74
+#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:55
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:28
 #: src/components/onboarding/validators/validationSchemas.ts:157
 msgid "Line 2"
@@ -6003,7 +5998,7 @@ msgstr "Political Organizations"
 msgid "Portugal"
 msgstr "Portugal"
 
-#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:102
+#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:83
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:31
 #: src/components/onboarding/validators/validationSchemas.ts:160
 msgid "Postal code"
@@ -6557,7 +6552,7 @@ msgstr "Roofing/Siding, Sheet Metal"
 msgid "Routing number"
 msgstr "Routing number"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:160
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:132
 msgid "Routing Number"
 msgstr "Routing Number"
 
@@ -6830,7 +6825,7 @@ msgstr "Set a recurrence period to issue invoices automatically"
 msgid "Set as default"
 msgstr "Set as default"
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:263
+#: src/components/receivables/components/BankAccountFormContent.tsx:253
 msgid "Set as default for this currency"
 msgstr "Set as default for this currency"
 
@@ -6992,7 +6987,7 @@ msgstr "Something went wrong. Please try again"
 msgid "Sort code"
 msgstr "Sort code"
 
-#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:169
+#: src/components/onboarding/OnboardingBankAccount/OnboardingBankAccount.tsx:141
 msgid "Sort Code"
 msgstr "Sort Code"
 
@@ -7066,7 +7061,7 @@ msgid "Start date"
 msgstr "Start date"
 
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartAddressView/CounterpartAddressView.tsx:38
-#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:92
+#: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:73
 #: src/components/onboarding/OnboardingPersonsReview/OnboardingAddressView/OnboardingAddressView.tsx:30
 #: src/components/onboarding/validators/validationSchemas.ts:159
 msgid "State"
@@ -7523,7 +7518,7 @@ msgstr "They will contact you if your credit score improves and you can reapply.
 msgid "This action can't be undone."
 msgstr "This action can't be undone."
 
-#: src/components/receivables/components/BankAccountFormContent.tsx:150
+#: src/components/receivables/components/BankAccountFormContent.tsx:164
 msgid "This bank account will receive payments for your invoices"
 msgstr "This bank account will receive payments for your invoices"
 
@@ -7995,7 +7990,7 @@ msgstr "Update PDF File"
 msgid "Update PDF file with payment info"
 msgstr "Update PDF file with payment info"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:114
+#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:100
 msgid "Update Vat Id"
 msgstr "Update Vat Id"
 
@@ -8251,7 +8246,7 @@ msgstr "VAT total"
 msgid "VAT Total"
 msgstr "VAT Total"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:87
+#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:73
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:79
 msgid "Vat type"
 msgstr "Vat type"
@@ -8260,7 +8255,7 @@ msgstr "Vat type"
 msgid "Vat Type"
 msgstr "Vat Type"
 
-#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:95
+#: src/components/counterparts/CounterpartDetails/CounterpartVatForm/CounterpartVatForm.tsx:81
 #: src/components/counterparts/CounterpartDetails/CounterpartView/CounterpartVatView/CounterpartVatView.tsx:83
 msgid "Vat value"
 msgstr "Vat value"

--- a/packages/sdk-react/src/core/utils/selectHelpers.ts
+++ b/packages/sdk-react/src/core/utils/selectHelpers.ts
@@ -1,21 +1,6 @@
 import { components } from '@/api';
 
-import type { CountriesType } from './countries';
 import type { CurrenciesType } from './currencies';
-
-export type SelectOption = { label: string; value: string };
-
-export const countriesToSelect = (countries: CountriesType): SelectOption[] =>
-  Object.keys(countries).map((country) => ({
-    value: country,
-    label: countries[country as AllowedCountries],
-  }));
-
-export const currencyToSelect = (currencies: CurrenciesType): SelectOption[] =>
-  Object.keys(currencies).map((currency) => ({
-    value: currency,
-    label: currencies[currency as CurrencyEnum],
-  }));
 
 export const currenciesToStringArray = (
   currencies: CurrenciesType
@@ -23,4 +8,3 @@ export const currenciesToStringArray = (
   Object.keys(currencies).map((currency) => currency as CurrencyEnum);
 
 type CurrencyEnum = components['schemas']['CurrencyEnum'];
-type AllowedCountries = components['schemas']['AllowedCountries'];

--- a/packages/sdk-react/src/ui/Country/CountryFlag.tsx
+++ b/packages/sdk-react/src/ui/Country/CountryFlag.tsx
@@ -1,0 +1,35 @@
+import { Box, BoxProps } from '@mui/material';
+
+export interface CountryFlagProps {
+  code: string;
+  label: string;
+  width?: string;
+  className?: string;
+  boxProps?: BoxProps;
+}
+
+export const CountryFlag = ({
+  code,
+  label,
+  width = '20',
+  className,
+  boxProps,
+}: CountryFlagProps) => {
+  const imgProps = {
+    className,
+    loading: 'lazy' as const,
+    width,
+    src: `https://flagcdn.com/w${width}/${code.toLowerCase()}.png`,
+    // eslint-disable-next-line lingui/no-unlocalized-strings
+    srcSet: `https://flagcdn.com/w${
+      parseInt(width) * 2
+    }/${code.toLowerCase()}.png 2x`,
+    alt: label,
+  };
+
+  if (boxProps) {
+    return <Box component="img" {...imgProps} {...boxProps} />;
+  }
+
+  return <img {...imgProps} />;
+};

--- a/packages/sdk-react/src/ui/Country/CountryInput.tsx
+++ b/packages/sdk-react/src/ui/Country/CountryInput.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+import { CountryType } from '@/core/utils/countries';
+import { InputAdornment, TextField, TextFieldProps } from '@mui/material';
+
+import { CountryFlag } from './CountryFlag';
+
+export type CountryInputProps = TextFieldProps & {
+  showFlag?: boolean;
+  currentValue?: CountryType | null;
+  helperText?: string;
+};
+
+export const CountryInput = React.forwardRef<HTMLDivElement, CountryInputProps>(
+  (
+    {
+      showFlag = true,
+      currentValue,
+      label,
+      required,
+      InputProps,
+      inputProps,
+      error,
+      helperText,
+      ...rest
+    },
+    ref
+  ) => (
+    <TextField
+      {...rest}
+      ref={ref}
+      label={label}
+      required={required}
+      error={error}
+      helperText={helperText}
+      inputProps={{
+        ...inputProps,
+        autoComplete: 'new-password',
+      }}
+      InputProps={{
+        ...InputProps,
+        startAdornment:
+          showFlag && currentValue && typeof currentValue.code === 'string' ? (
+            <InputAdornment position="start" sx={{ ml: 1, mr: -0.5 }}>
+              <CountryFlag
+                code={currentValue.code}
+                label={currentValue.label || currentValue.code}
+              />
+            </InputAdornment>
+          ) : (
+            InputProps?.startAdornment
+          ),
+      }}
+    />
+  )
+);

--- a/packages/sdk-react/src/ui/Country/CountryOption.tsx
+++ b/packages/sdk-react/src/ui/Country/CountryOption.tsx
@@ -1,0 +1,48 @@
+import { CountryType } from '@/core/utils/countries';
+import { Box, Typography } from '@mui/material';
+
+import { CountryFlag } from './CountryFlag';
+
+export interface CountryOptionProps {
+  props: React.HTMLAttributes<HTMLLIElement>;
+  option: CountryType;
+  state: {
+    inputValue: string;
+  };
+  showFlag?: boolean;
+}
+
+export const CountryOption = ({
+  props,
+  option,
+  state,
+  showFlag = true,
+}: CountryOptionProps) => {
+  const { inputValue } = state;
+  const parts = option.label.split(new RegExp(`(${inputValue})`, 'gi'));
+
+  return (
+    <Box component="li" sx={{ '& > img': { mr: 2, flexShrink: 0 } }} {...props}>
+      {showFlag && <CountryFlag code={option.code} label={option.label} />}
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        <Typography variant="body2">
+          {parts.map((part, index) => {
+            const isMatch = part.toLowerCase() === inputValue.toLowerCase();
+
+            return (
+              <Typography
+                key={`${part}-${index}-${isMatch ? 'match' : 'nomatch'}`}
+                component="span"
+                sx={{
+                  fontWeight: isMatch ? 'bolder' : 'regular',
+                }}
+              >
+                {part}
+              </Typography>
+            );
+          })}
+        </Typography>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/sdk-react/src/ui/Country/MoniteCountry.tsx
+++ b/packages/sdk-react/src/ui/Country/MoniteCountry.tsx
@@ -1,0 +1,134 @@
+import { useMemo } from 'react';
+import {
+  type UseControllerProps,
+  type FieldValues,
+  type FieldPath,
+  useController,
+} from 'react-hook-form';
+
+import { components } from '@/api';
+import {
+  RHFAutocompleteProps,
+  RHFAutocomplete,
+} from '@/components/RHF/RHFAutocomplete';
+import { useMoniteContext } from '@/core/context/MoniteContext';
+import { CountryType, getCountriesArray } from '@/core/utils/countries';
+import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+import { TextFieldProps } from '@mui/material';
+import type { AutocompleteRenderInputParams } from '@mui/material';
+
+import { CountryInput } from './CountryInput';
+import { CountryOption } from './CountryOption';
+
+export type MoniteCountryProps<
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>
+> = UseControllerProps<TFieldValues, TName> & {
+  disabled?: boolean;
+  required?: TextFieldProps['required'];
+  label?: string;
+  hideLabel?: boolean;
+  size?: TextFieldProps['size'];
+  fullWidth?: boolean;
+  multiple?: RHFAutocompleteProps<TFieldValues, TName, CountryType>['multiple'];
+  countryOptions?: CountryType[];
+  allowedCountries?: components['schemas']['AllowedCountries'][];
+  showFlag?: boolean;
+  onChange?: RHFAutocompleteProps<TFieldValues, TName, CountryType>['onChange'];
+};
+
+export const MoniteCountry = <
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>
+>({
+  disabled,
+  required,
+  label,
+  hideLabel = false,
+  fullWidth,
+  name,
+  control,
+  defaultValue,
+  rules,
+  shouldUnregister,
+  countryOptions: customCountryOptions,
+  allowedCountries,
+  showFlag = true,
+  onChange: customOnChange,
+  ...props
+}: MoniteCountryProps<TFieldValues, TName>) => {
+  const { i18n } = useLingui();
+  const { componentSettings } = useMoniteContext();
+
+  const { field, fieldState } = useController<TFieldValues, TName>({
+    name,
+    control,
+  });
+
+  const countryLabel = label ?? t(i18n)`Country`;
+
+  const renderInput = (params: AutocompleteRenderInputParams) => (
+    <CountryInput
+      {...params}
+      ref={params.InputProps.ref}
+      error={Boolean(fieldState.error)}
+      helperText={fieldState.error?.message}
+      required={required}
+      label={countryLabel}
+      currentValue={field.value as CountryType | null}
+      showFlag={showFlag}
+    />
+  );
+
+  const countryOptions = useMemo(() => {
+    const baseOptions = customCountryOptions ?? getCountriesArray(i18n);
+
+    if (allowedCountries) {
+      return baseOptions.filter((countryItem) =>
+        allowedCountries.includes(countryItem.code as AllowedCountries)
+      );
+    }
+
+    if (componentSettings?.receivables?.bankAccountCountries) {
+      return baseOptions.filter((countryItem) =>
+        componentSettings.receivables.bankAccountCountries?.includes(
+          countryItem.code as AllowedCountries
+        )
+      );
+    }
+
+    return baseOptions;
+  }, [componentSettings, customCountryOptions, allowedCountries, i18n]);
+
+  return (
+    <RHFAutocomplete
+      {...props}
+      name={name}
+      control={control}
+      defaultValue={defaultValue}
+      rules={rules}
+      shouldUnregister={shouldUnregister}
+      onChange={customOnChange}
+      disabled={countryOptions?.length === 1 || disabled}
+      className={`Monite-Country ${hideLabel ? 'Monite-Label-Hidden' : ''}`}
+      label={countryLabel}
+      options={countryOptions}
+      optionKey="code"
+      labelKey="label"
+      fullWidth={fullWidth}
+      renderInput={renderInput}
+      renderOption={(props, option, state) => (
+        <CountryOption
+          key={option.code}
+          props={props}
+          option={option}
+          state={{ inputValue: state?.inputValue ?? '' }}
+          showFlag={showFlag}
+        />
+      )}
+    />
+  );
+};
+
+type AllowedCountries = components['schemas']['AllowedCountries'];

--- a/packages/sdk-react/src/ui/Country/index.tsx
+++ b/packages/sdk-react/src/ui/Country/index.tsx
@@ -1,0 +1,3 @@
+export { MoniteCountry } from './MoniteCountry';
+export { CountryOption } from './CountryOption';
+export { CountryInput } from './CountryInput';


### PR DESCRIPTION
**Changes:**

*   Introduced `<MoniteCountry />` as the standard component for country selection.
*   Refactored related sub-components (`CountryOption`, `CountryInput`, `CountryFlag`) to support `MoniteCountry` and fix bugs related to search highlighting, input focus errors, and error message display.
*   Replaced inconsistent country selectors in various forms with `<MoniteCountry />`.
*   Removed redundant option-generation logic from affected forms.

**Affected UI Locations:**
*   **Counterpart Forms:** Address (Create/Update), Bank Account (Create/Update), VAT ID (Create/Update).
*   **Receivables:** Entity Bank Account Form (Settings -> Bank Accounts).
*   **Onboarding Flow:** Bank Account Step, Address Step(s).
