### PR TITLE
fix(proposal): node 22 build compat

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,4 +6,5 @@ module.exports = {
   importOrderSeparation: true,
   importOrder: ['^react(.*)$', '^@(.*)$', '<THIRD_PARTY_MODULES>', '^[./]'],
   importOrderParserPlugins: ['importAssertions', 'typescript', 'jsx'],
+  plugins: ['@trivago/prettier-plugin-sort-imports'],
 };

--- a/examples/with-nextjs-and-clerk-auth/package.json
+++ b/examples/with-nextjs-and-clerk-auth/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "~29.7.0",
     "jest-environment-jsdom": "~29.7.0",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "smee-client": "~2.0.0",
     "tsup": "~8.0.1"
   },

--- a/examples/with-nextjs-and-clerk-auth/package.json
+++ b/examples/with-nextjs-and-clerk-auth/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.5.0",
     "dotenv-cli": "^7.3.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "jest": "~29.7.0",
     "jest-environment-jsdom": "~29.7.0",
     "prettier": "^3.0.0",

--- a/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/monite-client.ts
+++ b/examples/with-nextjs-and-clerk-auth/src/lib/monite-api/monite-client.ts
@@ -1,5 +1,5 @@
 import createClient from 'openapi-fetch';
-import apiPackage from 'sdk-demo-with-nextjs-and-clerk-auth/package.json' assert { type: 'json' };
+import apiPackage from 'sdk-demo-with-nextjs-and-clerk-auth/package.json' with { type: 'json' };
 
 import { AccessToken } from '@/lib/monite-api/fetch-token';
 import { paths } from '@/lib/monite-api/schema';

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "~3.6.0",
     "eslint-plugin-import": "~2.27.5",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "husky": "^7.0.0",
     "lint-staged": "~13.0.2",
     "prettier": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "husky": "^7.0.0",
     "lint-staged": "~13.0.2",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "pretty-quick": "^3.1.3",
     "turbo": "~2.5.3",
     "typescript": "~5.5.4"

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -19,7 +19,7 @@
     "eslint-import-resolver-typescript": "~3.6.1",
     "eslint-plugin-import": "~2.29.1",
     "eslint-plugin-lingui": "~0.2.1",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react-hooks": "~4.6.0",
     "eslint-plugin-react-refresh": "~0.3.4",
     "eslint-plugin-testing-library": "~5.11.0"

--- a/packages/sdk-demo/rollup.config.mjs
+++ b/packages/sdk-demo/rollup.config.mjs
@@ -1,6 +1,5 @@
 import { rollupConfig } from '@team-monite/rollup-config';
