### PR TITLE
fix(DEV-15570): Approval policies triggers for tags, with better parsing

### DIFF
--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/components/ApprovalPoliciesTriggers.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPoliciesTable/components/ApprovalPoliciesTriggers.tsx
@@ -1,7 +1,7 @@
 import type { components } from '@/api';
 import {
   useApprovalPolicyTrigger,
-  Triggers,
+  ParsedTriggers,
 } from '@/components/approvalPolicies/useApprovalPolicyTrigger';
 
 import * as Styled from '../styles';
@@ -27,48 +27,50 @@ export const ApprovalPoliciesTriggers = ({
 
   return (
     <Styled.ColumnList>
-      {(Object.keys(triggers) as Array<keyof Triggers>).map((triggerKey) => {
-        switch (triggerKey) {
-          case 'amount': {
-            return (
-              <li key={triggerKey}>
-                <UMoneyBill width={18} />
-                {getTriggerName(triggerKey)}
-              </li>
-            );
-          }
+      {(Object.keys(triggers) as Array<keyof ParsedTriggers>).map(
+        (triggerKey) => {
+          switch (triggerKey) {
+            case 'amount': {
+              return (
+                <li key={triggerKey}>
+                  <UMoneyBill width={18} />
+                  {getTriggerName(triggerKey)}
+                </li>
+              );
+            }
 
-          case 'was_created_by_user_id': {
-            return (
-              <li key={triggerKey}>
-                <UUserCircle width={18} />
-                {getTriggerName(triggerKey)}
-              </li>
-            );
-          }
+            case 'was_created_by_user_id': {
+              return (
+                <li key={triggerKey}>
+                  <UUserCircle width={18} />
+                  {getTriggerName(triggerKey)}
+                </li>
+              );
+            }
 
-          case 'counterpart_id': {
-            return (
-              <li key={triggerKey}>
-                <UBuilding width={18} />
-                {getTriggerName(triggerKey)}
-              </li>
-            );
-          }
+            case 'counterpart_id': {
+              return (
+                <li key={triggerKey}>
+                  <UBuilding width={18} />
+                  {getTriggerName(triggerKey)}
+                </li>
+              );
+            }
 
-          case 'tags': {
-            return (
-              <li key={triggerKey}>
-                <ULabel width={18} />
-                {getTriggerName(triggerKey)}
-              </li>
-            );
-          }
+            case 'tags': {
+              return (
+                <li key={triggerKey}>
+                  <ULabel width={18} />
+                  {getTriggerName(triggerKey)}
+                </li>
+              );
+            }
 
-          default:
-            return null;
+            default:
+              return null;
+          }
         }
-      })}
+      )}
     </Styled.ColumnList>
   );
 };

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
@@ -7,7 +7,9 @@ import { useDialog } from '@/components';
 import { AutocompleteRoles } from '@/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/AutocompleteRoles';
 import { AutocompleteUser } from '@/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/AutocompleteUser';
 import {
+  NAMED_VALUES,
   NamedValue,
+  OPERATOR_OPERATIONS,
   OperatorOperation,
 } from '@/components/approvalPolicies/triggerUtils';
 import {
@@ -111,9 +113,9 @@ const buildApprovalPolicyPayload = (values: FormValues) => {
         values.triggers.was_created_by_user_id?.length > 0
           ? [
               {
-                operator: 'in',
+                operator: OPERATOR_OPERATIONS.IN,
                 left_operand: {
-                  name: 'invoice.was_created_by_user_id',
+                  name: `invoice.${NAMED_VALUES.WAS_CREATED_BY_USER_ID}`,
                 },
                 right_operand: values.triggers.was_created_by_user_id.map(
                   (user) => user.id
@@ -125,9 +127,9 @@ const buildApprovalPolicyPayload = (values: FormValues) => {
         values.triggers.counterpart_id?.length > 0
           ? [
               {
-                operator: 'in',
+                operator: OPERATOR_OPERATIONS.IN,
                 left_operand: {
-                  name: 'invoice.counterpart_id',
+                  name: `invoice.${NAMED_VALUES.COUNTERPART_ID}`,
                 },
                 right_operand: values.triggers.counterpart_id.map(
                   (counterpart) => counterpart.id
@@ -138,10 +140,10 @@ const buildApprovalPolicyPayload = (values: FormValues) => {
         // Named value `tags.id` is a list. So in order to use the 'x in list' format, we need to build a trigger for each tag
         ...(values.triggers.tags?.length && values.triggers.tags?.length > 0
           ? values.triggers.tags.map((tag) => ({
-              operator: 'in',
+              operator: OPERATOR_OPERATIONS.IN,
               left_operand: tag.id,
               right_operand: {
-                name: 'invoice.tags.id',
+                name: `invoice.${NAMED_VALUES.TAGS}`,
               },
             }))
           : []),
@@ -151,15 +153,15 @@ const buildApprovalPolicyPayload = (values: FormValues) => {
               ...values.triggers.amount.value.map((value) => ({
                 operator: value[0],
                 left_operand: {
-                  name: 'invoice.amount',
+                  name: `invoice.${NAMED_VALUES.AMOUNT}`,
                 },
                 right_operand:
                   typeof value[1] === 'number' ? value[1] : parseInt(value[1]),
               })),
               {
-                operator: '==',
+                operator: OPERATOR_OPERATIONS.EQUALS,
                 left_operand: {
-                  name: 'invoice.currency',
+                  name: `invoice.${NAMED_VALUES.CURRENCY}`,
                 },
                 right_operand: values.triggers.amount.currency,
               },

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
@@ -117,17 +117,6 @@ const buildApprovalPolicyPayload = (values: FormValues) => {
               },
             ]
           : []),
-        ...(values.triggers.tags?.length && values.triggers.tags?.length > 0
-          ? [
-              {
-                operator: 'in',
-                left_operand: {
-                  name: 'invoice.tags.id',
-                },
-                right_operand: values.triggers.tags.map((tag) => tag.id),
-              },
-            ]
-          : []),
         ...(values.triggers.counterpart_id?.length &&
         values.triggers.counterpart_id?.length > 0
           ? [
@@ -141,6 +130,16 @@ const buildApprovalPolicyPayload = (values: FormValues) => {
                 ),
               },
             ]
+          : []),
+        // Named value `tags.id` is a list. So in order to use the 'x in list' format, we need to build a trigger for each tag
+        ...(values.triggers.tags?.length && values.triggers.tags?.length > 0
+          ? values.triggers.tags.map((tag) => ({
+              operator: 'in',
+              left_operand: tag.id,
+              right_operand: {
+                name: 'invoice.tags.id',
+              },
+            }))
           : []),
         ...(values.triggers.amount?.value?.length &&
         values.triggers.amount?.value?.length > 0

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/ApprovalPolicyForm.tsx
@@ -7,13 +7,15 @@ import { useDialog } from '@/components';
 import { AutocompleteRoles } from '@/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/AutocompleteRoles';
 import { AutocompleteUser } from '@/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyForm/AutocompleteUser';
 import {
+  NamedValue,
+  OperatorOperation,
+} from '@/components/approvalPolicies/triggerUtils';
+import {
   ApprovalPolicyScriptType,
   useApprovalPolicyScript,
 } from '@/components/approvalPolicies/useApprovalPolicyScript';
 import {
   useApprovalPolicyTrigger,
-  ApprovalPoliciesTriggerKey,
-  ApprovalPoliciesOperator,
   AmountTuple,
 } from '@/components/approvalPolicies/useApprovalPolicyTrigger';
 import {
@@ -61,11 +63,13 @@ interface ApprovalPolicyFormProps {
   onUpdated?: (id: string) => void;
 }
 
+type FormTriggerKey = Exclude<NamedValue, 'tags.id'> | 'tags';
+
 export interface FormValues {
   name: string;
   description: string;
 
-  triggerType: ApprovalPoliciesTriggerKey | null;
+  triggerType: FormTriggerKey | null;
   triggers: {
     was_created_by_user_id?: components['schemas']['EntityUserResponse'][];
     tags?: components['schemas']['TagReadSchema'][];
@@ -75,7 +79,7 @@ export interface FormValues {
       value: AmountTuple[];
     };
   };
-  amountOperator?: ApprovalPoliciesOperator;
+  amountOperator?: OperatorOperation;
   amountValue?: string | number;
   amountRangeLeftValue?: string | number;
   amountRangeRightValue?: string | number;
@@ -262,8 +266,9 @@ export const ApprovalPolicyForm = ({
 
   const [isAddingTrigger, setIsAddingTrigger] = useState<boolean>(false);
   const [isAddingRule, setIsAddingRule] = useState<boolean>(false);
-  const [triggerInEdit, setTriggerInEdit] =
-    useState<ApprovalPoliciesTriggerKey | null>(null);
+  const [triggerInEdit, setTriggerInEdit] = useState<FormTriggerKey | null>(
+    null
+  );
 
   const [prevFormValues, setPrevFormValues] =
     useState<Partial<FormValues> | null>(null);

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyView/ApprovalPolicyView.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyView/ApprovalPolicyView.tsx
@@ -8,7 +8,7 @@ import {
   Rules,
 } from '@/components/approvalPolicies/useApprovalPolicyScript';
 import {
-  Triggers,
+  ParsedTriggers,
   useApprovalPolicyTrigger,
 } from '@/components/approvalPolicies/useApprovalPolicyTrigger';
 import { getCounterpartName } from '@/components/counterparts/helpers';
@@ -94,65 +94,65 @@ export const ApprovalPolicyView = ({
       },
     });
 
-  const triggersList = (Object.keys(triggers) as Array<keyof Triggers>).map(
-    (triggerKey) => {
-      const triggerLabel = getTriggerLabel(triggerKey);
-      let triggerValue: ReactNode;
+  const triggersList = (
+    Object.keys(triggers) as Array<keyof ParsedTriggers>
+  ).map((triggerKey) => {
+    const triggerLabel = getTriggerLabel(triggerKey);
+    let triggerValue: ReactNode;
 
-      switch (triggerKey) {
-        case 'was_created_by_user_id':
-          if (Array.isArray(triggers[triggerKey])) {
-            triggerValue = (
-              <Stack direction="row" gap={1} sx={{ flexWrap: 'wrap' }}>
-                {triggers[triggerKey].map((userId) => (
-                  <User key={userId} userId={userId} />
-                ))}
-              </Stack>
-            );
-          }
-          break;
-        case 'tags':
+    switch (triggerKey) {
+      case 'was_created_by_user_id':
+        if (Array.isArray(triggers[triggerKey])) {
           triggerValue = (
             <Stack direction="row" gap={1} sx={{ flexWrap: 'wrap' }}>
-              {tagsForTriggers?.data.map((tag) => (
-                <Chip key={tag.id} label={tag.name} />
+              {triggers[triggerKey].map((userId) => (
+                <User key={userId} userId={userId} />
               ))}
             </Stack>
           );
-          break;
-        case 'counterpart_id':
-          triggerValue = (
-            <Stack direction="row" gap={1} sx={{ flexWrap: 'wrap' }}>
-              {counterpartsForTriggers?.data.map((counterpart) => (
-                <Chip
-                  key={counterpart.id}
-                  label={getCounterpartName(counterpart)}
-                />
-              ))}
-            </Stack>
-          );
-          break;
-        case 'amount':
-          triggerValue = (
-            <p>
-              {getAmountLabel(
-                triggers.amount?.value ?? [],
-                triggers.amount?.currency ?? 'EUR'
-              )}
-            </p>
-          );
-          break;
-        default:
-          triggerValue = triggerKey;
-          break;
-      }
-
-      return {
-        label: triggerLabel,
-        value: triggerValue,
-      };
+        }
+        break;
+      case 'tags':
+        triggerValue = (
+          <Stack direction="row" gap={1} sx={{ flexWrap: 'wrap' }}>
+            {tagsForTriggers?.data.map((tag) => (
+              <Chip key={tag.id} label={tag.name} />
+            ))}
+          </Stack>
+        );
+        break;
+      case 'counterpart_id':
+        triggerValue = (
+          <Stack direction="row" gap={1} sx={{ flexWrap: 'wrap' }}>
+            {counterpartsForTriggers?.data.map((counterpart) => (
+              <Chip
+                key={counterpart.id}
+                label={getCounterpartName(counterpart)}
+              />
+            ))}
+          </Stack>
+        );
+        break;
+      case 'amount':
+        triggerValue = (
+          <p>
+            {getAmountLabel(
+              triggers.amount?.value ?? [],
+              triggers.amount?.currency ?? 'EUR'
+            )}
+          </p>
+        );
+        break;
+      default:
+        triggerValue = triggerKey;
+        break;
     }
-  );
+
+    return {
+      label: triggerLabel,
+      value: triggerValue,
+    };
+  });
 
   const approvalFlows =
     rules &&

--- a/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ConditionsTable/ConditionsTable.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/ApprovalPolicyDetails/ConditionsTable/ConditionsTable.tsx
@@ -20,7 +20,7 @@ import {
 
 import {
   useApprovalPolicyTrigger,
-  Triggers,
+  ParsedTriggers,
 } from '../../useApprovalPolicyTrigger';
 import { FormValues } from '../ApprovalPolicyForm';
 
@@ -41,7 +41,7 @@ export const ConditionsTable = ({
   const { getTriggerLabel, getAmountLabel } = useApprovalPolicyTrigger({});
 
   const triggersList = useMemo(() => {
-    return (Object.keys(triggers) as Array<keyof Triggers>).map(
+    return (Object.keys(triggers) as Array<keyof ParsedTriggers>).map(
       (triggerKey) => {
         const triggerLabel = getTriggerLabel(triggerKey);
         let triggerValue: ReactNode;

--- a/packages/sdk-react/src/components/approvalPolicies/triggerUtils.test.ts
+++ b/packages/sdk-react/src/components/approvalPolicies/triggerUtils.test.ts
@@ -1,0 +1,211 @@
+import {
+  formatFieldName,
+  extractFieldName,
+  getTriggerKeyAndValue,
+  NAMED_VALUES,
+  OPERATOR_OPERATIONS,
+  isValidTriggerKey,
+  isValidOperation,
+  NamedValue,
+} from './triggerUtils';
+
+describe('triggerUtils', () => {
+  describe('formatFieldName', () => {
+    test('should format field names correctly', () => {
+      expect(formatFieldName('was_created_by_user_id')).toBe(
+        'invoice.was_created_by_user_id'
+      );
+      expect(formatFieldName('counterpart_id')).toBe('invoice.counterpart_id');
+      expect(formatFieldName('tags.id')).toBe('invoice.tags.id');
+      expect(formatFieldName('amount')).toBe('invoice.amount');
+      expect(formatFieldName('currency')).toBe('invoice.currency');
+    });
+  });
+
+  describe('extractFieldName', () => {
+    test('should extract field names correctly', () => {
+      expect(extractFieldName('invoice.was_created_by_user_id')).toBe(
+        'was_created_by_user_id'
+      );
+      expect(extractFieldName('invoice.counterpart_id')).toBe('counterpart_id');
+      expect(extractFieldName('invoice.tags.id')).toBe('tags.id');
+      expect(extractFieldName('invoice.amount')).toBe('amount');
+      expect(extractFieldName('invoice.currency')).toBe('currency');
+    });
+
+    test('should handle field names without invoice prefix', () => {
+      expect(extractFieldName('was_created_by_user_id')).toBe(
+        'was_created_by_user_id'
+      );
+      expect(extractFieldName('tags.id')).toBe('tags.id');
+    });
+  });
+
+  describe('getTriggerKeyAndValue', () => {
+    test('should extract key and value from named values that are strings or numbers', () => {
+      const trigger = {
+        operator: 'in',
+        left_operand: { name: 'invoice.was_created_by_user_id' as NamedValue },
+        right_operand: ['user1', 'user2'],
+      };
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe('was_created_by_user_id');
+      expect(result.value).toEqual(['user1', 'user2']);
+    });
+
+    test('should extract key and value from named values that are lists', () => {
+      const trigger = {
+        operator: 'in',
+        left_operand: 'tag1',
+        right_operand: { name: 'invoice.tags.id' as NamedValue },
+      };
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe('tags.id');
+      expect(result.value).toBe('tag1');
+    });
+
+    test('should handle amount triggers correctly', () => {
+      const trigger = {
+        operator: '>',
+        left_operand: { name: 'invoice.amount' as NamedValue },
+        right_operand: 1000,
+      };
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe('amount');
+      expect(result.value).toBe(1000);
+    });
+
+    test('should handle currency triggers correctly', () => {
+      const trigger = {
+        operator: 'in',
+        left_operand: { name: 'invoice.currency' as NamedValue },
+        right_operand: 'USD',
+      };
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe('currency');
+      expect(result.value).toBe('USD');
+    });
+
+    test('should return null for invalid format', () => {
+      const trigger = {
+        operator: 'invalid',
+        left_operand: 'invalid',
+        right_operand: 'invalid',
+      } as any;
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe(null);
+      expect(result.value).toBe(null);
+    });
+
+    test('should handle triggers with missing properties', () => {
+      const trigger = {
+        operator: 'in',
+        left_operand: null,
+        right_operand: null,
+      } as any;
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe(null);
+      expect(result.value).toBe(null);
+    });
+  });
+
+  describe('isValidTriggerKey', () => {
+    test('should validate trigger keys correctly', () => {
+      expect(isValidTriggerKey('was_created_by_user_id')).toBe(true);
+      expect(isValidTriggerKey('counterpart_id')).toBe(true);
+      expect(isValidTriggerKey('tags.id')).toBe(true);
+      expect(isValidTriggerKey('amount')).toBe(true);
+      expect(isValidTriggerKey('currency')).toBe(true);
+
+      expect(isValidTriggerKey('invalid')).toBe(false);
+      expect(isValidTriggerKey('')).toBe(false);
+      expect(isValidTriggerKey('tags')).toBe(false); // Should be 'tags.id'
+    });
+  });
+
+  describe('isValidOperation', () => {
+    test('should validate operations correctly', () => {
+      expect(isValidOperation('in')).toBe(true);
+      expect(isValidOperation('==')).toBe(true);
+      expect(isValidOperation('>')).toBe(true);
+      expect(isValidOperation('<')).toBe(true);
+      expect(isValidOperation('>=')).toBe(true);
+      expect(isValidOperation('<=')).toBe(true);
+      expect(isValidOperation('range')).toBe(true);
+
+      expect(isValidOperation('invalid')).toBe(false);
+      expect(isValidOperation('')).toBe(false);
+      expect(isValidOperation('equals')).toBe(false);
+    });
+  });
+
+  describe('constants', () => {
+    test('should have correct field names', () => {
+      expect(NAMED_VALUES.WAS_CREATED_BY_USER_ID).toBe(
+        'was_created_by_user_id'
+      );
+      expect(NAMED_VALUES.COUNTERPART_ID).toBe('counterpart_id');
+      expect(NAMED_VALUES.TAGS).toBe('tags.id');
+      expect(NAMED_VALUES.AMOUNT).toBe('amount');
+      expect(NAMED_VALUES.CURRENCY).toBe('currency');
+    });
+
+    test('should have correct operators', () => {
+      expect(OPERATOR_OPERATIONS.IN).toBe('in');
+      expect(OPERATOR_OPERATIONS.EQUALS).toBe('==');
+      expect(OPERATOR_OPERATIONS.GREATER_THAN).toBe('>');
+      expect(OPERATOR_OPERATIONS.LESS_THAN).toBe('<');
+      expect(OPERATOR_OPERATIONS.GREATER_THAN_OR_EQUAL).toBe('>=');
+      expect(OPERATOR_OPERATIONS.LESS_THAN_OR_EQUAL).toBe('<=');
+      expect(OPERATOR_OPERATIONS.RANGE).toBe('range');
+    });
+
+    test('should have consistent NamedValue type', () => {
+      const allValues = Object.values(NAMED_VALUES);
+      allValues.forEach((value) => {
+        expect(isValidTriggerKey(value)).toBe(true);
+      });
+    });
+  });
+
+  describe('edge cases and error handling', () => {
+    test('should handle empty strings in formatFieldName', () => {
+      expect(formatFieldName('')).toBe('invoice.');
+    });
+
+    test('should handle empty strings in extractFieldName', () => {
+      expect(extractFieldName('')).toBe('');
+      expect(extractFieldName('invoice.')).toBe('');
+    });
+
+    test('should handle triggers with undefined operands', () => {
+      const trigger = {
+        operator: 'in',
+        left_operand: undefined,
+        right_operand: undefined,
+      } as any;
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe(null);
+      expect(result.value).toBe(null);
+    });
+
+    test('should handle triggers with null operands', () => {
+      const trigger = {
+        operator: 'in',
+        left_operand: null,
+        right_operand: null,
+      } as any;
+
+      const result = getTriggerKeyAndValue(trigger);
+      expect(result.key).toBe(null);
+      expect(result.value).toBe(null);
+    });
+  });
+});

--- a/packages/sdk-react/src/components/approvalPolicies/triggerUtils.ts
+++ b/packages/sdk-react/src/components/approvalPolicies/triggerUtils.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared utilities for approval policy trigger parsing and building
+ */
+
+export const NAMED_VALUES = {
+  WAS_CREATED_BY_USER_ID: 'was_created_by_user_id',
+  COUNTERPART_ID: 'counterpart_id',
+  TAGS: 'tags.id',
+  AMOUNT: 'amount',
+  CURRENCY: 'currency',
+} as const;
+
+export type NamedValue = (typeof NAMED_VALUES)[keyof typeof NAMED_VALUES];
+
+export const isValidTriggerKey = (key: string): key is NamedValue => {
+  return Object.values(NAMED_VALUES).includes(key as NamedValue);
+};
+
+export const OPERATOR_OPERATIONS = {
+  IN: 'in',
+  EQUALS: '==',
+  GREATER_THAN: '>',
+  LESS_THAN: '<',
+  GREATER_THAN_OR_EQUAL: '>=',
+  LESS_THAN_OR_EQUAL: '<=',
+  RANGE: 'range',
+} as const;
+
+export type OperatorOperation =
+  (typeof OPERATOR_OPERATIONS)[keyof typeof OPERATOR_OPERATIONS];
+
+export const isValidOperation = (
+  operation: string
+): operation is OperatorOperation =>
+  Object.values(OPERATOR_OPERATIONS).includes(operation as OperatorOperation);
+
+/**
+ * Operator to check the named value against a value (single or list)
+ * Format: named in [value1, value2]
+ * Example: was_created_by_user_id in [user1, user2]
+ * Used for: counterpart_id, was_created_by_user_id, amount, currency
+ */
+interface OperatorNamedValueOnValue {
+  operator: string;
+  left_operand: { name: NamedValue };
+  right_operand: string | string[] | number;
+}
+
+/**
+ * Operator to check a single value against a named value
+ * Format: value in named[]
+ * Example: tag1 in tags.id
+ * Used for tags
+ */
+interface OperatorValueOnNamedValueList {
+  operator: string;
+  left_operand: string;
+  right_operand: { name: NamedValue };
+}
+
+export type OperatorTrigger =
+  | OperatorNamedValueOnValue
+  | OperatorValueOnNamedValueList;
+
+export interface ApprovalPolicyTriggers {
+  all: Array<OperatorTrigger | string>;
+}
+
+/**
+ * Formats a field name for use in trigger operands
+ * @param fieldName - The field name (e.g., 'was_created_by_user_id')
+ * @returns The formatted field name (e.g., 'invoice.was_created_by_user_id')
+ */
+export const formatFieldName = (fieldName: string): string => {
+  return `invoice.${fieldName}`;
+};
+
+/**
+ * Extracts the field name from a formatted field name
+ * @param formattedFieldName - The formatted field name (e.g., 'invoice.was_created_by_user_id')
+ * @returns The extracted field name (e.g., 'was_created_by_user_id')
+ */
+export const extractFieldName = (formattedFieldName: string): string => {
+  return formattedFieldName.replace('invoice.', '');
+};
+
+/**
+ * Checks if a trigger has named values that are lists
+ *
+ * For lists, the name is on the right_operand and values are on the left_operand
+ *
+ * Example:
+ * {
+ *   operator: 'in',
+ *   left_operand: 'tag1',
+ *   right_operand: { name: 'invoice.tags.id' }
+ * }
+ * @param trigger - The trigger object to check
+ * @returns True if the trigger has named values that are lists
+ */
+const isNamedValuesList = (
+  trigger: OperatorTrigger
+): trigger is OperatorValueOnNamedValueList => {
+  return (
+    trigger.operator === OPERATOR_OPERATIONS.IN &&
+    typeof trigger.left_operand === 'string' &&
+    typeof trigger.right_operand === 'object' &&
+    trigger.right_operand &&
+    'name' in trigger.right_operand
+  );
+};
+
+/**
+ * Checks if a trigger has named values that are strings or numbers
+ *
+ * For strings/numbers, the name is on the left_operand and values are on the right_operand
+ *
+ * Example:
+ * {
+ *   operator: 'in',
+ *   left_operand: { name: 'invoice.was_created_by_user_id' },
+ *   right_operand: ['user1']
+ * }
+ * @param trigger - The trigger object to check
+ * @returns True if the trigger has named values that are strings or numbers
+ */
+const isNamedValuesStringOrNumber = (
+  trigger: OperatorTrigger
+): trigger is OperatorNamedValueOnValue => {
+  return (
+    Boolean(trigger.left_operand) &&
+    typeof trigger.left_operand === 'object' &&
+    'name' in trigger.left_operand
+  );
+};
+
+/**
+ * Gets the field name and value from a trigger, regardless of format
+ * @param trigger - The trigger object
+ * @returns The field name and value or null if not found
+ */
+export const getTriggerKeyAndValue = (
+  trigger: OperatorTrigger
+): { key: string | null; value: string | string[] | number | null } => {
+  if (isNamedValuesList(trigger)) {
+    return {
+      key: extractFieldName(trigger.right_operand.name),
+      value: trigger.left_operand,
+    };
+  }
+
+  if (isNamedValuesStringOrNumber(trigger)) {
+    return {
+      key: extractFieldName(trigger.left_operand?.name),
+      value: trigger.right_operand,
+    };
+  }
+
+  return {
+    key: null,
+    value: null,
+  };
+};

--- a/packages/sdk-react/src/components/approvalPolicies/useApprovalPolicyTrigger.test.tsx
+++ b/packages/sdk-react/src/components/approvalPolicies/useApprovalPolicyTrigger.test.tsx
@@ -1,0 +1,386 @@
+import { components } from '@/api';
+import { approvalPoliciesListFixture } from '@/mocks/approvalPolicies/approvalPoliciesFixture';
+import {
+  individualId,
+  organizationId,
+} from '@/mocks/counterparts/counterpart.mocks.types';
+import {
+  entityUserByIdFixture,
+  entityUser2,
+} from '@/mocks/entityUsers/entityUserByIdFixture';
+import { tagListFixture } from '@/mocks/tags';
+import { renderHook } from '@testing-library/react';
+
+import { OPERATOR_OPERATIONS } from './triggerUtils';
+import {
+  useApprovalPolicyTrigger,
+  AmountTuple,
+} from './useApprovalPolicyTrigger';
+
+describe('useApprovalPolicyTrigger', () => {
+  describe('trigger parsing based on format', () => {
+    test('should parse triggers with named values that are lists', () => {
+      const approvalPolicy = approvalPoliciesListFixture.data[2]; // "Has tags and approved by users from the list"
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers.tags).toEqual([
+        tagListFixture[0].id,
+        tagListFixture[2].id,
+        tagListFixture[3].id,
+      ]);
+    });
+
+    test('should parse triggers with named values that are strings or numbers', () => {
+      const approvalPolicy: components['schemas']['ApprovalPolicyResource'] = {
+        id: 'test-id',
+        name: 'Test Policy',
+        description: 'Test Description',
+        status: 'active',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        created_by: 'user-1',
+        updated_by: 'user-1',
+        script: [],
+        // @ts-expect-error - `trigger` is not covered by the schema
+        trigger: {
+          all: [
+            {
+              operator: 'in',
+              left_operand: {
+                name: 'invoice.tags.id',
+              },
+              right_operand: [tagListFixture[0].id, tagListFixture[1].id],
+            },
+          ],
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers.tags).toEqual([
+        tagListFixture[0].id,
+        tagListFixture[1].id,
+      ]);
+    });
+
+    test('should handle mixed formats correctly', () => {
+      const approvalPolicy: components['schemas']['ApprovalPolicyResource'] = {
+        id: 'test-id',
+        name: 'Test Policy',
+        description: 'Test Description',
+        status: 'active',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        created_by: 'user-1',
+        updated_by: 'user-1',
+        script: [],
+        // @ts-expect-error - `trigger` is not covered by the schema
+        trigger: {
+          all: [
+            {
+              operator: 'in',
+              left_operand: tagListFixture[0].id,
+              right_operand: {
+                name: 'invoice.tags.id',
+              },
+            },
+            {
+              operator: 'in',
+              left_operand: {
+                name: 'invoice.tags.id',
+              },
+              right_operand: [tagListFixture[1].id, tagListFixture[2].id],
+            },
+          ],
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers.tags).toEqual([
+        tagListFixture[0].id,
+        tagListFixture[1].id,
+        tagListFixture[2].id,
+      ]);
+    });
+
+    test('should parse amount triggers correctly', () => {
+      const approvalPolicy = approvalPoliciesListFixture.data[4]; // "For amount and approved by roles"
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers.amount).toEqual({
+        currency: 'EUR',
+        value: [
+          ['>=', 30000],
+          ['<=', '50000'],
+        ],
+      });
+    });
+
+    test('should parse counterpart_id triggers correctly', () => {
+      const approvalPolicy = approvalPoliciesListFixture.data[3]; // "By counterparts and approved by users chain"
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers.counterpart_id).toEqual([
+        organizationId,
+        individualId,
+      ]);
+    });
+
+    test('should parse was_created_by_user_id triggers correctly', () => {
+      const approvalPolicy = approvalPoliciesListFixture.data[1]; // "Created by user and single user"
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers.was_created_by_user_id).toEqual([
+        entityUserByIdFixture.id,
+        entityUser2.id,
+      ]);
+    });
+
+    test('should parse complex policy with all trigger types', () => {
+      const approvalPolicy = approvalPoliciesListFixture.data[0]; // "Approval policy with all conditions and flows"
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers).toEqual({
+        was_created_by_user_id: [entityUserByIdFixture.id, entityUser2.id],
+        tags: [
+          tagListFixture[0].id,
+          tagListFixture[2].id,
+          tagListFixture[3].id,
+        ],
+        counterpart_id: [organizationId, individualId],
+        amount: {
+          currency: 'EUR',
+          value: [
+            ['>=', 30000],
+            ['<=', '50000'],
+          ],
+        },
+      });
+    });
+
+    test('should handle invalid triggers gracefully', () => {
+      const approvalPolicy: components['schemas']['ApprovalPolicyResource'] = {
+        id: 'test-id',
+        name: 'Test Policy',
+        description: 'Test Description',
+        status: 'active',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        created_by: 'user-1',
+        updated_by: 'user-1',
+        script: [],
+        // @ts-expect-error - `trigger` is not covered by the schema
+        trigger: {
+          all: [
+            {
+              operator: 'in',
+              left_operand: tagListFixture[0].id,
+              right_operand: {
+                name: 'invoice.tags.id',
+              },
+            },
+            // Invalid trigger - missing required properties
+            {
+              operator: 'invalid',
+              left_operand: 'invalid',
+              right_operand: 'invalid',
+            },
+            // String trigger (should be skipped)
+            'string-trigger',
+          ],
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      // Should only parse the valid tag trigger
+      expect(result.current.triggers.tags).toEqual([tagListFixture[0].id]);
+    });
+
+    test('should handle approval policy without trigger', () => {
+      const approvalPolicy: components['schemas']['ApprovalPolicyResource'] = {
+        id: 'test-id',
+        name: 'Test Policy',
+        description: 'Test Description',
+        status: 'active',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        created_by: 'user-1',
+        updated_by: 'user-1',
+        script: [],
+      };
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers).toEqual({});
+    });
+
+    test('should handle null approval policy', () => {
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy: undefined })
+      );
+
+      expect(result.current.triggers).toEqual({});
+    });
+
+    test('should parse amount triggers with different operators correctly', () => {
+      const approvalPolicy: components['schemas']['ApprovalPolicyResource'] = {
+        id: 'test-id',
+        name: 'Test Policy',
+        description: 'Test Description',
+        status: 'active',
+        created_at: '2023-01-01T00:00:00Z',
+        updated_at: '2023-01-01T00:00:00Z',
+        created_by: 'user-1',
+        updated_by: 'user-1',
+        script: [],
+        // @ts-expect-error - `trigger` is not covered by the schema
+        trigger: {
+          all: [
+            {
+              operator: '>',
+              left_operand: {
+                name: 'invoice.amount',
+              },
+              right_operand: 1000,
+            },
+            {
+              operator: '<=',
+              left_operand: {
+                name: 'invoice.amount',
+              },
+              right_operand: 5000,
+            },
+            {
+              operator: 'in',
+              left_operand: {
+                name: 'invoice.currency',
+              },
+              right_operand: 'USD',
+            },
+          ],
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy })
+      );
+
+      expect(result.current.triggers.amount).toEqual({
+        currency: 'USD',
+        value: [
+          ['>', 1000],
+          ['<=', 5000],
+        ],
+      });
+    });
+  });
+
+  describe('trigger name and label functions', () => {
+    test('should return correct trigger names', () => {
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy: undefined })
+      );
+
+      expect(result.current.getTriggerName('amount')).toBe('Amount');
+      expect(result.current.getTriggerName('counterpart_id')).toBe(
+        'Counterparts'
+      );
+      expect(result.current.getTriggerName('was_created_by_user_id')).toBe(
+        'Created by user'
+      );
+      expect(result.current.getTriggerName('tags')).toBe('Tags');
+    });
+
+    test('should return correct trigger labels', () => {
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy: undefined })
+      );
+
+      expect(result.current.getTriggerLabel('amount')).toBe('Amount');
+      expect(result.current.getTriggerLabel('counterpart_id')).toBe(
+        'Counterparts'
+      );
+      expect(result.current.getTriggerLabel('was_created_by_user_id')).toBe(
+        'Created by'
+      );
+      expect(result.current.getTriggerLabel('tags')).toBe('Has tags');
+    });
+  });
+
+  describe('amount label formatting', () => {
+    test('should format single amount condition correctly', () => {
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy: undefined })
+      );
+
+      const amountValue: AmountTuple[] = [
+        [OPERATOR_OPERATIONS.GREATER_THAN, 1000],
+      ];
+      const label = result.current.getAmountLabel(amountValue, 'USD');
+
+      expect(label).toContain('Greater than');
+      expect(label).toContain('1000');
+    });
+
+    test('should format range amount condition correctly', () => {
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy: undefined })
+      );
+
+      const amountValue: AmountTuple[] = [
+        [OPERATOR_OPERATIONS.GREATER_THAN_OR_EQUAL, 1000],
+        [OPERATOR_OPERATIONS.LESS_THAN_OR_EQUAL, 5000],
+      ];
+      const label = result.current.getAmountLabel(amountValue, 'USD');
+
+      expect(label).toContain('1000');
+      expect(label).toContain('5000');
+      expect(label).toContain('-');
+    });
+
+    test('should handle different operators correctly', () => {
+      const { result } = renderHook(() =>
+        useApprovalPolicyTrigger({ approvalPolicy: undefined })
+      );
+
+      const operators: Array<[string, string]> = [
+        [OPERATOR_OPERATIONS.GREATER_THAN, 'Greater than'],
+        [OPERATOR_OPERATIONS.GREATER_THAN_OR_EQUAL, 'Greater than or equal to'],
+        [OPERATOR_OPERATIONS.LESS_THAN, 'Less than'],
+        [OPERATOR_OPERATIONS.LESS_THAN_OR_EQUAL, 'Less than or equal to'],
+        [OPERATOR_OPERATIONS.EQUALS, 'Equal to'],
+      ];
+
+      operators.forEach(([operator, expectedText]) => {
+        const amountValue: AmountTuple[] = [[operator as any, 1000]];
+        const label = result.current.getAmountLabel(amountValue, 'USD');
+        expect(label).toContain(expectedText);
+      });
+    });
+  });
+});

--- a/packages/sdk-react/src/mocks/approvalPolicies/approvalPoliciesFixture.ts
+++ b/packages/sdk-react/src/mocks/approvalPolicies/approvalPoliciesFixture.ts
@@ -37,14 +37,24 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
             },
             {
               operator: 'in',
-              left_operand: {
+              left_operand: tagListFixture[0].id,
+              right_operand: {
                 name: 'invoice.tags.id',
               },
-              right_operand: [
-                tagListFixture[0].id,
-                tagListFixture[2].id,
-                tagListFixture[3].id,
-              ],
+            },
+            {
+              operator: 'in',
+              left_operand: tagListFixture[2].id,
+              right_operand: {
+                name: 'invoice.tags.id',
+              },
+            },
+            {
+              operator: 'in',
+              left_operand: tagListFixture[3].id,
+              right_operand: {
+                name: 'invoice.tags.id',
+              },
             },
             {
               operator: 'in',
@@ -195,14 +205,24 @@ export const approvalPoliciesListFixture: components['schemas']['ApprovalPolicyR
           all: [
             {
               operator: 'in',
-              left_operand: {
+              left_operand: tagListFixture[0].id,
+              right_operand: {
                 name: 'invoice.tags.id',
               },
-              right_operand: [
-                tagListFixture[0].id,
-                tagListFixture[2].id,
-                tagListFixture[3].id,
-              ],
+            },
+            {
+              operator: 'in',
+              left_operand: tagListFixture[2].id,
+              right_operand: {
+                name: 'invoice.tags.id',
+              },
+            },
+            {
+              operator: 'in',
+              left_operand: tagListFixture[3].id,
+              right_operand: {
+                name: 'invoice.tags.id',
+              },
             },
           ],
         },


### PR DESCRIPTION
# Scope

Fix approval policies payload for triggers of type tags. Also, improved the parsing logic for all triggers, for better maintainability.

Jira ticket: https://monite.atlassian.net/browse/DEV-15570

# Implementation

- Changed the payload of the approval policies form to use the correct syntax for tag triggers, with one trigger per tag and operator with "value on named value list".
- Added `triggerUtils.ts` with types and helper functions to parse and build triggers for approval policies.
- Updated `useApprovalPolicyTrigger` to parse the new payload syntax and use the news utils.
- Added tests and updated tests fixtures.

# Remarks

The main fix is in commit f669c31ae54e94cbc332345f48e14550b0ff3b57. All else is improved parsing. 😃

# Steps to test

## Tags
1. Create an Approval Policy with trigger tag for a specific tag.
2. Create and submit a Payable with that tag.
3. Check that the Approval Policy matches the Payable and an Approval Request was issued.

## Tags and created by user
1. Create an Approval Policy with trigger tag for a specific tag AND trigger for the same user.
2. Create and submit a Payable with that tag.
3. Check that the Approval Policy matches the Payable and an Approval Request was issued.