### PR TITLE
fix(proposal): pointer events none dialogs

### DIFF
--- a/.changeset/strong-teeth-pull.md
+++ b/.changeset/strong-teeth-pull.md
@@ -1,0 +1,6 @@
+---
+'@monite/sdk-react': patch
+'@monite/sdk-drop-in': patch
+---
+
+Fix an issue when stacked dialogs could result on disabled pointer events

--- a/packages/sdk-react/src/components/products/ProductDetails/components/ConfirmDeleteMeasureUnitDialogue/ConfirmDeleteMeasureUnitDialogue.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/components/ConfirmDeleteMeasureUnitDialogue/ConfirmDeleteMeasureUnitDialogue.tsx
@@ -1,4 +1,5 @@
 import { useMoniteContext } from '@/core/context/MoniteContext';
+import { useRootElements } from '@/core/context/RootElementsProvider';
 import { useCurrencies } from '@/core/hooks';
 import { ConfirmationModal } from '@/ui/ConfirmationModal';
 import { t } from '@lingui/macro';
@@ -33,6 +34,7 @@ export const ConfirmDeleteMeasureUnitDialogue = ({
   const { i18n } = useLingui();
   const { api } = useMoniteContext();
   const { formatCurrencyToDisplay } = useCurrencies();
+  const root = useRootElements();
 
   const { data: products, isLoading: isLoadingProducts } =
     api.products.getProducts.useQuery(
@@ -104,6 +106,7 @@ export const ConfirmDeleteMeasureUnitDialogue = ({
   return (
     <ConfirmationModal
       open={open}
+      container={root?.root}
       title={
         isEmpty
           ? t(i18n)`Delete "${name}" unit?`

--- a/packages/sdk-react/src/ui/ConfirmationModal/ConfirmationModal.tsx
+++ b/packages/sdk-react/src/ui/ConfirmationModal/ConfirmationModal.tsx
@@ -1,17 +1,16 @@
-import { ReactNode } from 'react';
-
+import { LoadingSpinner } from '../loading';
+import { Button } from '@/ui/components/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/ui/components/dialog';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import { Button } from '@/ui/components/button';
-import { LoadingSpinner } from '../loading';
-import { 
-  Dialog, 
-  DialogContent, 
-  DialogDescription, 
-  DialogFooter, 
-  DialogHeader, 
-  DialogTitle 
-} from '@/ui/components/dialog';
+import { ReactNode } from 'react';
 
 type BaseConfirmationModalProps = {
   open: boolean;
@@ -21,6 +20,7 @@ type BaseConfirmationModalProps = {
   onClose: () => void;
   onConfirm: () => void;
   isLoading?: boolean;
+  container?: Element;
 };
 
 type MessageConfirmationModalProps = BaseConfirmationModalProps & {
@@ -46,6 +46,7 @@ export const ConfirmationModal = ({
   cancelLabel,
   onClose,
   onConfirm,
+  container,
   isLoading = false,
 }: ConfirmationModalProps) => {
   const { i18n } = useLingui();
@@ -56,7 +57,10 @@ export const ConfirmationModal = ({
       onOpenChange={onClose}
       aria-label={t(i18n)`Confirmation dialog`}
     >
-      <DialogContent showCloseButton={false}>
+      <DialogContent
+        container={container as HTMLElement}
+        showCloseButton={false}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
@@ -72,7 +76,9 @@ export const ConfirmationModal = ({
             disabled={isLoading}
             variant="destructive"
           >
-            {isLoading && <LoadingSpinner className="mtw:w-5 mtw:h-5 mtw:border-inherit mtw:border-t-transparent" />}
+            {isLoading && (
+              <LoadingSpinner className="mtw:w-5 mtw:h-5 mtw:border-inherit mtw:border-t-transparent" />
+            )}
             {confirmLabel}
           </Button>
         </DialogFooter>

--- a/packages/sdk-react/src/ui/components/dialog.tsx
+++ b/packages/sdk-react/src/ui/components/dialog.tsx
@@ -1,9 +1,7 @@
-import * as React from 'react';
-
 import { cn } from '@/ui/lib/utils';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
-
 import { XIcon } from 'lucide-react';
+import * as React from 'react';
 
 function Dialog({
   ...props
@@ -50,22 +48,32 @@ function DialogContent({
   children,
   showCloseButton = true,
   fullScreen = false,
+  container,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
   fullScreen?: boolean;
+  container?: HTMLElement;
 }) {
   return (
-    <DialogPortal data-slot="dialog-portal">
+    <DialogPortal container={container} data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
           'mtw:bg-background mtw:data-[state=open]:animate-in mtw:data-[state=closed]:animate-out mtw:data-[state=closed]:fade-out-0 mtw:data-[state=open]:fade-in-0 mtw:data-[state=closed]:zoom-out-95 mtw:data-[state=open]:zoom-in-95 mtw:fixed mtw:top-[50%] mtw:left-[50%] mtw:z-1300 mtw:grid mtw:w-full mtw:max-w-[calc(100%-2rem)] mtw:translate-x-[-50%] mtw:translate-y-[-50%] mtw:gap-4 mtw:rounded-lg mtw:border mtw:p-6 mtw:shadow-lg mtw:duration-200 mtw:sm:max-w-lg',
-          fullScreen && 'mtw:border-none mtw:rounded-none mtw:h-screen mtw:max-w-screen mtw:sm:max-w-screen',
+          fullScreen &&
+            'mtw:border-none mtw:rounded-none mtw:h-screen mtw:max-w-screen mtw:sm:max-w-screen',
           className
         )}
         {...props}
+        // Fix Radix UI issue with pointer events when using the Dialog component
+        // closing the dialog when used together with dialogs from other libraries
+        // https://github.com/shadcn-ui/ui/issues/1859
+        onCloseAutoFocus={(event) => {
+          event.preventDefault();
+          (container ?? document.body).style.pointerEvents = '';
+        }}
       >
         {children}
         {showCloseButton && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Dialogs/modals can now render into a specified container/root for better embedding and portal placement.
* Bug Fixes
  * Resolved an issue where stacked dialogs could disable pointer interactions.
  * Improved focus handling to prevent pointer-events from remaining blocked when multiple dialog libraries are used together.
* Chores
  * Released patch updates for @monite/sdk-react and @monite/sdk-drop-in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->