### PR TITLE
fix(proposal): Remove SDK demo as a dependency on Drop-in

### DIFF
--- a/packages/sdk-drop-in/monite-app-demo.html
+++ b/packages/sdk-drop-in/monite-app-demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -17,15 +17,11 @@
   </head>
   <body>
     <script type="module">
-      import { createAPIClient } from '@monite/sdk-react';
-      import { createEntityUsersMyEntityRequestFn } from '@team-monite/sdk-demo';
-
       import {
         MONITE_APP_ELEMENT_NAME,
         MoniteDropin,
       } from './src/custom-elements/monite-app';
       import { getConfig } from './src/lib/ConfigLoader.tsx';
-      import { fetchTokenDev } from './src/lib/fetchTokenDev.ts';
       import {
         MoniteEventTypes,
         addMoniteEventListener,
@@ -33,6 +29,9 @@
         getMoniteAppElement,
         getMoniteAppEventTarget,
       } from './src/lib/MoniteEvents';
+      import { fetchTokenDev } from './src/lib/fetchTokenDev.ts';
+      import { createEntityUsersMyEntityRequestFn } from './src/utils/demo-utils';
+      import { createAPIClient } from '@monite/sdk-react';
 
       /**
        * Initialize event listeners using the manual approach with standard DOM API

--- a/packages/sdk-drop-in/package.json
+++ b/packages/sdk-drop-in/package.json
@@ -62,7 +62,6 @@
     "@playwright/test": "~1.45.0",
     "@tanstack/react-query": "~5.28.6",
     "@team-monite/eslint-plugin": "workspace:~",
-    "@team-monite/sdk-demo": "workspace:~",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "@vitejs/plugin-react": "~4.3.4",

--- a/packages/sdk-drop-in/src/apps/MoniteIframeApp.tsx
+++ b/packages/sdk-drop-in/src/apps/MoniteIframeApp.tsx
@@ -1,3 +1,7 @@
+import {
+  EntityIdLoader,
+  SDKDemoAPIProvider,
+} from '../utils/sdk-demo-components';
 import { AppCircularProgress } from '@/lib/AppCircularProgress';
 import { ConfigLoader } from '@/lib/ConfigLoader';
 import { DropInMoniteProvider } from '@/lib/DropInMoniteProvider';
@@ -7,7 +11,6 @@ import { css, Global } from '@emotion/react';
 import { type APISchema } from '@monite/sdk-react';
 import { CssBaseline } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { EntityIdLoader, SDKDemoAPIProvider } from '@team-monite/sdk-demo';
 import { ComponentProps, Suspense, useMemo } from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 

--- a/packages/sdk-drop-in/src/apps/MoniteIframeAppDemo.tsx
+++ b/packages/sdk-drop-in/src/apps/MoniteIframeAppDemo.tsx
@@ -1,3 +1,9 @@
+import {
+  DefaultLayout,
+  EntityIdLoader,
+  SDKDemoAPIProvider,
+  SDKDemoI18nProvider,
+} from '../utils/sdk-demo-components';
 import { AppCircularProgress } from '@/lib/AppCircularProgress';
 import { ConfigLoader } from '@/lib/ConfigLoader';
 import { MoniteIframeAppCommunicator } from '@/lib/MoniteIframeAppCommunicator';
@@ -5,12 +11,6 @@ import { fetchTokenDev } from '@/lib/fetchTokenDev';
 import { type APISchema } from '@monite/sdk-react';
 import { CssBaseline } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import {
-  DefaultLayout,
-  EntityIdLoader,
-  SDKDemoAPIProvider,
-  SDKDemoI18nProvider,
-} from '@team-monite/sdk-demo';
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { BrowserRouter, Route, Routes, useParams } from 'react-router-dom';
 

--- a/packages/sdk-drop-in/src/utils/demo-utils.ts
+++ b/packages/sdk-drop-in/src/utils/demo-utils.ts
@@ -1,0 +1,32 @@
+import { createAPIClient } from '@monite/sdk-react';
+import { createSecureRequestFn } from '@openapi-qraft/react/Unstable_QraftSecureRequestFn';
+import { QueryClient } from '@tanstack/react-query';
+
+type EntityIdLoaderBaseProps = {
+  apiUrl: string;
+  fetchToken: () => Promise<{
+    access_token: string;
+    expires_in: number;
+    token_type: string;
+  }>;
+};
+
+export const createEntityUsersMyEntityRequestFn = (
+  fetchToken: EntityIdLoaderBaseProps['fetchToken']
+) => {
+  const { requestFn: moniteRequestFn } = createAPIClient();
+
+  return createSecureRequestFn(
+    {
+      async HTTPBearer() {
+        const { access_token } = await fetchToken();
+        return {
+          token: access_token,
+          refreshInterval: Infinity,
+        };
+      },
+    },
+    moniteRequestFn,
+    new QueryClient()
+  );
+};

--- a/packages/sdk-drop-in/src/utils/sdk-demo-components.tsx
+++ b/packages/sdk-drop-in/src/utils/sdk-demo-components.tsx
@@ -1,0 +1,341 @@
+import { setupI18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { type APISchema, createAPIClient } from '@monite/sdk-react';
+import {
+  Avatar,
+  Box,
+  Drawer,
+  Typography,
+  CircularProgress,
+  Stack,
+} from '@mui/material';
+import { type QraftContextValue } from '@openapi-qraft/react';
+import {
+  createSecureRequestFn,
+  QraftSecureRequestFn,
+} from '@openapi-qraft/react/Unstable_QraftSecureRequestFn';
+import { QueryClient, useQueryClient } from '@tanstack/react-query';
+import {
+  Component,
+  createContext,
+  ReactNode,
+  useMemo,
+  useContext,
+  useEffect,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+
+// ==============================================================================
+// EntityIdLoader Components
+// ==============================================================================
+
+type EntityIdLoaderBaseProps = {
+  apiUrl: string;
+  fetchToken: () => Promise<
+    APISchema.components['schemas']['AccessTokenResponse']
+  >;
+};
+
+export const EntityIdLoader = ({
+  children,
+  fetchToken,
+  apiUrl,
+}: EntityIdLoaderBaseProps & {
+  children: (entityId: string) => ReactNode;
+}) => {
+  return (
+    <EntityIdLoaderProvider fetchToken={fetchToken} apiUrl={apiUrl}>
+      <ErrorBoundary>
+        <EntityIdLoaderRenderCallback>{children}</EntityIdLoaderRenderCallback>
+      </ErrorBoundary>
+    </EntityIdLoaderProvider>
+  );
+};
+
+const EntityIdLoaderProvider = ({
+  children,
+  apiUrl,
+  fetchToken,
+}: EntityIdLoaderBaseProps & { children: ReactNode }) => {
+  const requestFn = useMemo(
+    () => createEntityUsersMyEntityRequestFn(fetchToken),
+    [fetchToken]
+  );
+
+  return (
+    <EntityIdContext.Provider
+      value={{
+        requestFn,
+        baseUrl: apiUrl,
+      }}
+    >
+      {children}
+    </EntityIdContext.Provider>
+  );
+};
+
+const EntityIdLoaderRenderCallback = ({
+  children,
+}: {
+  children: (entityId: string) => ReactNode;
+}) => {
+  const { api } = createAPIClient({ context: EntityIdContext });
+  const getEntityUsersMeQuery =
+    api.entityUsers.getEntityUsersMyEntity.useSuspenseQuery(
+      {},
+      {
+        // Keep entity user data in cache indefinitely,
+        // as it's unlikely to change during iframe app lifecycle.
+        staleTime: Infinity,
+        gcTime: Infinity,
+      }
+    );
+
+  return <>{children(getEntityUsersMeQuery.data.id)}</>;
+};
+
+export const createEntityUsersMyEntityRequestFn = (
+  fetchToken: EntityIdLoaderBaseProps['fetchToken']
+) => {
+  const { requestFn: moniteRequestFn } = createAPIClient();
+
+  return createSecureRequestFn(
+    {
+      async HTTPBearer() {
+        const { access_token } = await fetchToken();
+        return {
+          token: access_token,
+          refreshInterval: Infinity,
+        };
+      },
+    },
+    moniteRequestFn,
+    new QueryClient()
+  );
+};
+
+const EntityIdContext = createContext<QraftContextValue>(undefined);
+
+// ==============================================================================
+// SDKDemoAPIProvider
+// ==============================================================================
+
+export const SDKDemoAPIProvider = ({
+  children,
+  apiUrl,
+  entityId,
+  fetchToken,
+}: {
+  children: ReactNode;
+  apiUrl: string;
+  entityId: string | undefined;
+  fetchToken: () => Promise<{
+    access_token: string;
+    expires_in: number;
+    token_type: string;
+  }>;
+}) => {
+  const queryClient = useQueryClient();
+
+  const { requestFn, api, version } = useMemo(
+    () => createAPIClient({ context: SDKDemoQraftContext, entityId }),
+    [entityId]
+  );
+
+  return (
+    <QraftSecureRequestFn
+      requestFn={requestFn}
+      securitySchemes={{
+        HTTPBearer: async () => {
+          const { access_token } = await fetchToken();
+          return {
+            token: access_token,
+            refreshInterval: 10 * 60_000,
+          };
+        },
+      }}
+    >
+      {(securedRequestFn) => (
+        <SDKDemoQraftContext.Provider
+          value={{
+            requestFn: securedRequestFn,
+            baseUrl: apiUrl,
+            queryClient: queryClient,
+          }}
+        >
+          <SDKDemoAPIContext.Provider
+            value={{
+              api,
+              version,
+              requestFn: securedRequestFn,
+            }}
+          >
+            {children}
+          </SDKDemoAPIContext.Provider>
+        </SDKDemoQraftContext.Provider>
+      )}
+    </QraftSecureRequestFn>
+  );
+};
+
+const SDKDemoQraftContext = createContext<QraftContextValue>(undefined);
+const SDKDemoAPIContext = createContext<ReturnType<typeof createAPIClient>>(
+  undefined!
+);
+
+export const useSDKDemoAPI = () => {
+  const value = useContext(SDKDemoAPIContext);
+  if (!value) {
+    throw new Error('useSDKDemoAPI must be used within a SDKDemoAPIProvider');
+  }
+  return value;
+};
+
+// ==============================================================================
+// SDKDemoI18nProvider
+// ==============================================================================
+
+export const SDKDemoI18nProvider = ({
+  children,
+  localeCode,
+  messages,
+}: {
+  children: ReactNode;
+  localeCode: string;
+  messages?: Record<string, any>;
+}) => {
+  const sdkDemoI18n = useMemo(() => {
+    return setupI18n({
+      locale: localeCode,
+      messages: {
+        [localeCode]: messages || {},
+      },
+    });
+  }, [localeCode, messages]);
+
+  return <I18nProvider i18n={sdkDemoI18n}>{children}</I18nProvider>;
+};
+
+// ==============================================================================
+// DefaultLayout Component
+// ==============================================================================
+
+type DefaultLayoutProps = {
+  children?: ReactNode;
+  siderProps?: { footer?: ReactNode };
+  MenuComponent?: React.ComponentType;
+};
+
+export const DefaultLayout = ({
+  children,
+  siderProps,
+  MenuComponent,
+}: DefaultLayoutProps) => {
+  const location = useLocation();
+  const { api } = useSDKDemoAPI();
+  const { data: user, isLoading: isUserLoading } =
+    api.entityUsers.getEntityUsersMe.useQuery({});
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location]);
+
+  const drawerWidth = '240px';
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: 'flex',
+          m: 0,
+          height: '100vh',
+          width: '100vw',
+        }}
+      >
+        <Drawer
+          sx={{
+            width: drawerWidth,
+            flexShrink: 0,
+            '& .MuiDrawer-paper': {
+              width: drawerWidth,
+              boxSizing: 'border-box',
+            },
+          }}
+          variant="permanent"
+          anchor="left"
+        >
+          <Box sx={{ display: 'flex', alignItems: 'center', p: 2 }}>
+            {!isUserLoading && user && (
+              <>
+                <Avatar
+                  sx={{ width: 44, height: 44 }}
+                  alt={user.first_name}
+                  src={user.userpic_file_id || undefined}
+                />
+                <Typography
+                  ml={1}
+                  variant="button"
+                  textOverflow="ellipsis"
+                  overflow="hidden"
+                >
+                  {user.first_name} {user.last_name}
+                </Typography>
+              </>
+            )}
+            {isUserLoading && <CircularProgress size={44} />}
+          </Box>
+          <Box display="flex" sx={{ flex: 1 }}>
+            {MenuComponent && <MenuComponent />}
+          </Box>
+          <Box>
+            <Stack direction="column" spacing={2} mx={2} mb={2}>
+              {siderProps?.footer}
+            </Stack>
+          </Box>
+        </Drawer>
+
+        <Box
+          sx={{
+            display: 'flex',
+            flex: 1,
+            flexDirection: 'column',
+            height: 'inherit',
+            position: 'relative',
+            width: `calc(100vw - ${drawerWidth})`,
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+// ==============================================================================
+// Error Boundary
+// ==============================================================================
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  {
+    isError: boolean;
+  }
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { isError: false };
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { isError: true, error: error };
+  }
+
+  render() {
+    if (this.state.isError) return null;
+    return this.props.children;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5896,7 +5896,6 @@ __metadata:
     "@playwright/test": "npm:~1.45.0"
     "@tanstack/react-query": "npm:~5.28.6"
     "@team-monite/eslint-plugin": "workspace:~"
-    "@team-monite/sdk-demo": "workspace:~"
     "@types/react": "npm:^18.0.9"
     "@types/react-dom": "npm:^18.0.4"
     "@vitejs/plugin-react": "npm:~4.3.4"


### PR DESCRIPTION
## Summary

This PR copies over some of the code from sdk-demo that is used in the Drop-in dev demo pages, in preparation for sdk-demo removal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a built-in demo toolkit with token-secured API access, internationalization support, and a default layout for a smoother demo experience.
- Refactor
  - Streamlined the demo app initialization to fetch the entity and set up the client before loading the UI, improving reliability and consistency.
  - Replaced external demo module usage with internal equivalents without changing user-facing behavior.
- Chores
  - Removed an unused development dependency to simplify the setup.
- Style
  - Normalized the HTML doctype declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->