### PR TITLE
ci(DEV-15784): include sdk-playground in the CI/CD pipeline

### DIFF
--- a/.github/workflows/build-and-trigger-deploy-review.yaml
+++ b/.github/workflows/build-and-trigger-deploy-review.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - uses: werf/actions/install@v2
         with:
           version: v2.16.2
@@ -54,7 +54,7 @@ jobs:
             --parallel-tasks-limit=-1 \
             --repo registry.monite.com/monite/frontend/sdkapp \
             --tag registry.monite.com/monite/frontend/sdkapp:%image%-${{ github.sha }}
-    
+
   build-sdk-demo:
     name: Build and Push sdk-demo
     needs: check-label
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - uses: werf/actions/install@v2
         with:
           version: v2.16.2
@@ -94,7 +94,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - uses: werf/actions/install@v2
         with:
           version: v2.16.2
@@ -115,12 +115,64 @@ jobs:
             --repo registry.monite.com/monite/frontend/sdkapp \
             --tag registry.monite.com/monite/frontend/sdkapp:%image%-${{ github.sha }}
 
+  build-sdk-playground:
+    name: Build and Push sdk-playground
+    needs: check-label
+    if: needs.check-label.outputs.has_label == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: werf/actions/install@v2
+        with:
+          version: v2.16.2
+
+      - name: Log in to GitLab Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.monite.com
+          username: ${{ vars.GITLAB_BOT_USERNAME }}
+          password: ${{ secrets.GITLAB_BOT_ACCESS_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Create .env file and Build SDK Playground
+        run: |
+          # Create .env file from GitHub secrets
+          cat > packages/sdk-playground/.env << EOF
+          VITE_MONITE_ENTITY_ID=${{ secrets.VITE_MONITE_ENTITY_ID }}
+          VITE_MONITE_ENTITY_USER_ID=${{ secrets.VITE_MONITE_ENTITY_USER_ID }}
+          VITE_MONITE_PROJECT_CLIENT_ID=${{ secrets.VITE_MONITE_PROJECT_CLIENT_ID }}
+          VITE_MONITE_PROJECT_CLIENT_SECRET=${{ secrets.VITE_MONITE_PROJECT_CLIENT_SECRET }}
+          VITE_MONITE_API_URL=${{ secrets.VITE_MONITE_API_URL }}
+          EOF
+
+          # Build SDK Playground with .env file
+          yarn build --filter='sdk-playground'
+
+      - name: Build and Push Images
+        run: |
+          . $(werf ci-env github --as-file)
+          werf export \
+            --config werf.sdk-playground.yaml \
+            --parallel-tasks-limit=-1 \
+            --repo registry.monite.com/monite/frontend/sdkapp \
+            --tag registry.monite.com/monite/frontend/sdkapp:%image%-${{ github.sha }}
+
   trigger-gitlab-deploy:
     name: Trigger GitLab Deployment to Review
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - build-sdk-demo
       - build-sdk-drop-in
+      - build-sdk-playground
       - check-label
 
     steps:
@@ -134,12 +186,14 @@ jobs:
           SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH="sdk-demo-with-nextjs-and-clerk-auth-${{ github.sha }}"
           SDK_DEMO_NGINX="sdk-demo-nginx-${{ github.sha }}"
           SDK_DROP_IN_NGINX="sdk-drop-in-nginx-${{ github.sha }}"
+          SDK_PLAYGROUND_NGINX="sdk-playground-nginx-${{ github.sha }}"
           NORMALIZED_GITHUB_BRANCH=$(echo "${{ github.head_ref }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | cut -c1-63)
           echo "normalized_branch_name=$NORMALIZED_GITHUB_BRANCH" >> "$GITHUB_OUTPUT"
 
           echo "sdk-demo-with-nextjs-and-clerk-auth = $SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH"
           echo "sdk-demo-nginx = $SDK_DEMO_NGINX"
           echo "sdk-drop-in-nginx = $SDK_DROP_IN_NGINX"
+          echo "sdk-playground-nginx = $SDK_PLAYGROUND_NGINX"
           echo "$NORMALIZED_GITHUB_BRANCH"
 
           RESPONSE=$(curl --request POST \
@@ -149,6 +203,7 @@ jobs:
             --form "variables[SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH]=${SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH}" \
             --form "variables[SDK_DEMO_NGINX]=${SDK_DEMO_NGINX}" \
             --form "variables[SDK_DROP_IN_NGINX]=${SDK_DROP_IN_NGINX}" \
+            --form "variables[SDK_PLAYGROUND_NGINX]=${SDK_PLAYGROUND_NGINX}" \
             --form "variables[NORMALIZED_GITHUB_BRANCH]=${NORMALIZED_GITHUB_BRANCH}" \
             --form "variables[GITHUB_BRANCH]=${{ github.head_ref }}" \
             --form "variables[CI_PIPELINE_SOURCE]=pipeline" \
@@ -164,12 +219,13 @@ jobs:
 
       - name: Comment on PR with Preview URLs
         uses: thollander/actions-comment-pull-request@v3
-        env: 
+        env:
           NORMALIZED_GITHUB_BRANCH: ${{ steps.trigger-pipeline.outputs.normalized_branch_name }}
         with:
           message: |
-            🚀 **Preview URLs are now available!** 🚀            
+            🚀 **Preview URLs are now available!** 🚀
             - [SDK Demo](https://sdk-demo-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
+            - [SDK Playground](https://sdk-pg-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
             - [SDK Drop in](https://cdn-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
             - [SDK with NextJS](https://demo-${{ env.NORMALIZED_GITHUB_BRANCH }}.review.monite.com)
           comment-tag: preview-comment

--- a/.github/workflows/build-and-trigger-deploy.yaml
+++ b/.github/workflows/build-and-trigger-deploy.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - uses: werf/actions/install@v2
         with:
           version: v2.16.2
@@ -32,14 +32,14 @@ jobs:
             --parallel-tasks-limit=-1 \
             --repo registry.monite.com/monite/frontend/sdkapp \
             --tag registry.monite.com/monite/frontend/sdkapp:%image%-${{ github.sha }}
-    
+
   build-sdk-demo:
     name: Build and Push sdk-demo
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - uses: werf/actions/install@v2
         with:
           version: v2.16.2
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - uses: werf/actions/install@v2
         with:
           version: v2.16.2
@@ -87,12 +87,63 @@ jobs:
             --repo registry.monite.com/monite/frontend/sdkapp \
             --tag registry.monite.com/monite/frontend/sdkapp:%image%-${{ github.sha }}
 
+  build-sdk-playground:
+    name: Build and Push sdk-playground
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Create .env file and Build SDK Playground
+        run: |
+          # Create .env file from GitHub secrets
+          cat > packages/sdk-playground/.env << EOF
+          VITE_MONITE_ENTITY_ID=${{ secrets.VITE_MONITE_ENTITY_ID }}
+          VITE_MONITE_ENTITY_USER_ID=${{ secrets.VITE_MONITE_ENTITY_USER_ID }}
+          VITE_MONITE_PROJECT_CLIENT_ID=${{ secrets.VITE_MONITE_PROJECT_CLIENT_ID }}
+          VITE_MONITE_PROJECT_CLIENT_SECRET=${{ secrets.VITE_MONITE_PROJECT_CLIENT_SECRET }}
+          VITE_MONITE_API_URL=${{ secrets.VITE_MONITE_API_URL }}
+          EOF
+
+          # Build SDK Playground with .env file
+          yarn build --filter='sdk-playground'
+
+      - uses: werf/actions/install@v2
+        with:
+          version: v2.16.2
+
+      - name: Log in to GitLab Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.monite.com
+          username: ${{ vars.GITLAB_BOT_USERNAME }}
+          password: ${{ secrets.GITLAB_BOT_ACCESS_TOKEN }}
+
+      - name: Build and Push Images
+        run: |
+          . $(werf ci-env github --as-file)
+
+          werf export \
+            --config werf.sdk-playground.yaml \
+            --parallel-tasks-limit=-1 \
+            --repo registry.monite.com/monite/frontend/sdkapp \
+            --tag registry.monite.com/monite/frontend/sdkapp:%image%-${{ github.sha }}
+
   trigger-gitlab-deploy:
     name: Trigger GitLab Deployment to Dev
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - build-sdk-demo
       - build-sdk-drop-in
+      - build-sdk-playground
 
     steps:
       - name: Trigger GitLab Pipeline Deploy to Dev
@@ -104,10 +155,12 @@ jobs:
           SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH="sdk-demo-with-nextjs-and-clerk-auth-${{ github.sha }}"
           SDK_DEMO_NGINX="sdk-demo-nginx-${{ github.sha }}"
           SDK_DROP_IN_NGINX="sdk-drop-in-nginx-${{ github.sha }}"
+          SDK_PLAYGROUND_NGINX="sdk-playground-nginx-${{ github.sha }}"
 
           echo "sdk-demo-with-nextjs-and-clerk-auth = $SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH"
           echo "sdk-demo-nginx = $SDK_DEMO_NGINX"
           echo "sdk-drop-in-nginx = $SDK_DROP_IN_NGINX"
+          echo "sdk-playground-nginx = $SDK_PLAYGROUND_NGINX"
 
           curl --request POST \
             --form token="${GITLAB_TOKEN}" \
@@ -116,6 +169,7 @@ jobs:
             --form "variables[SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH]=${SDK_DEMO_WITH_NEXTJS_AND_CLERK_AUTH}" \
             --form "variables[SDK_DEMO_NGINX]=${SDK_DEMO_NGINX}" \
             --form "variables[SDK_DROP_IN_NGINX]=${SDK_DROP_IN_NGINX}" \
+            --form "variables[SDK_PLAYGROUND_NGINX]=${SDK_PLAYGROUND_NGINX}" \
             --form "variables[GITHUB_BRANCH]=${{ github.ref_name }}" \
             --form "variables[CI_PIPELINE_SOURCE]=pipeline" \
             --form "variables[CI_ACTION]=dev_deploy" \
@@ -124,7 +178,7 @@ jobs:
   trigger-storybook-deploy:
     name: Trigger GitLab Storybook build and deploy
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - build-sdk-demo
 
     steps:

--- a/Dockerfile.sdk-playground
+++ b/Dockerfile.sdk-playground
@@ -1,0 +1,10 @@
+FROM nginx:alpine
+
+# Copy the pre-built SDK Playground dist files  
+COPY packages/sdk-playground/dist /app
+
+# Copy nginx configuration if needed
+# COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -63,3 +63,4 @@ yarn storybook
 
 ## License
 MIT
+

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -3,4 +3,3 @@ config:
   dockerfile:
     allowContextAddFiles:
       - packages/sdk-playground/dist
-      - packages/sdk-playground/.env

--- a/werf-giterminism.yaml
+++ b/werf-giterminism.yaml
@@ -1,0 +1,6 @@
+giterminismConfigVersion: 1
+config:
+  dockerfile:
+    allowContextAddFiles:
+      - packages/sdk-playground/dist
+      - packages/sdk-playground/.env

--- a/werf.sdk-playground.yaml
+++ b/werf.sdk-playground.yaml
@@ -1,0 +1,9 @@
+project: sdkapp
+configVersion: 1
+---
+image: sdk-playground-nginx
+dockerfile: ./Dockerfile.sdk-playground
+context: .
+contextAddFiles:
+  - packages/sdk-playground/dist
+  - packages/sdk-playground/.env

--- a/werf.sdk-playground.yaml
+++ b/werf.sdk-playground.yaml
@@ -6,4 +6,3 @@ dockerfile: ./Dockerfile.sdk-playground
 context: .
 contextAddFiles:
   - packages/sdk-playground/dist
-  - packages/sdk-playground/.env


### PR DESCRIPTION
Add `sdk-playground` app to the CI/CD pipeline.

Current State

- sdk-playground package exists in /packages/sdk-playground/
- Uses Vite build system with output to dist/ directory
- Currently not deployed to any environment

Future state, after merge

1. Endpoints
After implementation, `sdk-playground` should be accessible at:
- Development environment: https://sdk-pg.dev.monite.com (auto-deployed on merge to main)
- Review environment: `https://sdk-pg-{branch-name-slug}.review.monite.com` (deployed when PR has pullpreview label)
  - e.g. for this PR: `https://sdk-pg-dev-15784.review.monite.com`

2. Build Integration
- Integrate sdk-playground into the existing Docker build process
- Follow the same build patterns as other demo applications
- Ensure builds work in CI/CD environment with workspace dependencies

3. Developer Experience
- Preview Environment: When a PR is labeled with `pullpreview`, the playground URL should be included in the automated PR comment
- Development Flow: After merging to main, playground should be automatically available on dev environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated build and deployment process for the SDK Playground environment, including Docker image creation and registry publishing.
  * Preview URLs for the SDK Playground are now included in pull request comments for easier access to review environments.

* **Chores**
  * Introduced new configuration files to support deterministic builds and deployment of the SDK Playground.
  * Minor formatting improvements in workflow files.
  * Updated documentation with a minor formatting change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->