### PR TITLE
fix(DEV-15836): Do not reset Bank Account form fields on change of currency 

### DIFF
--- a/.changeset/wicked-beers-press.md
+++ b/.changeset/wicked-beers-press.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Fix to not reset Bank Account form fields when selected currency changes.

--- a/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx
+++ b/packages/sdk-react/src/components/counterparts/CounterpartDetails/CounterpartBankForm/CounterpartBankForm.tsx
@@ -17,14 +17,11 @@ import { Controller } from 'react-hook-form';
 
 export const CounterpartBankForm = (props: CounterpartBankFormProps) => {
   const { i18n } = useLingui();
-  const {
-    methods: { control, handleSubmit, watch, clearErrors, resetField },
-    counterpart,
-    bank,
-    formId,
-    saveBank,
-    isLoading,
-  } = useCounterpartBankForm(props);
+  const { methods, counterpart, bank, formId, saveBank, isLoading } =
+    useCounterpartBankForm(props);
+
+  const { control, handleSubmit, watch, clearErrors } = methods;
+
   const country = watch('country');
 
   const { currencyGroups, isLoadingCurrencyGroups } =
@@ -45,12 +42,8 @@ export const CounterpartBankForm = (props: CounterpartBankFormProps) => {
         'sort_code',
         'routing_number',
       ]);
-
-      resetField('sort_code');
-      resetField('account_number');
-      resetField('routing_number');
     }
-  }, [clearErrors, resetField, country]);
+  }, [clearErrors, country]);
 
   if (isLoading) {
     return <LoadingPage />;


### PR DESCRIPTION
# Scope

Don't reset Bank Account form fields when currency value changes.
Jira ticket [DEV-15836](https://monite.atlassian.net/browse/DEV-15836).

# Implementation

- Changed useEffect in CounterpartBankForm to remove reset of sort_code, account_number, and routing_number fields.

# Steps to test

1. Open or create a Counterpart.
2. Click "add Bank Account" to open the bank form.
3. Fill some values (namely account_number, sort_code, or routing_number).
4. Select a currency.
5. Change the currency value, the value of the other fields should not reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form behavior so that changing the country now only clears errors for specific fields without resetting their values.
  * Fixed an issue where changing the currency selection in the Bank Account form would reset entered values; now input values are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->