### PR TITLE
feat(DEV-15902): Allow Line Items negative price

### DIFF
--- a/.changeset/rare-singers-sniff.md
+++ b/.changeset/rare-singers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Allow Line Items with negative price values

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -171,7 +171,6 @@ const getValidationSchema = (i18n: I18n) =>
             .number()
             .label(t(i18n)`Item price`)
             .required()
-            .min(0)
             .typeError(t(i18n)`Item price must be a number`),
           tax: yup
             .number()


### PR DESCRIPTION
# Scope

Allow Line Items negative price values.

Jira ticket: https://monite.atlassian.net/browse/DEV-15902

# Implementation

- Removed `min` validation from field lineItems.price in PayableDetailsForm.

# Steps to test

1. Create or edit a Payable.
2. Add or edit one Line Item with a negative value for the price.
3. The form should accept the nagetive value.
4. Save the Payable, should see no errors.