### PR TITLE
ci(DEV-15784): include sdk-playground in the CI/CD pipeline

### DIFF
--- a/.github/workflows/build-and-trigger-deploy-review.yaml
+++ b/.github/workflows/build-and-trigger-deploy-review.yaml
@@ -134,12 +134,14 @@ jobs:
           SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH="sdk-demo-with-nextjs-and-clerk-auth-${{ github.sha }}"
           SDK_DEMO_NGINX="sdk-demo-nginx-${{ github.sha }}"
           SDK_DROP_IN_NGINX="sdk-drop-in-nginx-${{ github.sha }}"
+          SDK_PLAYGROUND_NGINX="sdk-playground-nginx-${{ github.sha }}"
           NORMALIZED_GITHUB_BRANCH=$(echo "${{ github.head_ref }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-63)
           echo "normalized_branch_name=$NORMALIZED_GITHUB_BRANCH" >> "$GITHUB_OUTPUT"
 
           echo "sdk-demo-with-nextjs-and-clerk-auth = $SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH"
           echo "sdk-demo-nginx = $SDK_DEMO_NGINX"
           echo "sdk-drop-in-nginx = $SDK_DROP_IN_NGINX"
+          echo "sdk-playground-nginx = $SDK_PLAYGROUND_NGINX"
           echo "$NORMALIZED_GITHUB_BRANCH"
 
           RESPONSE=$(curl --request POST \
@@ -149,6 +151,7 @@ jobs:
             --form "variables[SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH]=${SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH}" \
             --form "variables[SDK_DEMO_NGINX]=${SDK_DEMO_NGINX}" \
             --form "variables[SDK_DROP_IN_NGINX]=${SDK_DROP_IN_NGINX}" \
+            --form "variables[SDK_PLAYGROUND_NGINX]=${SDK_PLAYGROUND_NGINX}" \
             --form "variables[NORMALIZED_GITHUB_BRANCH]=${NORMALIZED_GITHUB_BRANCH}" \
             --form "variables[GITHUB_BRANCH]=${{ github.head_ref }}" \
             --form "variables[CI_PIPELINE_SOURCE]=pipeline" \
@@ -170,6 +173,7 @@ jobs:
           message: |
             🚀 **Preview URLs are now available!** 🚀            
             - [SDK Demo](https://sdk-demo-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
+            - [SDK Playground](https://sdk-playground-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
             - [SDK Drop in](https://cdn-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
             - [SDK with NextJS](https://demo-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
           comment-tag: preview-comment

--- a/.github/workflows/build-and-trigger-deploy.yaml
+++ b/.github/workflows/build-and-trigger-deploy.yaml
@@ -104,10 +104,12 @@ jobs:
           SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH="sdk-demo-with-nextjs-and-clerk-auth-${{ github.sha }}"
           SDK_DEMO_NGINX="sdk-demo-nginx-${{ github.sha }}"
           SDK_DROP_IN_NGINX="sdk-drop-in-nginx-${{ github.sha }}"
+          SDK_PLAYGROUND_NGINX="sdk-playground-nginx-${{ github.sha }}"
 
           echo "sdk-demo-with-nextjs-and-clerk-auth = $SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH"
           echo "sdk-demo-nginx = $SDK_DEMO_NGINX"
           echo "sdk-drop-in-nginx = $SDK_DROP_IN_NGINX"
+          echo "sdk-playground-nginx = $SDK_PLAYGROUND_NGINX"
 
           curl --request POST \
             --form token="${GITLAB_TOKEN}" \
@@ -116,6 +118,7 @@ jobs:
             --form "variables[SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH]=${SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH}" \
             --form "variables[SDK_DEMO_NGINX]=${SDK_DEMO_NGINX}" \
             --form "variables[SDK_DROP_IN_NGINX]=${SDK_DROP_IN_NGINX}" \
+            --form "variables[SDK_PLAYGROUND_NGINX]=${SDK_PLAYGROUND_NGINX}" \
             --form "variables[GITHUB_BRANCH]=${{ github.ref_name }}" \
             --form "variables[CI_PIPELINE_SOURCE]=pipeline" \
             --form "variables[CI_ACTION]=dev_deploy" \

--- a/Dockerfile.sdk-playground
+++ b/Dockerfile.sdk-playground
@@ -1,0 +1,16 @@
+FROM cimg/node:20.12.2
+
+USER root
+
+RUN groupadd -g 1000 app && \
+    useradd -m -u 1000 -g app -s /bin/bash app
+
+WORKDIR /app
+
+COPY . /app
+RUN chown -R app:app /app
+
+USER app
+
+RUN yarn install --immutable
+RUN yarn build --filter='sdk-playground'

--- a/Dockerfile.sdk-playground-nginx
+++ b/Dockerfile.sdk-playground-nginx
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as base
+
+FROM nginx:1.25.1
+
+RUN ln -snf /usr/share/zoneinfo/Europe/Berlin /etc/localtime && echo "Europe/Berlin" > /etc/timezone
+
+WORKDIR /app
+
+COPY --from=base /app/packages/sdk-playground/dist /app

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ yarn storybook
 
 ## License
 MIT
+

--- a/werf.demo.yaml
+++ b/werf.demo.yaml
@@ -17,3 +17,16 @@ dependencies:
   imports:
   - type: ImageName
     targetBuildArg: BASE_IMAGE
+---
+image: sdk-playground
+dockerfile: ./Dockerfile.sdk-playground
+context: .
+---
+image: sdk-playground-nginx
+dockerfile: ./Dockerfile.sdk-playground-nginx
+context: .
+dependencies:
+- image: sdk-playground
+  imports:
+  - type: ImageName
+    targetBuildArg: BASE_IMAGE


### PR DESCRIPTION
Add `sdk-playground` app to the CI/CD pipeline.

Current State

- sdk-playground package exists in /packages/sdk-playground/
- Uses Vite build system with output to dist/ directory
- Currently not deployed to any environment

Future state, after merge

1. Endpoints
After implementation, `sdk-playground` should be accessible at:
- Development environment: https://sdk-playground.dev.monite.com (auto-deployed on merge to main)
- Review environment: `https://sdk-playground-{branch-name}.review.monite.com` (deployed when PR has pullpreview label)

2. Build Integration
- Integrate sdk-playground into the existing Docker build process
- Follow the same build patterns as other demo applications
- Ensure builds work in CI/CD environment with workspace dependencies

3. Developer Experience
- Preview Environment: When a PR is labeled with `pullpreview`, the playground URL should be included in the automated PR comment
- Development Flow: After merging to main, playground should be automatically available on dev environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new Docker images for the SDK Playground and its nginx deployment.
  * Added deployment support and preview URLs for the SDK Playground nginx environment.

* **Chores**
  * Updated deployment workflows and configuration files to support the new SDK Playground images and environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->