### PR TITLE
fix(DEV-15570): Approval policies triggers for tags, counterparts, and created_by_user

### DIFF
--- a/.changeset/real-queens-divide.md
+++ b/.changeset/real-queens-divide.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Fix Approval Policies with triggers for tags

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
@@ -106,40 +106,22 @@ const buildApprovalPolicyPayload = (values: FormValues) => {
         ...(values.triggers.was_created_by_user_id?.length &&
         values.triggers.was_created_by_user_id?.length > 0
           ? [
-              {
-                operator: 'in',
-                left_operand: {
-                  name: 'invoice.was_created_by_user_id',
-                },
-                right_operand: values.triggers.was_created_by_user_id.map(
-                  (user) => user.id
-                ),
-              },
+              `{invoice.was_created_by_user_id in [${values.triggers.was_created_by_user_id
+                .map((user) => `'${user.id}'`)
+                .join(', ')}]}`,
             ]
           : []),
         ...(values.triggers.tags?.length && values.triggers.tags?.length > 0
-          ? [
-              {
-                operator: 'in',
-                left_operand: {
-                  name: 'invoice.tags.id',
-                },
-                right_operand: values.triggers.tags.map((tag) => tag.id),
-              },
-            ]
+          ? values.triggers.tags.map(
+              (tag) => `{'${tag.id}' in invoice.tags.id}`
+            )
           : []),
         ...(values.triggers.counterpart_id?.length &&
         values.triggers.counterpart_id?.length > 0
           ? [
-              {
-                operator: 'in',
-                left_operand: {
-                  name: 'invoice.counterpart_id',
-                },
-                right_operand: values.triggers.counterpart_id.map(
-                  (counterpart) => counterpart.id
-                ),
-              },
+              `{invoice.counterpart_id in [${values.triggers.counterpart_id
+                .map((counterpart) => `'${counterpart.id}'`)
+                .join(', ')}]}`,
             ]
           : []),
         ...(values.triggers.amount?.value?.length &&

--- a/packages/sdk-react/src/mocks/approvalPolicies/approvalPoliciesFixture.ts
+++ b/packages/sdk-react/src/mocks/approvalPolicies/approvalPoliciesFixture.ts
@@ -27,32 +27,12 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
         // @ts-expect-error - `trigger` is not covered by the schema
         trigger: {
           all: [
-            "{event_name == 'submit_for_approval'}",
-            {
-              operator: 'in',
-              left_operand: {
-                name: 'invoice.was_created_by_user_id',
-              },
-              right_operand: [entityUserByIdFixture.id, entityUser2.id],
-            },
-            {
-              operator: 'in',
-              left_operand: {
-                name: 'invoice.tags.id',
-              },
-              right_operand: [
-                tagListFixture[0].id,
-                tagListFixture[2].id,
-                tagListFixture[3].id,
-              ],
-            },
-            {
-              operator: 'in',
-              left_operand: {
-                name: 'invoice.counterpart_id',
-              },
-              right_operand: [organizationId, individualId],
-            },
+            "{event_name == 'submitted_for_approval'}",
+            `{invoice.was_created_by_user_id in ['${entityUserByIdFixture.id}', '${entityUser2.id}']}`,
+            `{'${tagListFixture[0].id}' in invoice.tags.id}`,
+            `{'${tagListFixture[2].id}' in invoice.tags.id}`,
+            `{'${tagListFixture[3].id}' in invoice.tags.id}`,
+            `{invoice.counterpart_id in ['${organizationId}', '${individualId}']}`,
             {
               operator: '>=',
               left_operand: {
@@ -68,7 +48,7 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
               right_operand: '50000',
             },
             {
-              operator: 'in',
+              operator: '==',
               left_operand: {
                 name: 'invoice.currency',
               },
@@ -151,14 +131,8 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
         // @ts-expect-error - `trigger` is not covered by the schema
         trigger: {
           all: [
-            "{event_name == 'submit_for_approval'}",
-            {
-              operator: 'in',
-              left_operand: {
-                name: 'invoice.was_created_by_user_id',
-              },
-              right_operand: [entityUserByIdFixture.id, entityUser2.id],
-            },
+            "{event_name == 'submitted_for_approval'}",
+            `{invoice.was_created_by_user_id in ['${entityUserByIdFixture.id}', '${entityUser2.id}']}`,
           ],
         },
         script: [
@@ -193,17 +167,10 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
         // @ts-expect-error - `trigger` is not covered by the schema
         trigger: {
           all: [
-            {
-              operator: 'in',
-              left_operand: {
-                name: 'invoice.tags.id',
-              },
-              right_operand: [
-                tagListFixture[0].id,
-                tagListFixture[2].id,
-                tagListFixture[3].id,
-              ],
-            },
+            "{event_name == 'submitted_for_approval'}",
+            `{'${tagListFixture[0].id}' in invoice.tags.id}`,
+            `{'${tagListFixture[2].id}' in invoice.tags.id}`,
+            `{'${tagListFixture[3].id}' in invoice.tags.id}`,
           ],
         },
         script: [
@@ -241,14 +208,8 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
         // @ts-expect-error - `trigger` is not covered by the schema
         trigger: {
           all: [
-            "{event_name == 'submit_for_approval'}",
-            {
-              operator: 'in',
-              left_operand: {
-                name: 'invoice.counterpart_id',
-              },
-              right_operand: [organizationId, individualId],
-            },
+            "{event_name == 'submitted_for_approval'}",
+            `{invoice.counterpart_id in ['${organizationId}', '${individualId}']}`,
           ],
         },
         script: [
@@ -295,7 +256,7 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
         // @ts-expect-error - `trigger` is not covered by the schema
         trigger: {
           all: [
-            "{event_name == 'submit_for_approval'}",
+            "{event_name == 'submitted_for_approval'}",
             {
               operator: '>=',
               left_operand: {
@@ -311,7 +272,7 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
               right_operand: '50000',
             },
             {
-              operator: 'in',
+              operator: '==',
               left_operand: {
                 name: 'invoice.currency',
               },


### PR DESCRIPTION
# Scope

Fix approval policies payload for triggers of type tags, counterparts, and created_by_user.

Jira ticket: https://monite.atlassian.net/browse/DEV-15570

# Implementation

- Changed the payload of the approval policies form to use format `"{'398b2748-b255-46da-b8dc-a01219539ec9' in invoice.tags.id}"` instead of `"operator": "in"` syntax for triggers tags, counterparts, and created_by_user.
- Updated `useApprovalPolicyTrigger` to parse the new payload syntax.
- Updated tests fixtures.

# Steps to test

## Tags
1. Create an Approval Policy with trigger tag for a specific tag.
2. Create and submit a Payable with that tag.
3. Check that the Approval Policy matches the Payable and an Approval Request was issued.

## Tags and created by user
1. Create an Approval Policy with trigger tag for a specific tag AND trigger for the same user.
2. Create and submit a Payable with that tag.
3. Check that the Approval Policy matches the Payable and an Approval Request was issued.