-
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 export default rollupConfig({
   module: packageJson.exports['.'],

--- a/packages/sdk-react/config/rollup.config.mjs
+++ b/packages/sdk-react/config/rollup.config.mjs
@@ -1,5 +1,4 @@
+import packageJson from '../package.json' with { type: 'json' };
 import { rollupConfig } from '@team-monite/rollup-config';
-
-import packageJson from '../package.json' assert { type: 'json' };
 
 export default rollupConfig(packageJson);

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -134,7 +134,7 @@
     "jest-watch-typeahead": "~2.2.2",
     "msw": "~2.4.11",
     "msw-storybook-addon": "~2.0.0",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5950,7 +5950,7 @@ __metadata:
     eslint-config-prettier: "npm:^8.5.0"
     eslint-import-resolver-typescript: "npm:~3.6.0"
     eslint-plugin-import: "npm:~2.27.5"
-    eslint-plugin-prettier: "npm:^4.0.0"
+    eslint-plugin-prettier: "npm:^5.0.0"
     husky: "npm:^7.0.0"
     lint-staged: "npm:~13.0.2"
     prettier: "npm:^3.0.0"
@@ -6702,6 +6702,13 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
+  languageName: node
+  linkType: hard
+
+"@pkgr/core@npm:^0.2.4":
+  version: 0.2.7
+  resolution: "@pkgr/core@npm:0.2.7"
+  checksum: 10/b16959878940f3d3016b79a4b2c23fd518aaec6b47295baa3154fbcf6574fee644c51023bb69069fa3ea9cdcaca40432818f54695f11acc0ae326cf56676e4d1
   languageName: node
   linkType: hard
 
@@ -10840,7 +10847,7 @@ __metadata:
     eslint-import-resolver-typescript: "npm:~3.6.1"
     eslint-plugin-import: "npm:~2.29.1"
     eslint-plugin-lingui: "npm:~0.2.1"
-    eslint-plugin-prettier: "npm:^4.0.0"
+    eslint-plugin-prettier: "npm:^5.0.0"
     eslint-plugin-react-hooks: "npm:~4.6.0"
     eslint-plugin-react-refresh: "npm:~0.3.4"
     eslint-plugin-testing-library: "npm:~5.11.0"
@@ -17408,18 +17415,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^4.0.0":
-  version: 4.2.1
-  resolution: "eslint-plugin-prettier@npm:4.2.1"
+"eslint-plugin-prettier@npm:^5.0.0":
+  version: 5.5.1
+  resolution: "eslint-plugin-prettier@npm:5.5.1"
   dependencies:
     prettier-linter-helpers: "npm:^1.0.0"
+    synckit: "npm:^0.11.7"
   peerDependencies:
-    eslint: ">=7.28.0"
-    prettier: ">=2.0.0"
+    "@types/eslint": ">=8.0.0"
+    eslint: ">=8.0.0"
+    eslint-config-prettier: ">= 7.0.0 <10.0.0 || >=10.1.0"
+    prettier: ">=3.0.0"
   peerDependenciesMeta:
+    "@types/eslint":
+      optional: true
     eslint-config-prettier:
       optional: true
-  checksum: 10/d387f85dd1bfcb6bc6b794845fee6afb9ebb2375653de6bcde6e615892fb97f85121a7c012a4651b181fc09953bdf54c9bc70cab7ad297019d89ae87dd007e28
+  checksum: 10/4d750c70d97d6ef50776bc0a27eeececaac64792fb50713213c69231ed475aa9822a3d177870300fee537d3e24d0dc8eed1528929cab2d20f6e7ec37484648a3
   languageName: node
   linkType: hard
 
@@ -27433,7 +27445,7 @@ __metadata:
     eslint: "npm:8.57.0"
     eslint-config-next: "npm:~14.0.3"
     eslint-config-prettier: "npm:^8.5.0"
-    eslint-plugin-prettier: "npm:^4.0.0"
+    eslint-plugin-prettier: "npm:^5.0.0"
     jest: "npm:~29.7.0"
     jest-environment-jsdom: "npm:~29.7.0"
     lucide-react: "npm:~0.514.0"
@@ -28708,6 +28720,15 @@ __metadata:
   version: 2.0.16
   resolution: "synchronous-promise@npm:2.0.16"
   checksum: 10/041f532cab52a82ffc95f1e437a4295cf981728ef431b79ca460577a68aeeaf7b1865e582b905f38a7b461bd7b3879f7e44913208eeba972e7057fa29a6976e1
+  languageName: node
+  linkType: hard
+
+"synckit@npm:^0.11.7":
+  version: 0.11.8
+  resolution: "synckit@npm:0.11.8"
+  dependencies:
+    "@pkgr/core": "npm:^0.2.4"
+  checksum: 10/9bb2cf11edaf31ba781f1c719dd58087323201bda6392254538aef4dea216aa02a32e25f06643bcfa1c1a2c95e0d84186d82cfb66f9a0ab3a2be4816c696a8a3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5953,7 +5953,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.0.0"
     husky: "npm:^7.0.0"
     lint-staged: "npm:~13.0.2"
-    prettier: "npm:^2.8.8"
+    prettier: "npm:^3.0.0"
     pretty-quick: "npm:^3.1.3"
     turbo: "npm:~2.5.3"
     typescript: "npm:~5.5.4"
@@ -6075,7 +6075,7 @@ __metadata:
     msw-storybook-addon: "npm:~2.0.0"
     pdfjs-dist: "npm:3.4.120"
     pdfobject: "npm:~2.3.0"
-    prettier: "npm:^2.8.8"
+    prettier: "npm:^3.0.0"
     prop-types: "npm:^15.8.1"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
@@ -11544,9 +11544,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:~4.17.16":
-  version: 4.17.16
-  resolution: "@types/lodash@npm:4.17.16"
-  checksum: 10/9a8bb7471a7521bd65d528e1bd14f79819a3eeb6f8a35a8a44649a7d773775c0813e93fd93bd32ccf350bb076c0bf02c6d47877c4625f526f6dd4d283c746aec
+  version: 4.17.20
+  resolution: "@types/lodash@npm:4.17.20"
+  checksum: 10/8cd8ad3bd78d2e06a93ae8d6c9907981d5673655fec7cb274a4d9a59549aab5bb5b3017361280773b8990ddfccf363e14d1b37c97af8a9fe363de677f9a61524
   languageName: node
   linkType: hard
 
@@ -24520,9 +24520,9 @@ __metadata:
   linkType: hard
 
 "pdfobject@npm:~2.3.0":
-  version: 2.3.0
-  resolution: "pdfobject@npm:2.3.0"
-  checksum: 10/d4443d65daf1950212ed4ccfec576b11607daa24c2528951849e5af87fb660023027c83a07789606f1edfc6777781a2f464a38693caee4e393e7dad6fe7b08bd
+  version: 2.3.1
+  resolution: "pdfobject@npm:2.3.1"
+  checksum: 10/d771805b361ff14eb41d2a1b68f62e7eb9c084be65971ea9790d45841d9d47c0d0b0654ca4d44207725c2a7f52e07077fa33d714b852fc5db9e9471bd8f71fe5
   languageName: node
   linkType: hard
 
@@ -25325,12 +25325,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^2.7.1, prettier@npm:^2.8.0, prettier@npm:^2.8.8":
+"prettier@npm:^2.7.1, prettier@npm:^2.8.0":
   version: 2.8.8
   resolution: "prettier@npm:2.8.8"
   bin:
     prettier: bin-prettier.js
   checksum: 10/00cdb6ab0281f98306cd1847425c24cbaaa48a5ff03633945ab4c701901b8e96ad558eb0777364ffc312f437af9b5a07d0f45346266e8245beaf6247b9c62b24
+  languageName: node
+  linkType: hard
+
+"prettier@npm:^3.0.0":
+  version: 3.6.2
+  resolution: "prettier@npm:3.6.2"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10/1213691706bcef1371d16ef72773c8111106c3533b660b1cc8ec158bd109cdf1462804125f87f981f23c4a3dba053b6efafda30ab0114cc5b4a725606bb9ff26
   languageName: node
   linkType: hard
 
@@ -27431,7 +27440,7 @@ __metadata:
     mqtt: "npm:~5.3.1"
     next: "npm:~14.2.26"
     openapi-fetch: "npm:~0.8.1"
-    prettier: "npm:^2.8.8"
+    prettier: "npm:^3.0.0"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     recharts: "npm:~2.15.3"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Prettier formatting tool to version 3.0.0 across multiple packages.
  * Updated eslint-plugin-prettier to version 5.0.0 in various packages.
  * Adjusted JSON import syntax in configuration files for improved compatibility.
  * Enhanced code formatting by adding a plugin to sort imports automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->