### PR TITLE
feat(DEV-16048): Add Expenses page with transactions table listing

### DIFF
--- a/.changeset/dirty-items-clap.md
+++ b/.changeset/dirty-items-clap.md
@@ -1,0 +1,6 @@
+---
+'@monite/sdk-react': patch
+'@team-monite/sdk-demo': patch
+---
+
+Add new Expense Management page "Expenses" with listing of Transactions

--- a/examples/with-nextjs-and-clerk-auth/src/app/(monite)/expenses/page.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/app/(monite)/expenses/page.tsx
@@ -1,0 +1,10 @@
+import { Expenses } from '@/components/MoniteComponents';
+import { Box } from '@mui/material';
+
+export default async function ExpensesPage() {
+  return (
+    <Box className="Monite-PageContainer Monite-Expenses">
+      <Expenses />
+    </Box>
+  );
+}

--- a/examples/with-nextjs-and-clerk-auth/src/components/MoniteComponents.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/components/MoniteComponents.tsx
@@ -5,6 +5,7 @@ import {
   ApprovalPolicies as ApprovalPoliciesBase,
   Counterparts as CounterpartsBase,
   Dialog,
+  Expenses as ExpensesBase,
   getCounterpartName,
   MoniteProvider as MoniteProviderBase,
   Payables as PayablesBase,
@@ -559,6 +560,10 @@ export const ApprovalPolicies = () => {
 
 export const Tags = () => {
   return <TagsBase />;
+};
+
+export const Expenses = () => {
+  return <ExpensesBase />;
 };
 
 export const UserRoles = () => {

--- a/examples/with-nextjs-and-clerk-auth/src/components/NavigationMenu/NavigationList.tsx
+++ b/examples/with-nextjs-and-clerk-auth/src/components/NavigationMenu/NavigationList.tsx
@@ -35,6 +35,9 @@ export const NavigationList = () => {
         <NavigationListItem href="/receivables" icon={<IconReceipt />}>
           {t(i18n)`Invoicing`}
         </NavigationListItem>
+        <NavigationListItem href="/expenses" icon={<IconUsdCircle />}>
+          {t(i18n)`Expenses`}
+        </NavigationListItem>
         <NavigationListItem href="/projects" icon={<IconBag />}>
           {t(i18n)`Projects`}
         </NavigationListItem>

--- a/examples/with-nextjs-and-clerk-auth/src/locales/en/messages.po
+++ b/examples/with-nextjs-and-clerk-auth/src/locales/en/messages.po
@@ -31,7 +31,7 @@ msgstr "Bill Pay"
 #~ msgid "Continue"
 #~ msgstr "Continue"
 
-#: src/components/NavigationMenu/NavigationList.tsx:42
+#: src/components/NavigationMenu/NavigationList.tsx:45
 msgid "Counterparts"
 msgstr "Counterparts"
 
@@ -56,7 +56,11 @@ msgstr "Dashboard"
 #~ msgid "English"
 #~ msgstr "English"
 
-#: src/components/NavigationMenu/NavigationList.tsx:86
+#: src/components/NavigationMenu/NavigationList.tsx:39
+msgid "Expenses"
+msgstr "Expenses"
+
+#: src/components/NavigationMenu/NavigationList.tsx:89
 msgid "Get Help"
 msgstr "Get Help"
 
@@ -114,11 +118,11 @@ msgstr "Invoicing"
 #~ msgid "Payable \"{0}\" has been paid"
 #~ msgstr "Payable \"{0}\" has been paid"
 
-#: src/components/NavigationMenu/NavigationList.tsx:45
+#: src/components/NavigationMenu/NavigationList.tsx:48
 msgid "Products & Services"
 msgstr "Products & Services"
 
-#: src/components/NavigationMenu/NavigationList.tsx:39
+#: src/components/NavigationMenu/NavigationList.tsx:42
 msgid "Projects"
 msgstr "Projects"
 
@@ -126,7 +130,7 @@ msgstr "Projects"
 #~ msgid "Purchases"
 #~ msgstr "Purchases"
 
-#: src/components/NavigationMenu/NavigationList.tsx:68
+#: src/components/NavigationMenu/NavigationList.tsx:71
 msgid "Roles & Approvals"
 msgstr "Roles & Approvals"
 
@@ -134,7 +138,7 @@ msgstr "Roles & Approvals"
 #~ msgid "Sales"
 #~ msgstr "Sales"
 
-#: src/components/NavigationMenu/NavigationList.tsx:60
+#: src/components/NavigationMenu/NavigationList.tsx:63
 msgid "Settings"
 msgstr "Settings"
 
@@ -142,7 +146,7 @@ msgstr "Settings"
 #~ msgid "Subtotal"
 #~ msgstr "Subtotal"
 
-#: src/components/NavigationMenu/NavigationList.tsx:71
+#: src/components/NavigationMenu/NavigationList.tsx:74
 msgid "Tags"
 msgstr "Tags"
 
@@ -150,7 +154,7 @@ msgstr "Tags"
 #~ msgid "Team"
 #~ msgstr "Team"
 
-#: src/components/NavigationMenu/NavigationList.tsx:65
+#: src/components/NavigationMenu/NavigationList.tsx:68
 msgid "Template settings"
 msgstr "Template settings"
 

--- a/packages/sdk-demo/src/apps/Base/Base.tsx
+++ b/packages/sdk-demo/src/apps/Base/Base.tsx
@@ -1,6 +1,4 @@
-import { ReactNode } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
-
+import { ROUTES } from './consts';
 import {
   ApprovalRequests,
   Counterparts,
@@ -8,13 +6,14 @@ import {
   Receivables,
   Products,
   Tags,
+  Expenses,
   Onboarding,
   Integrations,
   RolesAndApprovalPolicies,
 } from '@monite/sdk-react';
 import { Box } from '@mui/material';
-
-import { ROUTES } from './consts';
+import { ReactNode } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
 
 export const Base = () => {
   return (
@@ -75,6 +74,14 @@ export const Base = () => {
         element={
           <Gutter>
             <Tags />
+          </Gutter>
+        }
+      />
+      <Route
+        path={ROUTES.expenses}
+        element={
+          <Gutter>
+            <Expenses />
           </Gutter>
         }
       />

--- a/packages/sdk-demo/src/apps/Base/consts.ts
+++ b/packages/sdk-demo/src/apps/Base/consts.ts
@@ -6,6 +6,7 @@ export const ROUTES = {
   approvalRequests: '/approval-requests',
   roles: '/settings/roles',
   tags: '/settings/tags',
+  expenses: '/expenses',
   receivables: '/receivables',
   products: '/products',
   onboarding: '/onboarding',

--- a/packages/sdk-demo/src/components/Menu/consts.tsx
+++ b/packages/sdk-demo/src/components/Menu/consts.tsx
@@ -1,3 +1,4 @@
+import { MenuItemType } from './types';
 import { ROUTES } from '@/apps/Base';
 import type { I18n } from '@lingui/core';
 import { t } from '@lingui/macro';
@@ -10,9 +11,8 @@ import {
   Tab as TabIcon,
   Label as LabelIcon,
   DoneOutline as DoneOutlineIcon,
+  Storefront as StorefrontIcon,
 } from '@mui/icons-material';
-
-import { MenuItemType } from './types';
 
 export const getNavigationData = (
   i18n: I18n
@@ -31,6 +31,11 @@ export const getNavigationData = (
     label: t(i18n)`Sales`,
     url: ROUTES.receivables,
     renderIcon: (props) => <ReceiptIcon {...props} />,
+  },
+  expenses: {
+    label: t(i18n)`Expenses`,
+    url: ROUTES.expenses,
+    renderIcon: (props) => <StorefrontIcon {...props} />,
   },
   counterparts: {
     label: t(i18n)`Counterparts`,

--- a/packages/sdk-demo/src/locales/en/messages.po
+++ b/packages/sdk-demo/src/locales/en/messages.po
@@ -19,7 +19,7 @@ msgstr "Client ID"
 msgid "Client Secret"
 msgstr "Client Secret"
 
-#: src/components/Menu/consts.tsx:36
+#: src/components/Menu/consts.tsx:41
 msgid "Counterparts"
 msgstr "Counterparts"
 
@@ -35,7 +35,11 @@ msgstr "Entity User ID"
 msgid "Error: <0>{0}</0>"
 msgstr "Error: <0>{0}</0>"
 
-#: src/components/Menu/consts.tsx:66
+#: src/components/Menu/consts.tsx:36
+msgid "Expenses"
+msgstr "Expenses"
+
+#: src/components/Menu/consts.tsx:71
 msgid "Integrations"
 msgstr "Integrations"
 
@@ -59,7 +63,7 @@ msgstr "Logout"
 #~ msgid "Monite"
 #~ msgstr "Monite"
 
-#: src/components/Menu/consts.tsx:61
+#: src/components/Menu/consts.tsx:66
 msgid "Onboard Entity"
 msgstr "Onboard Entity"
 
@@ -67,11 +71,11 @@ msgstr "Onboard Entity"
 msgid "Payables"
 msgstr "Payables"
 
-#: src/components/Menu/consts.tsx:41
+#: src/components/Menu/consts.tsx:46
 msgid "Products"
 msgstr "Products"
 
-#: src/components/Menu/consts.tsx:51
+#: src/components/Menu/consts.tsx:56
 msgid "Roles & Approvals"
 msgstr "Roles & Approvals"
 
@@ -79,11 +83,11 @@ msgstr "Roles & Approvals"
 msgid "Sales"
 msgstr "Sales"
 
-#: src/components/Menu/consts.tsx:46
+#: src/components/Menu/consts.tsx:51
 msgid "Settings"
 msgstr "Settings"
 
-#: src/components/Menu/consts.tsx:56
+#: src/components/Menu/consts.tsx:61
 msgid "Tags"
 msgstr "Tags"
 

--- a/packages/sdk-playground/src/App.tsx
+++ b/packages/sdk-playground/src/App.tsx
@@ -9,6 +9,7 @@ import {
   ProductsPage,
   RolesApprovalsPage,
   TagsPage,
+  ExpensesPage,
   OnboardingPage,
   IntegrationsPage,
   TemplateSettingsPage,
@@ -35,6 +36,7 @@ function ProtectedApp() {
           <Route path="/products" element={<ProductsPage />} />
           <Route path="/roles-and-approvals" element={<RolesApprovalsPage />} />
           <Route path="/tags" element={<TagsPage />} />
+          <Route path="/expenses" element={<ExpensesPage />} />
           <Route path="/template-settings" element={<TemplateSettingsPage />} />
           <Route path="/onboarding" element={<OnboardingPage />} />
           <Route path="/integrations" element={<IntegrationsPage />} />

--- a/packages/sdk-playground/src/components/app-sidebar.tsx
+++ b/packages/sdk-playground/src/components/app-sidebar.tsx
@@ -27,6 +27,8 @@ import {
   TagIcon,
   ZapIcon,
   Settings2Icon,
+  DollarSignIcon,
+  StoreIcon,
 } from 'lucide-react';
 import { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
@@ -48,6 +50,11 @@ const menuItems = [
     url: '/approval-requests',
   },
   {
+    title: 'Expenses',
+    icon: StoreIcon,
+    url: '/expenses',
+  },
+  {
     title: 'Counterparts',
     icon: Building2Icon,
     url: '/counterparts',
@@ -66,6 +73,11 @@ const menuItems = [
     title: 'Tags',
     icon: TagIcon,
     url: '/tags',
+  },
+  {
+    title: 'Financing',
+    icon: DollarSignIcon,
+    url: '/financing',
   },
   {
     title: 'Template Settings',

--- a/packages/sdk-playground/src/pages/ExpensesPage.tsx
+++ b/packages/sdk-playground/src/pages/ExpensesPage.tsx
@@ -1,0 +1,10 @@
+import { AppMoniteProvider } from '@/components/app-monite-provider';
+import { Expenses } from '@monite/sdk-react';
+
+export function ExpensesPage() {
+  return (
+    <AppMoniteProvider>
+      <Expenses />
+    </AppMoniteProvider>
+  );
+}

--- a/packages/sdk-playground/src/pages/index.ts
+++ b/packages/sdk-playground/src/pages/index.ts
@@ -6,6 +6,7 @@ export { CounterpartsPage } from './CounterpartsPage';
 export { ProductsPage } from './ProductsPage';
 export { RolesApprovalsPage } from './RolesApprovalsPage';
 export { TagsPage } from './TagsPage';
+export { ExpensesPage } from './ExpensesPage';
 export { TemplateSettingsPage } from './TemplateSettingsPage';
 export { OnboardingPage } from './OnboardingPage';
 export { IntegrationsPage } from './IntegrationsPage';

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -61,6 +61,7 @@
     "@react-pdf-viewer/zoom": "3.12.0",
     "@sentry/react": "~7.119.1",
     "@tanstack/react-query": "~5.28.6",
+    "@tanstack/react-table": "~8.21.3",
     "@tanstack/react-virtual": "~3.13.6",
     "chroma-js": "~3.1.2",
     "class-variance-authority": "~0.7.1",

--- a/packages/sdk-react/src/api/schema.json
+++ b/packages/sdk-react/src/api/schema.json
@@ -38788,6 +38788,1449 @@
         "security": [{ "HTTPBearer": [] }]
       }
     },
+    "/receipts": {
+      "get": {
+        "tags": ["Receipts"],
+        "summary": "Get receipts",
+        "operationId": "get_receipts",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "description": "Sort order (ascending by default). Typically used together with the `sort` parameter.",
+            "required": false,
+            "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/OrderEnum" }],
+              "default": "asc"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "description": "The number of items (0 .. 100) to return in a single page of the response. The response may contain fewer items if it is the last or only page.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "default": 100
+            },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "description": "A pagination token obtained from a previous call to this endpoint. Use it to get the next or previous page of results for your initial query. If `pagination_token` is specified, all other query parameters are ignored and inferred from the initial query.\n\nIf not specified, the first page of results will be returned.",
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "pagination_token",
+            "in": "query"
+          },
+          {
+            "description": "The field to sort the results by. Typically used together with the `order` parameter.",
+            "required": false,
+            "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/ReceiptCursorFields" }]
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__gt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__lt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__gte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__lte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": {
+              "items": { "type": "string", "format": "uuid" },
+              "type": "array"
+            },
+            "name": "id__in",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "$ref": "#/components/schemas/CurrencyEnum" },
+            "name": "currency",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "document_id",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "document_id__contains",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "document_id__icontains",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total_amount__gt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total_amount__lt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total_amount__gte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total_amount__lte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "boolean" },
+            "name": "has_file",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "boolean" },
+            "name": "has_transaction",
+            "in": "query"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptPaginationResponse"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "post": {
+        "tags": ["Receipts"],
+        "summary": "Create a receipt",
+        "operationId": "post_receipts",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ReceiptCreateSchema" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponseSchema"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
+    "/receipts/upload_from_file": {
+      "post": {
+        "tags": ["Receipts"],
+        "summary": "Upload a receipt from a file",
+        "description": "Upload an incoming receipt in the PDF, PNG, or JPEG format and scan its contents. The maximum file size is 20 MB.",
+        "operationId": "post_receipts_upload_from_file",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": { "$ref": "#/components/schemas/ReceiptUploadFile" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponseSchema"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error uploading the file.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
+    "/receipts/{receipt_id}": {
+      "get": {
+        "tags": ["Receipts"],
+        "summary": "Get a receipt by ID",
+        "operationId": "get_receipts_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponseSchema"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "delete": {
+        "tags": ["Receipts"],
+        "summary": "Delete a receipt",
+        "operationId": "delete_receipts_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Business logic error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "patch": {
+        "tags": ["Receipts"],
+        "summary": "Update a receipt",
+        "operationId": "patch_receipts_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ReceiptUpdateSchema" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponseSchema"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
+    "/receipts/{receipt_id}/attach_file": {
+      "post": {
+        "tags": ["Receipts"],
+        "summary": "Attach a file to a receipt",
+        "description": "Attach a file to a receipt without an existing attachment.",
+        "operationId": "post_receipts_id_attach_file",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": { "$ref": "#/components/schemas/ReceiptAttachFile" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptResponseSchema"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
+    "/receipts/{receipt_id}/line_items": {
+      "get": {
+        "tags": ["Receipts"],
+        "summary": "Get all line items of a receipt",
+        "operationId": "get_receipts_id_line_items",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "description": "Sort order (ascending by default). Typically used together with the `sort` parameter.",
+            "required": false,
+            "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/OrderEnum" }],
+              "default": "asc"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "description": "The number of items (0 .. 100) to return in a single page of the response. The response may contain fewer items if it is the last or only page.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "default": 100
+            },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "description": "A pagination token obtained from a previous call to this endpoint. Use it to get the next or previous page of results for your initial query. If `pagination_token` is specified, all other query parameters are ignored and inferred from the initial query.\n\nIf not specified, the first page of results will be returned.",
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "pagination_token",
+            "in": "query"
+          },
+          {
+            "description": "The field to sort the results by. Typically used together with the `order` parameter.",
+            "required": false,
+            "schema": {
+              "allOf": [
+                { "$ref": "#/components/schemas/ReceiptLineItemCursorFields" }
+              ]
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__gt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__lt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__gte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__lte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "name",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "name__iexact",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "name__contains",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "name__icontains",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total__gt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total__lt",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total__gte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "integer", "minimum": 0.0 },
+            "name": "total__lte",
+            "in": "query"
+          },
+          {
+            "required": false,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "created_by_user_id",
+            "in": "query"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptLineItemsPaginationResponse"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "post": {
+        "tags": ["Receipts"],
+        "summary": "Add a new line item to a receipt",
+        "operationId": "post_receipts_id_line_items",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiptLineItemCreateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptLineItemResponseSchema"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
+    "/receipts/{receipt_id}/line_items/{line_item_id}": {
+      "delete": {
+        "tags": ["Receipts"],
+        "summary": "Delete a line item from a receipt",
+        "operationId": "delete_receipts_id_line_items_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "line_item_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "patch": {
+        "tags": ["Receipts"],
+        "summary": "Update a line item of a receipt",
+        "operationId": "patch_receipts_id_line_items_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "receipt_id",
+            "in": "path"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "line_item_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReceiptLineItemUpdateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptLineItemResponseSchema"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorSchemaResponse3"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
     "/receivables": {
       "get": {
         "tags": ["Receivables"],
@@ -44584,6 +46027,765 @@
         "security": [{ "HTTPBearer": [] }]
       }
     },
+    "/transactions": {
+      "get": {
+        "tags": ["Transactions"],
+        "summary": "Get transactions",
+        "operationId": "get_transactions",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "description": "Order by",
+            "required": false,
+            "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/OrderEnum" }],
+              "default": "asc"
+            },
+            "name": "order",
+            "in": "query"
+          },
+          {
+            "description": "Max is 100",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100.0,
+              "minimum": 1.0,
+              "default": 100
+            },
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "description": "A token, obtained from previous page. Prior over other filters",
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "pagination_token",
+            "in": "query"
+          },
+          {
+            "description": "Allowed sort fields",
+            "required": false,
+            "schema": {
+              "allOf": [
+                { "$ref": "#/components/schemas/TransactionCursorFields" }
+              ]
+            },
+            "name": "sort",
+            "in": "query"
+          },
+          {
+            "description": "Created after this datetime (exclusive)",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__gt",
+            "in": "query"
+          },
+          {
+            "description": "Created before this datetime (exclusive)",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "created_at__lt",
+            "in": "query"
+          },
+          {
+            "description": "Updated after this datetime (exclusive)",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "updated_at__gt",
+            "in": "query"
+          },
+          {
+            "description": "Updated before this datetime (exclusive)",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "updated_at__lt",
+            "in": "query"
+          },
+          {
+            "description": "Transaction started after this datetime (exclusive)",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "started_at__gt",
+            "in": "query"
+          },
+          {
+            "description": "Transaction started before this datetime (exclusive)",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "name": "started_at__lt",
+            "in": "query"
+          },
+          {
+            "description": "One or multiple of the transaction statuses",
+            "required": false,
+            "schema": {
+              "items": { "$ref": "#/components/schemas/TransactionStatusEnum" },
+              "type": "array"
+            },
+            "name": "status__in",
+            "in": "query"
+          },
+          {
+            "description": "One or multiple of the transaction types",
+            "required": false,
+            "schema": {
+              "items": { "$ref": "#/components/schemas/TransactionTypeEnum" },
+              "type": "array"
+            },
+            "name": "type__in",
+            "in": "query"
+          },
+          {
+            "description": "One or multiple of the entity users",
+            "required": false,
+            "schema": {
+              "items": { "type": "string", "format": "uuid" },
+              "type": "array"
+            },
+            "name": "entity_user_id__in",
+            "in": "query"
+          },
+          {
+            "description": "One or multiple of the transaction external ids",
+            "required": false,
+            "schema": { "items": { "type": "string" }, "type": "array" },
+            "name": "external_id__in",
+            "in": "query"
+          },
+          {
+            "description": "Amount greater than (exclusive)",
+            "required": false,
+            "schema": { "type": "integer" },
+            "name": "amount__gt",
+            "in": "query"
+          },
+          {
+            "description": "Amount less than (exclusive)",
+            "required": false,
+            "schema": { "type": "integer" },
+            "name": "amount__lt",
+            "in": "query"
+          },
+          {
+            "description": "One or multiple of the transaction currencies",
+            "required": false,
+            "schema": {
+              "items": { "$ref": "#/components/schemas/CurrencyEnum" },
+              "type": "array"
+            },
+            "name": "currency__in",
+            "in": "query"
+          },
+          {
+            "description": "Merchant amount greater than (exclusive)",
+            "required": false,
+            "schema": { "type": "integer" },
+            "name": "merchant_amount__gt",
+            "in": "query"
+          },
+          {
+            "description": "Merchant amount less than (exclusive)",
+            "required": false,
+            "schema": { "type": "integer" },
+            "name": "merchant_amount__lt",
+            "in": "query"
+          },
+          {
+            "description": "One or multiple of the transaction merchant currencies",
+            "required": false,
+            "schema": {
+              "items": { "$ref": "#/components/schemas/CurrencyEnum" },
+              "type": "array"
+            },
+            "name": "merchant_currency__in",
+            "in": "query"
+          },
+          {
+            "description": "Partially matched merchant name",
+            "required": false,
+            "schema": { "type": "string" },
+            "name": "merchant_name__icontains",
+            "in": "query"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionResponseList"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "post": {
+        "tags": ["Transactions"],
+        "summary": "Create a transaction",
+        "operationId": "post_transactions",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TransactionRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TransactionResponse" }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
+    "/transactions/bulk": {
+      "post": {
+        "tags": ["Transactions"],
+        "summary": "Create multiple transactions",
+        "operationId": "post_transactions_bulk",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionBulkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransactionBulkResponse"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
+    "/transactions/{transaction_id}": {
+      "get": {
+        "tags": ["Transactions"],
+        "summary": "Get a transaction",
+        "operationId": "get_transactions_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "transaction_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TransactionResponse" }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "delete": {
+        "tags": ["Transactions"],
+        "summary": "Delete a transaction",
+        "operationId": "delete_transactions_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "transaction_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "204": { "description": "Successful Response" },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      },
+      "patch": {
+        "tags": ["Transactions"],
+        "summary": "Update a transaction",
+        "operationId": "patch_transactions_id",
+        "parameters": [
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "date" },
+            "example": "2024-05-25",
+            "name": "x-monite-version",
+            "in": "header"
+          },
+          {
+            "required": true,
+            "schema": { "type": "string", "format": "uuid" },
+            "name": "transaction_id",
+            "in": "path"
+          },
+          {
+            "description": "The ID of the entity that owns the requested resource.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "examples": ["9d2b4c8f-2087-4738-ba91-7359683c49a4"]
+            },
+            "name": "x-monite-entity-id",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TransactionResponse" }
+              }
+            }
+          },
+          "405": {
+            "description": "Method Not Allowed",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "409": {
+            "description": "Business logic error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorSchemaResponse" }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/HTTPValidationError" }
+              }
+            }
+          }
+        },
+        "security": [{ "HTTPBearer": [] }]
+      }
+    },
     "/vat_rates": {
       "get": {
         "tags": ["VAT rates"],
@@ -47256,6 +49458,57 @@
         "type": "object",
         "required": ["bank_account_id", "bank_id"]
       },
+      "BankAccountPaymentMethod": {
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/BankAccountPaymentMethodDetails"
+          },
+          "type": { "type": "string", "enum": ["bank_account"] }
+        },
+        "type": "object",
+        "required": ["details", "type"]
+      },
+      "BankAccountPaymentMethodDetails": {
+        "properties": {
+          "account_holder_name": {
+            "type": "string",
+            "description": "The name of the person or business that owns this bank account. Required for US bank accounts to accept ACH payments.",
+            "example": "Bob Jones"
+          },
+          "account_number": {
+            "type": "string",
+            "description": "The bank account number. Required for US bank accounts to accept ACH payments. US account numbers contain 9 to 12 digits. UK account numbers typically contain 8 digits.",
+            "example": "12345678"
+          },
+          "bic": {
+            "type": "string",
+            "maxLength": 11,
+            "description": "The BIC/SWIFT code of the bank.",
+            "example": "DEUTDEFFXXX"
+          },
+          "currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "ISO currency code"
+          },
+          "iban": {
+            "type": "string",
+            "maxLength": 34,
+            "description": "The IBAN of the bank account.",
+            "example": "DE74500700100100000900"
+          },
+          "name": { "type": "string", "maxLength": 200 },
+          "routing_number": {
+            "type": "string",
+            "description": "The bank's routing transit number (RTN). Required for US bank accounts to accept ACH payments. US routing numbers consist of 9 digits."
+          },
+          "sort_code": {
+            "type": "string",
+            "description": "The bank's sort code.",
+            "example": "123456"
+          }
+        },
+        "type": "object"
+      },
       "BankAccountVerificationType": {
         "type": "string",
         "enum": ["airwallex_plaid", "micro_deposit"]
@@ -47467,6 +49720,50 @@
         },
         "type": "object"
       },
+      "CardPaymentMethod": {
+        "properties": {
+          "details": {
+            "$ref": "#/components/schemas/CardPaymentMethodDetails"
+          },
+          "type": { "type": "string", "enum": ["card"] }
+        },
+        "type": "object",
+        "required": ["details", "type"]
+      },
+      "CardPaymentMethodDetails": {
+        "properties": {
+          "brand": {
+            "type": "string",
+            "maxLength": 32,
+            "description": "The brand name of the card number."
+          },
+          "card_type": { "$ref": "#/components/schemas/CardTypeEnum" },
+          "expiry_month": {
+            "type": "integer",
+            "exclusiveMaximum": 13.0,
+            "exclusiveMinimum": 0.0
+          },
+          "expiry_year": {
+            "type": "integer",
+            "exclusiveMaximum": 2100.0,
+            "exclusiveMinimum": 2000.0
+          },
+          "last4": {
+            "type": "string",
+            "maxLength": 4,
+            "minLength": 4,
+            "description": "The last-four digits of the card number."
+          }
+        },
+        "type": "object",
+        "required": [
+          "brand",
+          "card_type",
+          "expiry_month",
+          "expiry_year",
+          "last4"
+        ]
+      },
       "CardTheme": {
         "properties": {
           "background_color": {
@@ -47477,6 +49774,10 @@
           }
         },
         "type": "object"
+      },
+      "CardTypeEnum": {
+        "type": "string",
+        "enum": ["credit", "debit", "prepaid", "unknown"]
       },
       "ClientMessage": {
         "properties": {
@@ -47606,7 +49907,8 @@
               "workflow",
               "approval_request",
               "approval_policy",
-              "payment_record"
+              "payment_record",
+              "receipt"
             ],
             "description": "Object type",
             "default": "comment"
@@ -47653,7 +49955,8 @@
               "workflow",
               "approval_request",
               "approval_policy",
-              "payment_record"
+              "payment_record",
+              "receipt"
             ],
             "description": "Object type",
             "default": "comment"
@@ -56343,7 +58646,10 @@
         "type": "object",
         "required": ["entity_ids"]
       },
-      "MailboxObjectTypeEnum": { "type": "string", "enum": ["payable"] },
+      "MailboxObjectTypeEnum": {
+        "type": "string",
+        "enum": ["payable", "receipt"]
+      },
       "MailboxResponse": {
         "properties": {
           "id": {
@@ -56689,7 +58995,10 @@
         "type": "object",
         "required": ["sender", "recipient", "line_items"]
       },
-      "OCRDocumentTypeEnum": { "enum": ["invoice", "credit_note", "receipt"] },
+      "OCRDocumentTypeEnum": {
+        "type": "string",
+        "enum": ["invoice", "credit_note", "receipt"]
+      },
       "OCRFileUpload": {
         "properties": { "file": { "type": "string", "format": "binary" } },
         "type": "object",
@@ -63379,6 +65688,382 @@
           "deleted"
         ]
       },
+      "ReceiptAttachFile": {
+        "properties": { "file": { "type": "string", "format": "binary" } },
+        "type": "object",
+        "required": ["file"]
+      },
+      "ReceiptCreateSchema": {
+        "properties": {
+          "base64_encoded_file": {
+            "type": "string",
+            "description": "Base64-encoded contents of the original receipt file."
+          },
+          "currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "Currency code used in the receipt.",
+            "example": "EUR"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Short transaction description.",
+            "example": "Payment for lunch with clients"
+          },
+          "document_id": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Unique receipt number assigned by the issuer.",
+            "example": "DE2287"
+          },
+          "issued_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Receipt issued date and time."
+          },
+          "merchant_location": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Location of the merchant.",
+            "example": "West Street, London, UK"
+          },
+          "merchant_name": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Name of the merchant.",
+            "example": "Tesco"
+          },
+          "partner_metadata": {
+            "type": "object",
+            "description": "Metadata for partner needs"
+          },
+          "total_amount": {
+            "type": "integer",
+            "minimum": 0.0,
+            "description": "Total amount for the receipt in minor units (e.g. cents).",
+            "example": 15000
+          },
+          "transaction_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Transaction ID."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "ReceiptCursorFields": { "type": "string", "enum": ["id", "created_at"] },
+      "ReceiptLineItemCreateSchema": {
+        "properties": {
+          "accounting_tax_rate_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Accounting tax rate ID."
+          },
+          "cost_center_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Cost center ID."
+          },
+          "general_ledger_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "General ledger ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Line item name/description."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Line item total in minor units."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "ReceiptLineItemCursorFields": {
+        "type": "string",
+        "enum": ["created_at", "updated_at"]
+      },
+      "ReceiptLineItemResponseSchema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique line item ID."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Created at."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Updated at."
+          },
+          "accounting_tax_rate_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Accounting tax rate ID."
+          },
+          "cost_center_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Cost center ID."
+          },
+          "created_by_entity_user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Created by user."
+          },
+          "name": { "type": "string", "description": "Line item name." },
+          "receipt_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Receipt ID."
+          },
+          "total": { "type": "integer", "description": "Total." }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["id", "created_at", "updated_at", "receipt_id"]
+      },
+      "ReceiptLineItemUpdateSchema": {
+        "properties": {
+          "accounting_tax_rate_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Accounting tax rate ID."
+          },
+          "cost_center_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Cost center ID."
+          },
+          "general_ledger_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "General ledger ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Line item name/description."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Line item total in minor units."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "ReceiptLineItemsPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/ReceiptLineItemResponseSchema"
+            },
+            "type": "array"
+          },
+          "next_pagination_token": {
+            "type": "string",
+            "description": "Next page token."
+          },
+          "prev_pagination_token": {
+            "type": "string",
+            "description": "Previous page token."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["data"]
+      },
+      "ReceiptOriginEnum": { "type": "string", "enum": ["upload", "email"] },
+      "ReceiptPaginationResponse": {
+        "properties": {
+          "data": {
+            "items": { "$ref": "#/components/schemas/ReceiptResponseSchema" },
+            "type": "array"
+          },
+          "next_pagination_token": {
+            "type": "string",
+            "description": "Next page token."
+          },
+          "prev_pagination_token": {
+            "type": "string",
+            "description": "Previous page token."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["data"]
+      },
+      "ReceiptResponseSchema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique receipt ID."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Creation timestamp."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Update timestamp."
+          },
+          "created_by_entity_user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Entity user who created."
+          },
+          "currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "Currency code."
+          },
+          "currency_exchange": {
+            "type": "object",
+            "description": "Currency exchange details."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Short transaction description.",
+            "example": "Payment for lunch with clients"
+          },
+          "document_id": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Receipt number."
+          },
+          "file_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The id of the receipt file stored in the file saver.",
+            "example": "123e4567-e89b-12d3-a456-426614174000"
+          },
+          "file_url": {
+            "type": "string",
+            "description": "The URL of the receipt file stored in the file saver."
+          },
+          "issued_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date when the receipt was issued."
+          },
+          "merchant_location": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Merchant location."
+          },
+          "merchant_name": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Merchant name."
+          },
+          "ocr_request_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "OCR request id."
+          },
+          "ocr_status": { "type": "string", "description": "OCR status." },
+          "origin": {
+            "allOf": [{ "$ref": "#/components/schemas/ReceiptOriginEnum" }],
+            "description": "Specifies how this receipt was created in Monite."
+          },
+          "partner_metadata": {
+            "type": "object",
+            "description": "Partner metadata."
+          },
+          "sender": {
+            "type": "string",
+            "format": "email",
+            "description": "The email address from which the invoice was sent to the entity.",
+            "example": "hello@example.com"
+          },
+          "source_of_data": {
+            "allOf": [
+              { "$ref": "#/components/schemas/SourceOfReceiptDataEnum" }
+            ],
+            "description": "Source of data."
+          },
+          "total_amount": {
+            "type": "integer",
+            "description": "Total amount in minor units."
+          },
+          "transaction_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Transaction ID."
+          }
+        },
+        "type": "object",
+        "required": ["id", "created_at", "updated_at", "origin"]
+      },
+      "ReceiptUpdateSchema": {
+        "properties": {
+          "base64_encoded_file": {
+            "type": "string",
+            "description": "Base64-encoded file contents."
+          },
+          "currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "Currency code."
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 1024,
+            "description": "Short transaction description.",
+            "example": "Payment for lunch with clients"
+          },
+          "document_id": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Receipt number."
+          },
+          "issued_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date when the receipt was issued."
+          },
+          "merchant_location": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Merchant location."
+          },
+          "merchant_name": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Merchant name."
+          },
+          "partner_metadata": {
+            "type": "object",
+            "description": "Metadata for partner needs"
+          },
+          "total_amount": {
+            "type": "integer",
+            "minimum": 0.0,
+            "description": "Total amount."
+          },
+          "transaction_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Transaction ID."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object"
+      },
+      "ReceiptUploadFile": {
+        "properties": { "file": { "type": "string", "format": "binary" } },
+        "type": "object",
+        "required": ["file"]
+      },
       "ReceivableCounterpartContact": {
         "properties": {
           "address": {
@@ -65809,6 +68494,7 @@
             "person": "#/components/schemas/CommonSchema-Input",
             "product": "#/components/schemas/CommonSchema-Input",
             "project": "#/components/schemas/CommonSchema-Input",
+            "receipt": "#/components/schemas/CommonSchema-Input",
             "receivable": "#/components/schemas/CommonSchema-Input",
             "reconciliation": "#/components/schemas/CommonSchema-Input",
             "role": "#/components/schemas/CommonSchema-Input",
@@ -65850,6 +68536,7 @@
             "person": "#/components/schemas/CommonSchema-Output",
             "product": "#/components/schemas/CommonSchema-Output",
             "project": "#/components/schemas/CommonSchema-Output",
+            "receipt": "#/components/schemas/CommonSchema-Output",
             "receivable": "#/components/schemas/CommonSchema-Output",
             "reconciliation": "#/components/schemas/CommonSchema-Output",
             "role": "#/components/schemas/CommonSchema-Output",
@@ -66162,6 +68849,10 @@
       "SourceOfPayableDataEnum": {
         "type": "string",
         "enum": ["ocr", "user_specified", "einvoicing"]
+      },
+      "SourceOfReceiptDataEnum": {
+        "type": "string",
+        "enum": ["ocr", "user_specified"]
       },
       "StatusChangedEventData": {
         "properties": {
@@ -66828,6 +69519,308 @@
         },
         "type": "object",
         "required": ["name", "value", "amount"]
+      },
+      "TransactionBulkObject": {
+        "properties": { "id": { "type": "string", "format": "uuid" } },
+        "type": "object"
+      },
+      "TransactionBulkRequest": {
+        "properties": {
+          "data": {
+            "items": { "$ref": "#/components/schemas/TransactionRequest" },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "required": ["data"]
+      },
+      "TransactionBulkResponse": {
+        "properties": {
+          "data": {
+            "items": { "$ref": "#/components/schemas/TransactionBulkObject" },
+            "type": "array",
+            "maxItems": 5000,
+            "minItems": 1
+          },
+          "status": { "$ref": "#/components/schemas/TransactionBulkStatusEnum" }
+        },
+        "type": "object",
+        "required": ["data", "status"]
+      },
+      "TransactionBulkStatusEnum": {
+        "type": "string",
+        "enum": ["success", "partial_success", "error"]
+      },
+      "TransactionCursorFields": {
+        "type": "string",
+        "enum": [
+          "created_at",
+          "updated_at",
+          "started_at",
+          "amount",
+          "merchant_amount",
+          "merchant_name",
+          "status",
+          "type",
+          "external_id"
+        ]
+      },
+      "TransactionPaymentMethod": {
+        "oneOf": [
+          { "$ref": "#/components/schemas/CardPaymentMethod" },
+          { "$ref": "#/components/schemas/BankAccountPaymentMethod" }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "card": "#/components/schemas/CardPaymentMethod",
+            "bank_account": "#/components/schemas/BankAccountPaymentMethod"
+          }
+        }
+      },
+      "TransactionRequest": {
+        "properties": {
+          "amount": {
+            "type": "integer",
+            "description": "The transaction amount in minor units. Positive for in-flow, negative for out-flow"
+          },
+          "currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "ISO currency code"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "A human-readable description of the transaction."
+          },
+          "entity_user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier for the employee who made the payment, if applicable"
+          },
+          "external_id": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "External identifier for idempotency, if provided by the source system."
+          },
+          "merchant_amount": {
+            "type": "integer",
+            "description": "Original merchant transaction amount in minor units"
+          },
+          "merchant_currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "ISO currency code for the 'merchant_amount'."
+          },
+          "merchant_location": { "type": "string", "maxLength": 128 },
+          "merchant_name": { "type": "string", "maxLength": 128 },
+          "partner_metadata": {
+            "additionalProperties": { "type": "string" },
+            "type": "object",
+            "description": "Extensible key-value pairs for storing additional, custom information."
+          },
+          "payment_method": {
+            "$ref": "#/components/schemas/TransactionPaymentMethod"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time when the transaction started"
+          },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/TransactionStatusEnum" }],
+            "description": "The current processing status of the transaction: 'created', 'pending', 'succeeded', 'refunded', 'failed', 'declined'.",
+            "default": "created"
+          },
+          "type": {
+            "allOf": [{ "$ref": "#/components/schemas/TransactionTypeEnum" }],
+            "description": "The nature of the transaction. e.g., 'capture', 'refund', 'cash_withdrawal', 'fee', 'adjustment', 'reversal'."
+          }
+        },
+        "type": "object",
+        "required": [
+          "amount",
+          "currency",
+          "merchant_amount",
+          "merchant_currency",
+          "merchant_location",
+          "merchant_name",
+          "payment_method",
+          "type"
+        ]
+      },
+      "TransactionResponse": {
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "amount": {
+            "type": "integer",
+            "description": "The transaction amount in minor units. Positive for in-flow, negative for out-flow"
+          },
+          "currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "ISO currency code"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "A human-readable description of the transaction."
+          },
+          "entity_id": { "type": "string", "format": "uuid" },
+          "entity_user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier for the employee who made the payment, if applicable"
+          },
+          "external_id": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "External identifier for idempotency, if provided by the source system."
+          },
+          "merchant_amount": {
+            "type": "integer",
+            "description": "Original merchant transaction amount in minor units"
+          },
+          "merchant_currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "ISO currency code for the 'merchant_amount'."
+          },
+          "merchant_location": { "type": "string", "maxLength": 128 },
+          "merchant_name": { "type": "string", "maxLength": 128 },
+          "partner_metadata": {
+            "additionalProperties": { "type": "string" },
+            "type": "object",
+            "description": "Extensible key-value pairs for storing additional, custom information."
+          },
+          "payment_method": {
+            "$ref": "#/components/schemas/TransactionPaymentMethod"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time when the transaction started"
+          },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/TransactionStatusEnum" }],
+            "description": "The current processing status of the transaction: 'created', 'pending', 'succeeded', 'refunded', 'failed', 'declined'.",
+            "default": "created"
+          },
+          "type": {
+            "allOf": [{ "$ref": "#/components/schemas/TransactionTypeEnum" }],
+            "description": "The nature of the transaction. e.g., 'capture', 'refund', 'cash_withdrawal', 'fee', 'adjustment', 'reversal'."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "amount",
+          "currency",
+          "entity_id",
+          "merchant_amount",
+          "merchant_currency",
+          "merchant_location",
+          "merchant_name",
+          "payment_method",
+          "type"
+        ]
+      },
+      "TransactionResponseList": {
+        "properties": {
+          "data": {
+            "items": { "$ref": "#/components/schemas/TransactionResponse" },
+            "type": "array"
+          },
+          "next_pagination_token": {
+            "type": "string",
+            "description": "A token that can be sent in the `pagination_token` query parameter to get the next page of results, or `null` if there is no next page (i.e. you've reached the last page)."
+          },
+          "prev_pagination_token": {
+            "type": "string",
+            "description": "A token that can be sent in the `pagination_token` query parameter to get the previous page of results, or `null` if there is no previous page (i.e. you've reached the first page)."
+          }
+        },
+        "type": "object",
+        "required": ["data"]
+      },
+      "TransactionStatusEnum": {
+        "type": "string",
+        "enum": [
+          "created",
+          "processing",
+          "succeeded",
+          "declined",
+          "refunded",
+          "failed"
+        ]
+      },
+      "TransactionTypeEnum": {
+        "type": "string",
+        "enum": [
+          "capture",
+          "refund",
+          "cash_withdrawal",
+          "fee",
+          "adjustment",
+          "reversal"
+        ]
+      },
+      "TransactionUpdateRequest": {
+        "properties": {
+          "amount": {
+            "type": "integer",
+            "description": "The transaction amount in minor units. Positive for in-flow, negative for out-flow"
+          },
+          "currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "ISO currency code"
+          },
+          "description": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "A human-readable description of the transaction."
+          },
+          "entity_user_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier for the employee who made the payment, if applicable"
+          },
+          "external_id": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "External identifier for idempotency, if provided by the source system."
+          },
+          "merchant_amount": {
+            "type": "integer",
+            "description": "Original merchant transaction amount in minor units"
+          },
+          "merchant_currency": {
+            "allOf": [{ "$ref": "#/components/schemas/CurrencyEnum" }],
+            "description": "ISO currency code for the 'merchant_amount'."
+          },
+          "merchant_location": { "type": "string", "maxLength": 128 },
+          "merchant_name": { "type": "string", "maxLength": 128 },
+          "partner_metadata": {
+            "additionalProperties": { "type": "string" },
+            "type": "object",
+            "description": "Extensible key-value pairs for storing additional, custom information."
+          },
+          "payment_method": {
+            "$ref": "#/components/schemas/TransactionPaymentMethod"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The time when the transaction started"
+          },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/TransactionStatusEnum" }],
+            "description": "The current processing status of the transaction: 'created', 'pending', 'succeeded', 'refunded', 'failed', 'declined'.",
+            "default": "created"
+          },
+          "type": {
+            "allOf": [{ "$ref": "#/components/schemas/TransactionTypeEnum" }],
+            "description": "The nature of the transaction. e.g., 'capture', 'refund', 'cash_withdrawal', 'fee', 'adjustment', 'reversal'."
+          }
+        },
+        "type": "object"
       },
       "Unit": {
         "properties": {
@@ -68520,7 +71513,9 @@
           "workflow",
           "workflow_pipeline",
           "ocr_task",
-          "delivery_note"
+          "delivery_note",
+          "receipt",
+          "transaction"
         ]
       },
       "WebhookSubscriptionCursorFields": {
@@ -68689,6 +71684,7 @@
     { "name": "Projects settings" },
     { "name": "Purchase orders" },
     { "name": "Quotes internal" },
+    { "name": "Receipts" },
     { "name": "Receivables" },
     { "name": "Recurrences" },
     { "name": "Register" },
@@ -68696,6 +71692,7 @@
     { "name": "Secrets" },
     { "name": "Tags" },
     { "name": "Text templates" },
+    { "name": "Transactions" },
     { "name": "Users" },
     { "name": "VAT rates" },
     { "name": "VAT rates internal" },

--- a/packages/sdk-react/src/components/UserDisplayCell/UserDisplayCell.tsx
+++ b/packages/sdk-react/src/components/UserDisplayCell/UserDisplayCell.tsx
@@ -1,9 +1,8 @@
-import { useMemo } from 'react';
-
 import { getIndividualName, getUserDisplayName } from '@/core/utils';
 import { UserAvatar } from '@/ui/UserAvatar/UserAvatar';
 import { type Theme } from '@monite/sdk-react/mui-styles';
 import { type SxProps, Box, Typography } from '@mui/material';
+import { useMemo } from 'react';
 
 interface UserDisplayCellProps {
   user: {
@@ -18,7 +17,7 @@ interface UserDisplayCellProps {
   showAvatar?: boolean;
   avatarSize?: number;
   variant?: 'inline' | 'stacked';
-  typographyVariant?: 'body1' | 'body2';
+  typographyVariant?: 'body1' | 'body2' | 'inherit';
   sx?: SxProps<Theme>;
 }
 

--- a/packages/sdk-react/src/components/expenses/Expenses.tsx
+++ b/packages/sdk-react/src/components/expenses/Expenses.tsx
@@ -1,4 +1,4 @@
-import { ExpensesTable } from './ExpensesTable/ExpensesTable';
+import { UserTransactionsTable } from './ExpensesTable/UserTransactionsTable';
 import { PageHeader } from '@/ui/PageHeader';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
@@ -12,7 +12,7 @@ export const Expenses = () => {
         <PageHeader title={t(i18n)`Expenses`} />
       </div>
       <div className="mtw:flex-1 mtw:min-h-0">
-        <ExpensesTable />
+        <UserTransactionsTable />
       </div>
     </div>
   );

--- a/packages/sdk-react/src/components/expenses/Expenses.tsx
+++ b/packages/sdk-react/src/components/expenses/Expenses.tsx
@@ -1,0 +1,19 @@
+import { ExpensesTable } from './ExpensesTable/ExpensesTable';
+import { PageHeader } from '@/ui/PageHeader';
+import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+
+export const Expenses = () => {
+  const { i18n } = useLingui();
+
+  return (
+    <div className="mtw:flex mtw:flex-col mtw:h-full">
+      <div className="mtw:flex-shrink-0">
+        <PageHeader title={t(i18n)`Expenses`} />
+      </div>
+      <div className="mtw:flex-1 mtw:min-h-0">
+        <ExpensesTable />
+      </div>
+    </div>
+  );
+};

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/ExpensesTable.tsx
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/ExpensesTable.tsx
@@ -1,0 +1,239 @@
+import { FILTER_TYPE_SEARCH, FILTER_TYPE_STARTED_AT } from './consts';
+import type { FilterTypes } from './types';
+import { components } from '@/api';
+import { useMoniteContext } from '@/core/context/MoniteContext';
+import { useRootElements } from '@/core/context/RootElementsProvider';
+import { useDataTableState } from '@/core/hooks';
+import { useEntityUserByAuthToken } from '@/core/queries';
+import { useIsActionAllowed } from '@/core/queries/usePermissions';
+import { GetNoRowsOverlay } from '@/ui/DataGridEmptyState/GetNoRowsOverlay';
+import { AccessRestriction } from '@/ui/accessRestriction';
+import { DataTable } from '@/ui/components/data-table';
+import { Input } from '@/ui/components/input';
+import { LoadingPage } from '@/ui/loadingPage';
+import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+import { DatePicker } from '@mui/x-date-pickers';
+import { ColumnDef } from '@tanstack/react-table';
+import { formatISO, addDays } from 'date-fns';
+import { useEffect, useMemo } from 'react';
+
+export const ExpensesTable = () => {
+  const { api, componentSettings, locale } = useMoniteContext();
+  const { i18n } = useLingui();
+  const { root } = useRootElements();
+
+  const { data: user } = useEntityUserByAuthToken();
+
+  const { data: isReadSupported, isLoading: isReadSupportedLoading } =
+    useIsActionAllowed({
+      method: 'transaction',
+      action: 'read',
+      entityUserId: user?.id,
+    });
+
+  const {
+    pagination,
+    sorting,
+    onPaginationChange,
+    onSortingChange,
+    sortModel,
+    filters,
+    onFilterChange,
+    currentPaginationToken,
+    updateApiResponse,
+    pageCount,
+  } = useDataTableState<
+    components['schemas']['TransactionCursorFields'],
+    FilterTypes
+  >({
+    initialPageSize: componentSettings.expenses.pageSizeOptions[0],
+    initialSort: {
+      field: 'started_at',
+      direction: 'desc',
+    },
+    filters: {
+      initialValue: {
+        [FILTER_TYPE_SEARCH]: '',
+        [FILTER_TYPE_STARTED_AT]: null,
+      },
+    },
+  });
+
+  const {
+    data: transactions,
+    isLoading,
+    error,
+    refetch,
+  } = api.transactions.getTransactions.useQuery({
+    query: {
+      sort: sortModel.field,
+      order: sortModel.sort,
+      limit: pagination.pageSize,
+      // Don't use pagination token when we have a search term and we're on the first page
+      pagination_token:
+        filters[FILTER_TYPE_SEARCH] && pagination.pageIndex === 0
+          ? undefined
+          : currentPaginationToken || undefined,
+      merchant_name__icontains: filters[FILTER_TYPE_SEARCH] || undefined,
+      started_at__gt: filters[FILTER_TYPE_STARTED_AT]
+        ? formatISO(filters[FILTER_TYPE_STARTED_AT] as Date)
+        : undefined,
+      started_at__lt: filters[FILTER_TYPE_STARTED_AT]
+        ? formatISO(addDays(filters[FILTER_TYPE_STARTED_AT] as Date, 1))
+        : undefined,
+    },
+  });
+
+  // Update the pagination hook with the latest API response
+  useEffect(() => {
+    updateApiResponse(transactions);
+  }, [transactions, updateApiResponse]);
+
+  const columns: ColumnDef<components['schemas']['TransactionResponse']>[] =
+    useMemo(
+      () => [
+        {
+          header: t(i18n)`Employee`,
+          accessorKey: 'employee',
+          cell: ({ row }) => row.original.entity_user_id, // TODO: show employee name
+          enableSorting: false,
+        },
+        {
+          header: t(i18n)`Merchant`,
+          accessorKey: 'merchant',
+          cell: ({ row }) => row.original.merchant_name,
+          enableSorting: false,
+        },
+        {
+          header: t(i18n)`Date`,
+          accessorKey: 'started_at',
+          cell: ({ row }) => {
+            const date = row.original.started_at;
+            if (!date) {
+              return '-';
+            }
+            return i18n.date(date, locale.dateTimeFormat);
+          },
+        },
+        {
+          header: t(i18n)`Payment Method`,
+          id: 'payment_method',
+          accessorFn: (row) => {
+            const paymentMethod = row.payment_method;
+            if (paymentMethod?.type === 'card') {
+              return t(i18n)`Card ••••${paymentMethod.details.last4}`;
+            }
+            return t(i18n)`Bank ${paymentMethod.details.iban}`;
+          },
+          cell: ({ row }) => row.getValue('payment_method'),
+          enableSorting: false,
+        },
+        {
+          header: t(i18n)`Amount`,
+          accessorKey: 'amount',
+          cell: ({ row }) => {
+            const formattedAmount = i18n.number(row.original.amount, {
+              style: 'currency',
+              currency: row.original.currency || 'USD',
+            });
+            return formattedAmount;
+          },
+        },
+      ],
+      [i18n, locale.dateTimeFormat]
+    );
+
+  if (isReadSupportedLoading) {
+    return <LoadingPage />;
+  }
+
+  if (!isReadSupported) {
+    return <AccessRestriction />;
+  }
+
+  return (
+    <div className="mtw:flex mtw:flex-col mtw:h-full mtw:gap-4">
+      <div className="mtw:flex mtw:items-center mtw:flex-shrink-0 mtw:gap-4 mtw:justify-between">
+        <Input
+          placeholder={t(i18n)`Search by merchant`}
+          value={filters[FILTER_TYPE_SEARCH] || ''}
+          onChange={(event) =>
+            onFilterChange(FILTER_TYPE_SEARCH, event.target.value)
+          }
+          className="mtw:max-w-sm"
+        />
+        <DatePicker
+          className="Monite-ExpensesStartedAtFilter Monite-FilterControl Monite-DateFilterControl"
+          onChange={(value, error) => {
+            if (error.validationError) {
+              return;
+            }
+
+            onFilterChange(FILTER_TYPE_STARTED_AT, value as Date | null);
+          }}
+          slotProps={{
+            textField: {
+              variant: 'standard',
+              placeholder: t(i18n)`Filter by date`,
+              InputProps: {
+                sx: {
+                  '&::placeholder': {
+                    opacity: 1,
+                    color: 'text.primary',
+                  },
+                  '& input::placeholder': {
+                    opacity: 1,
+                    color: 'text.primary',
+                  },
+                },
+              },
+            },
+            popper: {
+              container: root,
+            },
+            dialog: {
+              container: root,
+            },
+            actionBar: {
+              actions: ['clear', 'today'],
+            },
+          }}
+          views={['year', 'month', 'day']}
+        />
+      </div>
+
+      <div className="mtw:flex-1 mtw:min-h-0">
+        <DataTable
+          columns={columns}
+          data={transactions?.data || []}
+          loading={isLoading}
+          pagination={pagination}
+          onPaginationChange={onPaginationChange}
+          sorting={sorting}
+          onSortingChange={onSortingChange}
+          pageCount={pageCount}
+          noRowsOverlay={() => (
+            <GetNoRowsOverlay
+              isLoading={isLoading}
+              dataLength={transactions?.data.length || 0}
+              isFiltering={!!filters[FILTER_TYPE_STARTED_AT]}
+              isSearching={!!filters[FILTER_TYPE_SEARCH]}
+              isError={!!error}
+              refetch={refetch}
+              entityName={t(i18n)`Expenses`}
+              noDataTitle={t(i18n)`No expenses yet`}
+              noDataDescription1={t(i18n)`You don't have any expenses yet`}
+              noDataDescription2={t(i18n)`Your expenses will appear here`}
+              filterTitle={t(i18n)`No expenses found`}
+              filterDescription1={t(
+                i18n
+              )`Try adjusting your search or filter criteria`}
+              type="no-data"
+            />
+          )}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx
@@ -164,7 +164,12 @@ export const ManagerTransactionsTable = () => {
       if (!userData) return <span>-</span>;
 
       return (
-        <UserDisplayCell user={userData} showAvatar={false} variant="inline" />
+        <UserDisplayCell
+          user={userData}
+          showAvatar={false}
+          variant="inline"
+          typographyVariant="inherit"
+        />
       );
     };
   }, [userDataMap]);

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx
@@ -1,0 +1,238 @@
+import { FILTER_TYPE_SEARCH, FILTER_TYPE_STARTED_AT } from './consts';
+import type { FilterTypes } from './types';
+import { components } from '@/api';
+import { useMoniteContext } from '@/core/context/MoniteContext';
+import { useRootElements } from '@/core/context/RootElementsProvider';
+import { useDataTableState } from '@/core/hooks';
+import { useEntityUserByAuthToken } from '@/core/queries';
+import { useIsActionAllowed } from '@/core/queries/usePermissions';
+import { GetNoRowsOverlay } from '@/ui/DataGridEmptyState/GetNoRowsOverlay';
+import { AccessRestriction } from '@/ui/accessRestriction';
+import { DataTable } from '@/ui/components/data-table';
+import { Input } from '@/ui/components/input';
+import { LoadingPage } from '@/ui/loadingPage';
+import { t } from '@lingui/macro';
+import { useLingui } from '@lingui/react';
+import { DatePicker } from '@mui/x-date-pickers';
+import { ColumnDef } from '@tanstack/react-table';
+import { formatISO, addDays } from 'date-fns';
+import { useEffect, useMemo } from 'react';
+
+export const ManagerTransactionsTable = () => {
+  const { api, componentSettings, locale } = useMoniteContext();
+  const { i18n } = useLingui();
+  const { root } = useRootElements();
+
+  const { data: user } = useEntityUserByAuthToken();
+
+  const { data: isReadSupported, isLoading: isReadSupportedLoading } =
+    useIsActionAllowed({
+      method: 'transaction',
+      action: 'read',
+      entityUserId: user?.id,
+    });
+
+  const {
+    pagination,
+    sorting,
+    onPaginationChange,
+    onSortingChange,
+    sortModel,
+    filters,
+    onFilterChange,
+    currentPaginationToken,
+    updateApiResponse,
+    pageCount,
+  } = useDataTableState<
+    components['schemas']['TransactionCursorFields'],
+    FilterTypes
+  >({
+    initialPageSize: componentSettings.expenses.pageSizeOptions[0],
+    initialSort: {
+      field: 'started_at',
+      direction: 'desc',
+    },
+    filters: {
+      initialValue: {
+        [FILTER_TYPE_SEARCH]: '',
+        [FILTER_TYPE_STARTED_AT]: null,
+      },
+    },
+  });
+
+  const {
+    data: transactions,
+    isLoading,
+    error,
+    refetch,
+  } = api.transactions.getTransactions.useQuery({
+    query: {
+      sort: sortModel.field,
+      order: sortModel.sort,
+      limit: pagination.pageSize,
+      // Don't use pagination token when we have a search term and we're on the first page
+      pagination_token:
+        filters[FILTER_TYPE_SEARCH] && pagination.pageIndex === 0
+          ? undefined
+          : currentPaginationToken || undefined,
+      merchant_name__icontains: filters[FILTER_TYPE_SEARCH] || undefined,
+      started_at__gt: filters[FILTER_TYPE_STARTED_AT]
+        ? formatISO(filters[FILTER_TYPE_STARTED_AT] as Date)
+        : undefined,
+      started_at__lt: filters[FILTER_TYPE_STARTED_AT]
+        ? formatISO(addDays(filters[FILTER_TYPE_STARTED_AT] as Date, 1))
+        : undefined,
+    },
+  });
+
+  // Update the pagination hook with the latest API response
+  useEffect(() => {
+    updateApiResponse(transactions);
+  }, [transactions, updateApiResponse]);
+
+  const columns: ColumnDef<components['schemas']['TransactionResponse']>[] =
+    useMemo(
+      () => [
+        {
+          header: t(i18n)`Employee`,
+          accessorKey: 'employee',
+          cell: ({ row }) => row.original.entity_user_id, // TODO: show employee name
+          enableSorting: false,
+        },
+        {
+          header: t(i18n)`Merchant`,
+          accessorKey: 'merchant',
+          cell: ({ row }) => row.original.merchant_name,
+          enableSorting: false,
+        },
+        {
+          header: t(i18n)`Date`,
+          accessorKey: 'started_at',
+          cell: ({ row }) => {
+            const date = row.original.started_at;
+            if (!date) {
+              return '-';
+            }
+            return i18n.date(date, locale.dateTimeFormat);
+          },
+        },
+        {
+          header: t(i18n)`Payment Method`,
+          id: 'payment_method',
+          accessorFn: (row) => {
+            const paymentMethod = row.payment_method;
+            if (paymentMethod?.type === 'card') {
+              return t(i18n)`Card ••••${paymentMethod.details.last4}`;
+            }
+            return t(i18n)`Bank ${paymentMethod.details.iban}`;
+          },
+          cell: ({ row }) => row.getValue('payment_method'),
+          enableSorting: false,
+        },
+        {
+          header: t(i18n)`Amount`,
+          accessorKey: 'amount',
+          cell: ({ row }) => {
+            const formattedAmount = i18n.number(row.original.amount, {
+              style: 'currency',
+              currency: row.original.currency || 'USD',
+            });
+            return formattedAmount;
+          },
+        },
+      ],
+      [i18n, locale.dateTimeFormat]
+    );
+
+  if (isReadSupportedLoading) {
+    return <LoadingPage />;
+  }
+
+  if (!isReadSupported) {
+    return <AccessRestriction />;
+  }
+
+  return (
+    <div className="mtw:flex mtw:flex-col mtw:h-full mtw:gap-4">
+      <div className="mtw:flex mtw:items-center mtw:flex-shrink-0 mtw:gap-4 mtw:justify-between">
+        <Input
+          placeholder={t(i18n)`Search by merchant`}
+          value={filters[FILTER_TYPE_SEARCH] || ''}
+          onChange={(event) =>
+            onFilterChange(FILTER_TYPE_SEARCH, event.target.value)
+          }
+          className="mtw:max-w-sm"
+        />
+        <DatePicker
+          className="Monite-ExpensesStartedAtFilter Monite-FilterControl Monite-DateFilterControl"
+          onChange={(value, error) => {
+            if (error.validationError) {
+              return;
+            }
+            onFilterChange(FILTER_TYPE_STARTED_AT, value as Date | null);
+          }}
+          slotProps={{
+            textField: {
+              variant: 'standard',
+              placeholder: t(i18n)`Filter by date`,
+              InputProps: {
+                sx: {
+                  '&::placeholder': {
+                    opacity: 1,
+                    color: 'text.primary',
+                  },
+                  '& input::placeholder': {
+                    opacity: 1,
+                    color: 'text.primary',
+                  },
+                },
+              },
+            },
+            popper: {
+              container: root,
+            },
+            dialog: {
+              container: root,
+            },
+            actionBar: {
+              actions: ['clear', 'today'],
+            },
+          }}
+          views={['year', 'month', 'day']}
+        />
+      </div>
+
+      <div className="mtw:flex-1 mtw:min-h-0">
+        <DataTable
+          columns={columns}
+          data={transactions?.data || []}
+          loading={isLoading}
+          pagination={pagination}
+          onPaginationChange={onPaginationChange}
+          sorting={sorting}
+          onSortingChange={onSortingChange}
+          pageCount={pageCount}
+          noRowsOverlay={() => (
+            <GetNoRowsOverlay
+              isLoading={isLoading}
+              dataLength={transactions?.data.length || 0}
+              isFiltering={!!filters[FILTER_TYPE_STARTED_AT]}
+              isSearching={!!filters[FILTER_TYPE_SEARCH]}
+              isError={!!error}
+              refetch={refetch}
+              entityName={t(i18n)`Expenses`}
+              noDataTitle={t(i18n)`No expenses yet`}
+              noDataDescription1={t(i18n)`You don't have any expenses yet`}
+              noDataDescription2={t(i18n)`Your expenses will appear here`}
+              filterTitle={t(i18n)`No expenses found`}
+              filterDescription1={t(
+                i18n
+              )`Try adjusting your search or filter criteria`}
+              type="no-data"
+            />
+          )}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/UserTransactionsTable.tsx
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/UserTransactionsTable.tsx
@@ -18,7 +18,7 @@ import { ColumnDef } from '@tanstack/react-table';
 import { formatISO, addDays } from 'date-fns';
 import { useEffect, useMemo } from 'react';
 
-export const ExpensesTable = () => {
+export const UserTransactionsTable = () => {
   const { api, componentSettings, locale } = useMoniteContext();
   const { i18n } = useLingui();
   const { root } = useRootElements();
@@ -75,6 +75,7 @@ export const ExpensesTable = () => {
         filters[FILTER_TYPE_SEARCH] && pagination.pageIndex === 0
           ? undefined
           : currentPaginationToken || undefined,
+      entity_user_id__in: user?.id ? [user.id] : undefined,
       merchant_name__icontains: filters[FILTER_TYPE_SEARCH] || undefined,
       started_at__gt: filters[FILTER_TYPE_STARTED_AT]
         ? formatISO(filters[FILTER_TYPE_STARTED_AT] as Date)
@@ -93,12 +94,6 @@ export const ExpensesTable = () => {
   const columns: ColumnDef<components['schemas']['TransactionResponse']>[] =
     useMemo(
       () => [
-        {
-          header: t(i18n)`Employee`,
-          accessorKey: 'employee',
-          cell: ({ row }) => row.original.entity_user_id, // TODO: show employee name
-          enableSorting: false,
-        },
         {
           header: t(i18n)`Merchant`,
           accessorKey: 'merchant',
@@ -129,6 +124,7 @@ export const ExpensesTable = () => {
           cell: ({ row }) => row.getValue('payment_method'),
           enableSorting: false,
         },
+        // TODO: show linked receipt image
         {
           header: t(i18n)`Amount`,
           accessorKey: 'amount',
@@ -169,7 +165,6 @@ export const ExpensesTable = () => {
             if (error.validationError) {
               return;
             }
-
             onFilterChange(FILTER_TYPE_STARTED_AT, value as Date | null);
           }}
           slotProps={{

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/consts.ts
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/consts.ts
@@ -1,0 +1,2 @@
+export const FILTER_TYPE_SEARCH = 'search';
+export const FILTER_TYPE_STARTED_AT = 'started_at';

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/consts.ts
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/consts.ts
@@ -1,2 +1,3 @@
 export const FILTER_TYPE_SEARCH = 'search';
 export const FILTER_TYPE_STARTED_AT = 'started_at';
+export const FILTER_TYPE_USER = 'user';

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/index.tsx
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/index.tsx
@@ -1,0 +1,1 @@
+export { ExpensesTable } from './ExpensesTable';

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/index.tsx
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/index.tsx
@@ -1,1 +1,2 @@
-export { ExpensesTable } from './ExpensesTable';
+export { UserTransactionsTable } from './UserTransactionsTable';
+export { ManagerTransactionsTable } from './ManagerTransactionsTable';

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/types.ts
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/types.ts
@@ -1,0 +1,6 @@
+import { FILTER_TYPE_SEARCH, FILTER_TYPE_STARTED_AT } from './consts';
+
+export type FilterTypes = Partial<{
+  [FILTER_TYPE_SEARCH]: string | null;
+  [FILTER_TYPE_STARTED_AT]: Date | null;
+}>;

--- a/packages/sdk-react/src/components/expenses/ExpensesTable/types.ts
+++ b/packages/sdk-react/src/components/expenses/ExpensesTable/types.ts
@@ -1,6 +1,11 @@
-import { FILTER_TYPE_SEARCH, FILTER_TYPE_STARTED_AT } from './consts';
+import {
+  FILTER_TYPE_SEARCH,
+  FILTER_TYPE_STARTED_AT,
+  FILTER_TYPE_USER,
+} from './consts';
 
 export type FilterTypes = Partial<{
   [FILTER_TYPE_SEARCH]: string | null;
   [FILTER_TYPE_STARTED_AT]: Date | null;
+  [FILTER_TYPE_USER]: string | null;
 }>;

--- a/packages/sdk-react/src/components/expenses/index.tsx
+++ b/packages/sdk-react/src/components/expenses/index.tsx
@@ -1,0 +1,1 @@
+export * from './Expenses';

--- a/packages/sdk-react/src/components/index.ts
+++ b/packages/sdk-react/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './approvalPolicies';
 export * from './approvalRequests';
 export * from './payables';
 export * from './receivables';
+export * from './expenses';
 export * from './onboarding';
 export * from './products';
 export * from './tags';

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -1,3 +1,7 @@
+import {
+  defaultAvailableCountries,
+  defaultAvailableCurrencies,
+} from '../utils';
 import { components } from '@/api';
 import { CustomerTypes } from '@/components/counterparts/types';
 import { FINANCING_LABEL } from '@/components/financing/consts';
@@ -16,11 +20,6 @@ import {
 import type { MoniteIconWrapperProps } from '@/ui/iconWrapper';
 import type { I18n } from '@lingui/core';
 import { t } from '@lingui/macro';
-
-import {
-  defaultAvailableCountries,
-  defaultAvailableCurrencies,
-} from '../utils';
 
 interface ReceivableSettings extends MoniteReceivablesTableProps {
   pageSizeOptions: number[];
@@ -227,6 +226,9 @@ export interface ComponentSettings {
      */
     customerTypes?: CustomerTypes;
   };
+  expenses: {
+    pageSizeOptions: number[];
+  };
   payables: Partial<PayableSettings>;
   products: {
     pageSizeOptions: number[];
@@ -275,6 +277,10 @@ export const getDefaultComponentSettings = (
       'customer',
       'vendor',
     ],
+  },
+  expenses: {
+    pageSizeOptions:
+      componentSettings?.expenses?.pageSizeOptions || defaultPageSizeOptions,
   },
   payables: {
     pageSizeOptions:

--- a/packages/sdk-react/src/core/hooks/index.ts
+++ b/packages/sdk-react/src/core/hooks/index.ts
@@ -9,3 +9,4 @@ export * from './useDebounce';
 export * from './useMobile';
 export * from './useComponentSettings';
 export * from './useIsMounted';
+export * from './useDataTableState';

--- a/packages/sdk-react/src/core/hooks/useDataTableState.ts
+++ b/packages/sdk-react/src/core/hooks/useDataTableState.ts
@@ -1,0 +1,306 @@
+import {
+  PaginationState,
+  SortingState,
+  OnChangeFn,
+} from '@tanstack/react-table';
+import { useState, useCallback, useMemo } from 'react';
+
+interface DataTableStateOptions<
+  TSortField extends string = string,
+  TFilters extends Record<string, any> = Record<string, any>,
+> {
+  /** Initial page size */
+  initialPageSize: number;
+  /** Initial sort configuration */
+  initialSort: {
+    field: TSortField;
+    direction: 'asc' | 'desc';
+  };
+  /** Optional filters configuration */
+  filters?: {
+    initialValue?: TFilters;
+  };
+}
+
+interface DataTableApiResponse {
+  /** Current API response data */
+  apiResponse?: {
+    next_pagination_token?: string | null;
+    prev_pagination_token?: string | null;
+  };
+}
+
+interface DataTableStateReturn<
+  TSortField extends string = string,
+  TFilters extends Record<string, any> = Record<string, any>,
+> {
+  // TanStack Table state
+  pagination: PaginationState;
+  sorting: SortingState;
+
+  // TanStack Table handlers
+  onPaginationChange: OnChangeFn<PaginationState>;
+  onSortingChange: OnChangeFn<SortingState>;
+
+  // Filter functionality (includes search)
+  filters: TFilters;
+  onFilterChange: (field: keyof TFilters, value: any) => void;
+  onFiltersChange: (filters: Partial<TFilters>) => void;
+
+  // Computed values for API
+  sortModel: {
+    field: TSortField;
+    sort: 'asc' | 'desc';
+  };
+  currentPaginationToken: string | null;
+  pageCount: number;
+
+  // Page navigation state
+  currentPageIndex: number;
+  pageTokens: (string | null)[];
+
+  // Update function for API response data
+  updateApiResponse: (
+    apiResponse?: DataTableApiResponse['apiResponse']
+  ) => void;
+}
+
+/**
+ * Custom hook for managing data table state including cursor-based pagination,
+ * sorting, and filtering (including search) functionality for use with TanStack Table.
+ *
+ * This hook provides a complete state management solution for server-side
+ * data tables with automatic pagination reset when sorting or filters change.
+ * Search is treated as a filter type and managed through the filters state.
+ *
+ * @example
+ * ```tsx
+ * const {
+ *   pagination,
+ *   sorting,
+ *   filters,
+ *   onPaginationChange,
+ *   onSortingChange,
+ *   onFilterChange,
+ *   sortModel,
+ *   currentPaginationToken,
+ *   pageCount,
+ *   updateApiResponse,
+ * } = useDataTableState({
+ *   initialPageSize: 20,
+ *   initialSort: { field: 'created_at', direction: 'desc' },
+ *   filters: { initialValue: { search: '', status: null, date: null } },
+ * });
+ *
+ * // Use in API query
+ * const { data } = api.getData.useQuery({
+ *   query: {
+ *     sort: sortModel.field,
+ *     order: sortModel.sort,
+ *     limit: pagination.pageSize,
+ *     pagination_token: currentPaginationToken || undefined,
+ *     search: filters.search || undefined,
+ *     status: filters.status || undefined,
+ *     date: filters.date || undefined,
+ *   },
+ * });
+ *
+ * // Update with API response when available
+ * React.useEffect(() => {
+ *   updateApiResponse(data);
+ * }, [data, updateApiResponse]);
+ * ```
+ */
+export function useDataTableState<
+  TSortField extends string = string,
+  TFilters extends Record<string, any> = Record<string, any>,
+>({
+  initialPageSize,
+  initialSort,
+  filters,
+}: DataTableStateOptions<TSortField, TFilters>): DataTableStateReturn<
+  TSortField,
+  TFilters
+> {
+  // API response state
+  const [apiResponse, setApiResponse] =
+    useState<DataTableApiResponse['apiResponse']>();
+
+  // Cursor token management for API pagination
+  const [pageTokens, setPageTokens] = useState<(string | null)[]>([null]);
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+
+  // TanStack Table compatible pagination state
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: initialPageSize,
+  });
+
+  // TanStack Table compatible sorting state
+  const [sorting, setSortingState] = useState<SortingState>([
+    {
+      id: initialSort.field,
+      desc: initialSort.direction === 'desc',
+    },
+  ]);
+
+  // Filter state management (includes search)
+  const [filtersState, setFiltersState] = useState<TFilters>(
+    filters?.initialValue ?? ({} as TFilters)
+  );
+
+  // Convert TanStack Table sorting to API sort model
+  const sortModel = useMemo(() => {
+    if (sorting.length === 0) {
+      return {
+        field: initialSort.field,
+        sort: initialSort.direction,
+      };
+    }
+    const firstSort = sorting[0];
+    return {
+      field: firstSort.id as TSortField,
+      sort: firstSort.desc ? ('desc' as const) : ('asc' as const),
+    };
+  }, [sorting, initialSort]);
+
+  // Get current pagination token
+  const currentPaginationToken = pageTokens[currentPageIndex];
+
+  // Handle pagination changes from TanStack Table
+  const handlePaginationChange: OnChangeFn<PaginationState> = useCallback(
+    (updater) => {
+      const newPagination =
+        typeof updater === 'function' ? updater(pagination) : updater;
+
+      // If page size changed, reset to first page
+      if (newPagination.pageSize !== pagination.pageSize) {
+        setPageTokens([null]);
+        setCurrentPageIndex(0);
+        setPaginationState({ pageIndex: 0, pageSize: newPagination.pageSize });
+        return;
+      }
+
+      // Handle page navigation
+      if (newPagination.pageIndex !== pagination.pageIndex) {
+        const targetPageIndex = newPagination.pageIndex;
+
+        // If going forward and we don't have the token yet, we need to store it
+        if (
+          targetPageIndex > currentPageIndex &&
+          targetPageIndex === pageTokens.length
+        ) {
+          // We're going to the next page - store the next_pagination_token from current response
+          if (apiResponse?.next_pagination_token) {
+            setPageTokens((prev) => [
+              ...prev,
+              apiResponse.next_pagination_token!,
+            ]);
+          }
+        }
+
+        setCurrentPageIndex(targetPageIndex);
+        setPaginationState(newPagination);
+      }
+    },
+    [
+      pagination,
+      currentPageIndex,
+      pageTokens,
+      apiResponse?.next_pagination_token,
+    ]
+  );
+
+  // Handle sorting changes from TanStack Table
+  const handleSortingChange: OnChangeFn<SortingState> = useCallback(
+    (updater) => {
+      const newSorting =
+        typeof updater === 'function' ? updater(sorting) : updater;
+      setSortingState(newSorting);
+
+      // Reset pagination when sorting changes
+      setPageTokens([null]);
+      setCurrentPageIndex(0);
+      setPaginationState((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    [sorting]
+  );
+
+  // Handle filter changes (including search)
+  const handleFilterChange = useCallback(
+    (field: keyof TFilters, value: any) => {
+      setFiltersState((prev: TFilters) => ({
+        ...prev,
+        [field]: value,
+      }));
+
+      // Reset pagination when filters change
+      setPageTokens([null]);
+      setCurrentPageIndex(0);
+      setPaginationState((prev) => ({ ...prev, pageIndex: 0 }));
+    },
+    []
+  );
+
+  // Handle multiple filter changes
+  const handleFiltersChange = useCallback((newFilters: Partial<TFilters>) => {
+    setFiltersState((prev: TFilters) => ({
+      ...prev,
+      ...newFilters,
+    }));
+
+    // Reset pagination when filters change
+    setPageTokens([null]);
+    setCurrentPageIndex(0);
+    setPaginationState((prev) => ({ ...prev, pageIndex: 0 }));
+  }, []);
+
+  // Calculate page count for TanStack Table
+  // With cursor pagination, we can only know if there's a next page, not the total count
+  const pageCount = useMemo(() => {
+    if (!apiResponse) return -1; // Unknown page count while loading
+
+    // If there's a next page token, we know there's at least one more page
+    if (apiResponse.next_pagination_token) {
+      return Math.max(pagination.pageIndex + 2, pageTokens.length + 1);
+    }
+
+    // If there's no next page token, current page is the last page
+    return pagination.pageIndex + 1;
+  }, [apiResponse, pagination.pageIndex, pageTokens.length]);
+
+  // Update function for API response data
+  const updateApiResponse = useCallback(
+    (newApiResponse?: DataTableApiResponse['apiResponse']) => {
+      setApiResponse(newApiResponse);
+    },
+    []
+  );
+
+  return {
+    // TanStack Table state
+    pagination,
+    sorting,
+
+    // TanStack Table handlers
+    onPaginationChange: handlePaginationChange,
+    onSortingChange: handleSortingChange,
+
+    // Filter functionality (includes search)
+    filters: filtersState,
+    onFilterChange: handleFilterChange,
+    onFiltersChange: handleFiltersChange,
+
+    // Computed values for API
+    sortModel,
+    currentPaginationToken,
+    pageCount,
+
+    // Page navigation state
+    currentPageIndex,
+    pageTokens,
+
+    // Update function for API response
+    updateApiResponse,
+  };
+}

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -70,6 +70,10 @@ msgstr "(.pdf, .png, .jpg supported)"
 msgid "{0, plural, one {invoice} two {invoices} few {invoices} many {invoices} zero {invoices} other {invoices}}"
 msgstr "{0, plural, one {invoice} two {invoices} few {invoices} many {invoices} zero {invoices} other {invoices}}"
 
+#: src/ui/components/data-table.tsx:131
+msgid "{0, plural, one {result} other {results}}"
+msgstr "{0, plural, one {result} other {results}}"
+
 #: src/core/queries/useReceivables.ts:296
 msgid "{0, select, credit_note {Credit Note has been canceled} invoice {Invoice has been canceled} quote {Quote has been canceled} other {Receivable has been canceled}}"
 msgstr "{0, select, credit_note {Credit Note has been canceled} invoice {Invoice has been canceled} quote {Quote has been canceled} other {Receivable has been canceled}}"
@@ -103,6 +107,10 @@ msgstr "{0} - {1}"
 #: src/components/onboarding/OnboardingAddress/OnboardingAddress.tsx:49
 #~ msgid "{0} ({code})"
 #~ msgstr "{0} ({code})"
+
+#: src/ui/components/data-table.tsx:129
+msgid "{0} {1}"
+msgstr "{0} {1}"
 
 #: src/components/receivables/components/ReminderDetails.tsx:67
 msgid "{0} {1} after"
@@ -735,6 +743,8 @@ msgstr "American Samoa"
 #: src/components/approvalPolicies/useApprovalPolicyTrigger.tsx:42
 #: src/components/approvalPolicies/useApprovalPolicyTrigger.tsx:57
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:225
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:133
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:129
 #: src/components/receivables/components/CreditNotesTable.tsx:168
 #: src/components/receivables/components/InvoicesTable.tsx:338
 #: src/components/receivables/components/QuotesTable.tsx:204
@@ -1009,6 +1019,10 @@ msgstr "Aruba"
 msgid "Aruban Florin"
 msgstr "Aruban Florin"
 
+#: src/ui/components/data-table.tsx:91
+msgid "Ascending"
+msgstr "Ascending"
+
 #: src/components/aiAssistant/AIAssistant.tsx:85
 msgid "Ask AI"
 msgstr "Ask AI"
@@ -1182,6 +1196,11 @@ msgstr "Bangladesh"
 #: src/core/utils/currencies.ts:25
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
+
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:127
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:122
+msgid "Bank {0}"
+msgstr "Bank {0}"
 
 #: src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx:569
 #: src/components/payables/PayableDetails/PayableDetailsInfo/PayableDetailsInfo.tsx:293
@@ -1757,6 +1776,11 @@ msgstr "Car Rental Agencies"
 #: src/components/onboarding/dicts/mccCodes.ts:224
 msgid "Car Washes"
 msgstr "Car Washes"
+
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:125
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:120
+msgid "Card ••••{0}"
+msgstr "Card ••••{0}"
 
 #: src/components/onboarding/dicts/mccCodes.ts:243
 msgid "Carpentry Services"
@@ -2591,7 +2615,7 @@ msgstr "Created on"
 msgid "Credit note"
 msgstr "Credit note"
 
-#: src/core/componentSettings/index.ts:323
+#: src/core/componentSettings/index.ts:329
 msgid "Credit notes"
 msgstr "Credit notes"
 
@@ -2711,6 +2735,8 @@ msgstr "Dance Hall, Studios, Schools"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:109
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:104
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceIterations.tsx:60
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/TabPanels/PaymentTabPanel/PaymentRecordForm.tsx:111
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/TabPanels/PaymentTabPanel/schemas/manualPaymentRecordValidationSchema.ts:30
@@ -2968,6 +2994,10 @@ msgstr "Department"
 #: src/components/onboarding/dicts/mccCodes.ts:435
 msgid "Department Stores"
 msgstr "Department Stores"
+
+#: src/ui/components/data-table.tsx:95
+msgid "Descending"
+msgstr "Descending"
 
 #: src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyDetailsFormAdvanced/ApprovalPolicyDetailsFormAdvanced.tsx:38
 #: src/components/approvalPolicies/ApprovalPolicyDetails/ApprovalPolicyDetailsFormAdvanced/ApprovalPolicyDetailsFormAdvanced.tsx:181
@@ -3609,6 +3639,10 @@ msgstr "Email is required"
 msgid "Email must be a valid email"
 msgstr "Email must be a valid email"
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:97
+msgid "Employee"
+msgstr "Employee"
+
 #: src/core/hooks/useVatTypes.ts:203
 msgid "Employer Identification Number (USA)"
 msgstr "Employer Identification Number (USA)"
@@ -3867,6 +3901,12 @@ msgstr "Excluding tax"
 msgid "Executive"
 msgstr "Executive"
 
+#: src/components/expenses/Expenses.tsx:12
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:223
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:219
+msgid "Expenses"
+msgstr "Expenses"
+
 #: src/components/receivables/utils/getCommonStatusLabel.ts:17
 msgid "Expired"
 msgstr "Expired"
@@ -4077,6 +4117,11 @@ msgstr "File is being processed..."
 #: src/components/payables/PayableDetails/PayableDetailsAttachFile/PayableDetailsAttachFile.tsx:103
 msgid "File successfully attached"
 msgstr "File successfully attached"
+
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:177
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:173
+msgid "Filter by date"
+msgstr "Filter by date"
 
 #: src/components/receivables/hooks/useInvoiceRowActionMenuCell.tsx:255
 msgctxt "InvoicesTableRowActionMenu"
@@ -4414,6 +4459,22 @@ msgstr "Glassware, Crystal Stores"
 msgid "Go to Docs"
 msgstr "Go to Docs"
 
+#: src/ui/components/data-table.tsx:148
+msgid "Go to first page"
+msgstr "Go to first page"
+
+#: src/ui/components/data-table.tsx:178
+msgid "Go to last page"
+msgstr "Go to last page"
+
+#: src/ui/components/data-table.tsx:168
+msgid "Go to next page"
+msgstr "Go to next page"
+
+#: src/ui/components/data-table.tsx:158
+msgid "Go to previous page"
+msgstr "Go to previous page"
+
 #: src/components/onboarding/dicts/mccCodes.ts:702
 msgid "Golf Courses - Public"
 msgstr "Golf Courses - Public"
@@ -4567,6 +4628,7 @@ msgstr ""
 "{1}"
 
 #: src/components/financing/components/FinanceBanner.tsx:300
+#: src/ui/components/data-table.tsx:102
 msgid "Hide"
 msgstr "Hide"
 
@@ -4945,7 +5007,7 @@ msgid "Invoice will be issued with items in the selected currency"
 msgstr "Invoice will be issued with items in the selected currency"
 
 #: src/components/receivables/components/InvoicesTable.tsx:500
-#: src/core/componentSettings/index.ts:315
+#: src/core/componentSettings/index.ts:321
 msgid "Invoices"
 msgstr "Invoices"
 
@@ -5653,6 +5715,11 @@ msgstr "Mens, Womens Clothing Stores"
 msgid "Menu"
 msgstr "Menu"
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:103
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:98
+msgid "Merchant"
+msgstr "Merchant"
+
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/sections/PreviewDetailsSection.tsx:43
 msgid "Message"
 msgstr "Message"
@@ -6088,6 +6155,16 @@ msgstr "No Credit Notes"
 #~ msgid "No default email for selected Counterpart. Reminders will not be sent."
 #~ msgstr "No default email for selected Counterpart. Reminders will not be sent."
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:227
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:223
+msgid "No expenses found"
+msgstr "No expenses found"
+
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:224
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:220
+msgid "No expenses yet"
+msgstr "No expenses yet"
+
 #: src/core/hooks/useFileInput.tsx:84
 msgid "No file provided"
 msgstr "No file provided"
@@ -6153,6 +6230,10 @@ msgstr "No Receivables"
 #: src/components/receivables/components/ReminderDetails.tsx:61
 msgid "No reminder"
 msgstr "No reminder"
+
+#: src/ui/components/data-table.tsx:355
+msgid "No results."
+msgstr "No results."
 
 #: src/components/userRoles/UserRolesTable/UserRolesTable.tsx:193
 msgid "No Roles"
@@ -6658,6 +6739,8 @@ msgstr "Payment due"
 msgid "Payment link is still loading. Please wait a moment and try again."
 msgstr "Payment link is still loading. Please wait a moment and try again."
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:120
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:115
 #: src/components/tags/helpers.ts:22
 msgid "Payment Method"
 msgstr "Payment Method"
@@ -7282,7 +7365,7 @@ msgid "Quote"
 msgstr "Quote"
 
 #: src/components/receivables/components/QuotesTable.tsx:299
-#: src/core/componentSettings/index.ts:319
+#: src/core/componentSettings/index.ts:325
 msgid "Quotes"
 msgstr "Quotes"
 
@@ -7565,6 +7648,7 @@ msgstr "Required for non-EUR and non-GBP currencies"
 msgid "Required for USD and GBP currencies"
 msgstr "Required for USD and GBP currencies"
 
+#: src/ui/components/data-table.tsx:183
 #: src/ui/table/TablePagination.tsx:133
 msgid "Results per page"
 msgstr "Results per page"
@@ -7830,6 +7914,11 @@ msgstr "Script in Monite Script is required"
 #: src/components/receivables/InvoiceDetails/CreateReceivable/components/ProductsTableFilters.tsx:46
 msgid "Search"
 msgstr "Search"
+
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:159
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:155
+msgid "Search by merchant"
+msgstr "Search by merchant"
 
 #: src/components/counterparts/CounterpartsTable/Filters/Filters.tsx:36
 #: src/components/products/ProductsTable/components/Filters/Filters.tsx:39
@@ -9046,6 +9135,8 @@ msgstr "Truck StopIteration"
 msgid "Truck/Utility Trailer Rentals"
 msgstr "Truck/Utility Trailer Rentals"
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:228
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:224
 #: src/components/products/ProductsTable/ProductsTable.tsx:309
 msgid "Try adjusting your search or filter criteria"
 msgstr "Try adjusting your search or filter criteria"
@@ -9955,6 +10046,11 @@ msgstr "You don’t have any counterparts yet."
 msgid "You don’t have any credit notes yet."
 msgstr "You don’t have any credit notes yet."
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:225
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:221
+msgid "You don't have any expenses yet"
+msgstr "You don't have any expenses yet"
+
 #: src/components/receivables/components/InvoicesTable.test.tsx:126
 msgid "You don’t have any invoices yet."
 msgstr "You don’t have any invoices yet."
@@ -10051,6 +10147,11 @@ msgstr "Your bank account must be a checking account."
 #: src/components/templateSettings/components/DisplayBankSection.tsx:64
 msgid "Your customers can make direct bank transfers outside the payment links"
 msgstr "Your customers can make direct bank transfers outside the payment links"
+
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:226
+#: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:222
+msgid "Your expenses will appear here"
+msgstr "Your expenses will appear here"
 
 #: src/components/receivables/InvoiceDetails/CreateReceivable/sections/components/Billing/YourVatDetailsForm.tsx:116
 #~ msgid "Your Tax ID"

--- a/packages/sdk-react/src/core/i18n/locales/en/messages.po
+++ b/packages/sdk-react/src/core/i18n/locales/en/messages.po
@@ -658,6 +658,10 @@ msgstr "All customers"
 msgid "All documents are provided"
 msgstr "All documents are provided"
 
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:263
+msgid "All employees"
+msgstr "All employees"
+
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrence.tsx:58
 msgid "All future invoices will be issued based on this invoice"
 msgstr "All future invoices will be issued based on this invoice"
@@ -743,7 +747,7 @@ msgstr "American Samoa"
 #: src/components/approvalPolicies/useApprovalPolicyTrigger.tsx:42
 #: src/components/approvalPolicies/useApprovalPolicyTrigger.tsx:57
 #: src/components/approvalRequests/ApprovalRequestsTable/ApprovalRequestsTable.tsx:225
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:133
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:219
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:129
 #: src/components/receivables/components/CreditNotesTable.tsx:168
 #: src/components/receivables/components/InvoicesTable.tsx:338
@@ -1197,7 +1201,7 @@ msgstr "Bangladesh"
 msgid "Bangladeshi Taka"
 msgstr "Bangladeshi Taka"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:127
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:213
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:122
 msgid "Bank {0}"
 msgstr "Bank {0}"
@@ -1777,7 +1781,7 @@ msgstr "Car Rental Agencies"
 msgid "Car Washes"
 msgstr "Car Washes"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:125
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:211
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:120
 msgid "Card ••••{0}"
 msgstr "Card ••••{0}"
@@ -2735,7 +2739,7 @@ msgstr "Dance Hall, Studios, Schools"
 msgid "Danish Krone"
 msgstr "Danish Krone"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:109
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:195
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:104
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/ReceivableRecurrence/InvoiceRecurrenceIterations.tsx:60
 #: src/components/receivables/InvoiceDetails/ExistingInvoiceDetails/components/TabPanels/PaymentTabPanel/PaymentRecordForm.tsx:111
@@ -3639,7 +3643,7 @@ msgstr "Email is required"
 msgid "Email must be a valid email"
 msgstr "Email must be a valid email"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:97
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:181
 msgid "Employee"
 msgstr "Employee"
 
@@ -3902,7 +3906,7 @@ msgid "Executive"
 msgstr "Executive"
 
 #: src/components/expenses/Expenses.tsx:12
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:223
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:331
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:219
 msgid "Expenses"
 msgstr "Expenses"
@@ -4118,10 +4122,14 @@ msgstr "File is being processed..."
 msgid "File successfully attached"
 msgstr "File successfully attached"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:177
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:282
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:173
 msgid "Filter by date"
 msgstr "Filter by date"
+
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:260
+msgid "Filter by employee"
+msgstr "Filter by employee"
 
 #: src/components/receivables/hooks/useInvoiceRowActionMenuCell.tsx:255
 msgctxt "InvoicesTableRowActionMenu"
@@ -5715,7 +5723,7 @@ msgstr "Mens, Womens Clothing Stores"
 msgid "Menu"
 msgstr "Menu"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:103
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:189
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:98
 msgid "Merchant"
 msgstr "Merchant"
@@ -6155,12 +6163,12 @@ msgstr "No Credit Notes"
 #~ msgid "No default email for selected Counterpart. Reminders will not be sent."
 #~ msgstr "No default email for selected Counterpart. Reminders will not be sent."
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:227
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:335
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:223
 msgid "No expenses found"
 msgstr "No expenses found"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:224
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:332
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:220
 msgid "No expenses yet"
 msgstr "No expenses yet"
@@ -6739,7 +6747,7 @@ msgstr "Payment due"
 msgid "Payment link is still loading. Please wait a moment and try again."
 msgstr "Payment link is still loading. Please wait a moment and try again."
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:120
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:206
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:115
 #: src/components/tags/helpers.ts:22
 msgid "Payment Method"
@@ -7915,7 +7923,7 @@ msgstr "Script in Monite Script is required"
 msgid "Search"
 msgstr "Search"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:159
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:245
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:155
 msgid "Search by merchant"
 msgstr "Search by merchant"
@@ -9135,7 +9143,7 @@ msgstr "Truck StopIteration"
 msgid "Truck/Utility Trailer Rentals"
 msgstr "Truck/Utility Trailer Rentals"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:228
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:336
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:224
 #: src/components/products/ProductsTable/ProductsTable.tsx:309
 msgid "Try adjusting your search or filter criteria"
@@ -10046,7 +10054,7 @@ msgstr "You don’t have any counterparts yet."
 msgid "You don’t have any credit notes yet."
 msgstr "You don’t have any credit notes yet."
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:225
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:333
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:221
 msgid "You don't have any expenses yet"
 msgstr "You don't have any expenses yet"
@@ -10148,7 +10156,7 @@ msgstr "Your bank account must be a checking account."
 msgid "Your customers can make direct bank transfers outside the payment links"
 msgstr "Your customers can make direct bank transfers outside the payment links"
 
-#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:226
+#: src/components/expenses/ExpensesTable/ManagerTransactionsTable.tsx:334
 #: src/components/expenses/ExpensesTable/UserTransactionsTable.tsx:222
 msgid "Your expenses will appear here"
 msgstr "Your expenses will appear here"

--- a/packages/sdk-react/src/ui/components/data-table.tsx
+++ b/packages/sdk-react/src/ui/components/data-table.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from './select';
 import { Button } from '@/ui/components/button';
+import { Skeleton } from '@/ui/components/skeleton';
 import { plural, t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import {
@@ -207,6 +208,8 @@ export function DataTablePagination<TData>({
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
   data: TData[];
+  // Loading state
+  loading?: boolean;
   // Controlled pagination state
   pagination?: PaginationState;
   onPaginationChange?: OnChangeFn<PaginationState>;
@@ -218,11 +221,14 @@ interface DataTableProps<TData, TValue> {
   // Controlled column filters state
   columnFilters?: ColumnFiltersState;
   onColumnFiltersChange?: OnChangeFn<ColumnFiltersState>;
+  // Custom no rows overlay component
+  noRowsOverlay?: React.ComponentType;
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
+  loading = false,
   pagination: controlledPagination,
   onPaginationChange: controlledOnPaginationChange,
   pageCount,
@@ -230,6 +236,7 @@ export function DataTable<TData, TValue>({
   onSortingChange: controlledOnSortingChange,
   columnFilters: controlledColumnFilters,
   onColumnFiltersChange: controlledOnColumnFiltersChange,
+  noRowsOverlay: NoRowsOverlay,
 }: DataTableProps<TData, TValue>) {
   const { i18n } = useLingui();
 
@@ -301,7 +308,25 @@ export function DataTable<TData, TValue>({
               ))}
             </thead>
             <tbody className="mtw:[&_tr:last-child]:border-0">
-              {table.getRowModel().rows?.length ? (
+              {loading ? (
+                Array.from({ length: 10 }).map((_, index) => (
+                  <tr
+                    key={`loading-row-${index}`}
+                    className="mtw:border-b mtw:border-border"
+                  >
+                    {Array.from({ length: columns.length }).map(
+                      (_, cellIndex) => (
+                        <td
+                          key={`loading-cell-${index}-${cellIndex}`}
+                          className="mtw:p-3 mtw:align-middle mtw:whitespace-nowrap"
+                        >
+                          <Skeleton className="mtw:h-4 mtw:w-full" />
+                        </td>
+                      )
+                    )}
+                  </tr>
+                ))
+              ) : table.getRowModel().rows?.length ? (
                 table.getRowModel().rows.map((row) => (
                   <tr
                     key={row.id}
@@ -322,12 +347,12 @@ export function DataTable<TData, TValue>({
                   </tr>
                 ))
               ) : (
-                <tr className="mtw:hover:bg-muted/50 mtw:data-[state=selected]:bg-muted mtw:border-b mtw:border-border mtw:transition-colors">
+                <tr>
                   <td
                     colSpan={columns.length}
-                    className="mtw:h-24 mtw:text-center mtw:p-3 mtw:align-middle mtw:whitespace-nowrap"
+                    className="mtw:p-3 mtw:align-middle mtw:whitespace-nowrap mtw:font-normal mtw:text-center"
                   >
-                    {t(i18n)`No results.`}
+                    {NoRowsOverlay ? <NoRowsOverlay /> : t(i18n)`No results.`}
                   </td>
                 </tr>
               )}

--- a/packages/sdk-react/src/ui/components/data-table.tsx
+++ b/packages/sdk-react/src/ui/components/data-table.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from './dropdown-menu';
-import { Input } from './input';
 import {
   Select,
   SelectContent,
@@ -201,33 +200,6 @@ export function DataTablePagination<TData>({
           </SelectContent>
         </Select>
       </div>
-    </div>
-  );
-}
-
-interface DataTableSearchProps<TData> {
-  column: string;
-  placeholder?: string;
-  table: ReactTableTable<TData>;
-}
-
-export function DataTableSearch<TData>({
-  column,
-  placeholder,
-  table,
-}: DataTableSearchProps<TData>) {
-  const { i18n } = useLingui();
-
-  return (
-    <div className="mtw:flex mtw:items-center mtw:py-4">
-      <Input
-        placeholder={placeholder || t(i18n)`Search...`}
-        value={table.getColumn(column)?.getFilterValue() as string}
-        onChange={(event) =>
-          table.getColumn(column)?.setFilterValue(event.target.value)
-        }
-        className="mtw:max-w-sm"
-      />
     </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5963,6 +5963,7 @@ __metadata:
     "@swc/jest": "npm:~0.2.26"
     "@tailwindcss/postcss": "npm:~4.1.11"
     "@tanstack/react-query": "npm:~5.28.6"
+    "@tanstack/react-table": "npm:~8.21.3"
     "@tanstack/react-virtual": "npm:~3.13.6"
     "@team-monite/eslint-plugin": "workspace:~"
     "@testing-library/dom": "npm:~9.3.1"
@@ -10668,6 +10669,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-table@npm:~8.21.3":
+  version: 8.21.3
+  resolution: "@tanstack/react-table@npm:8.21.3"
+  dependencies:
+    "@tanstack/table-core": "npm:8.21.3"
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: 10/a32217ebe64d24e71dea6a6742bc288dcabf389657b16805a1ab3f347d3dca8262759c45c604a1f65bd97925d5cbdfb66d1be7637100a12eb5b279bdd420962d
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-virtual@npm:~3.13.6":
   version: 3.13.6
   resolution: "@tanstack/react-virtual@npm:3.13.6"
@@ -10677,6 +10690,13 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10/4500088f7719a5a6241f4fcf24074a2fa8cb54d9c5c50786e909e87aee98af2ac0c1513139984c388e97e8ddb65d108390d39083b0b793fbfd343976f13447c4
+  languageName: node
+  linkType: hard
+
+"@tanstack/table-core@npm:8.21.3":
+  version: 8.21.3
+  resolution: "@tanstack/table-core@npm:8.21.3"
+  checksum: 10/aa05e5f80110f0f56d66161e950668ea6ef3e2ea4f3a2ccd5d5980b39b4feea987245b20531aee2c6743e6edd12c0361503413b63090c807f88a61b19bfd04f3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Scope

Add Expenses page listing Transactions on a table. Jira ticket: https://monite.atlassian.net/browse/DEV-16048

Also, implemented DataTable component with shadcn components.

# Implementation

- Updated API schema file with new endpoints related to Expense Management transactions and receipts.
- Implemented DataTable component with shadcn components.
- Implemented useDataTableState hook for managing DataTable state, pagination, and filtering.
- Added new componentSettings for Expenses section.
- Created Expenses section component on SDK-react, which features the Transactions table listing, and exports two components (UserTransactionsTable and ManagerTransactionsTable).
- Add new Expenses page showing Transactions table. The new page was added to SDK Playground, SDK-Demo, and NextJS example.

# Remarks

- Currently, only the UserTransactionsTable is being displayed. The ManagerTransactionsTable is not used.
- Currently, the transaction details component is not yet implemented, so there are no actions on the table.
- The date filter uses the already available implementation, that uses MUI components. This was to not increase the scope of this PR with the re-implementation of that component in shadcn.

# Steps to test

1. Create some Transactions.
2. Open the "Expenses" page.
3. Should see a table listing the Transactions.
4. Should be able to search by Merchant name and filter by date.