### PR TITLE
fix(proposal): Fix/product form fixes

### DIFF
--- a/.changeset/wet-insects-wave.md
+++ b/.changeset/wet-insects-wave.md
@@ -1,0 +1,6 @@
+---
+'@monite/sdk-react': patch
+'@monite/sdk-drop-in': patch
+---
+
+Fix product form issues (overflow, form clearing when creating measuring units)

--- a/packages/sdk-react/src/components/products/ProductDetails/ProductCreate/CreateProduct.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/ProductCreate/CreateProduct.tsx
@@ -118,16 +118,15 @@ const CreateProductBase = (props: ProductDetailsCreateProps) => {
         closeSecondaryLevelDialog={() => setManageMeasureUnits(false)}
       />
       <DialogContent>
-        {manageMeasureUnits ? (
-          <ManageMeasureUnitsForm />
-        ) : (
+        <div style={{ display: manageMeasureUnits ? 'none' : 'block' }}>
           <ProductForm
             formId={productFormId}
             onSubmit={handleSubmit}
             defaultValues={defaultValues}
             onManageMeasureUnits={() => setManageMeasureUnits(true)}
           />
-        )}
+        </div>
+        {manageMeasureUnits && <ManageMeasureUnitsForm />}
       </DialogContent>
       {manageMeasureUnits ? (
         <DialogFooter

--- a/packages/sdk-react/src/components/products/ProductDetails/ProductEditForm/ProductEditForm.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/ProductEditForm/ProductEditForm.tsx
@@ -178,9 +178,7 @@ const ProductEditFormBase = (props: IProductEditFormProps) => {
           onClose={() => setCancelEditModalOpened(false)}
           onBack={props.onCanceled}
         />
-        {manageMeasureUnits ? (
-          <ManageMeasureUnitsForm />
-        ) : (
+        <div style={{ display: manageMeasureUnits ? 'none' : 'block' }}>
           <ProductForm
             formId={productFormId}
             onSubmit={handleSubmit}
@@ -188,7 +186,8 @@ const ProductEditFormBase = (props: IProductEditFormProps) => {
             onChanged={setIsFormDirty}
             onManageMeasureUnits={() => setManageMeasureUnits(true)}
           />
-        )}
+        </div>
+        {manageMeasureUnits && <ManageMeasureUnitsForm />}
       </DialogContent>
       {manageMeasureUnits ? (
         <DialogFooter

--- a/packages/sdk-react/src/components/products/ProductDetails/components/ManageMeasureUnitsForm/ManageMeasureUnitsForm.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/components/ManageMeasureUnitsForm/ManageMeasureUnitsForm.tsx
@@ -1,6 +1,4 @@
-import { useState, useCallback } from 'react';
-import { toast } from 'react-hot-toast';
-
+import { MeasureUnitsFormRow } from './components/MeasureUnitsFormRow';
 import { components } from '@/api';
 import { ConfirmDeleteMeasureUnitDialogue } from '@/components/products/ProductDetails/components/ConfirmDeleteMeasureUnitDialogue';
 import { useMoniteContext } from '@/core/context/MoniteContext';
@@ -22,8 +20,8 @@ import {
   Typography,
   CircularProgress,
 } from '@mui/material';
-
-import { MeasureUnitsFormRow } from './components/MeasureUnitsFormRow';
+import { useState, useCallback } from 'react';
+import { toast } from 'react-hot-toast';
 
 type UnitResponse = components['schemas']['UnitResponse'];
 
@@ -96,9 +94,10 @@ export const ManageMeasureUnitsForm = () => {
       spacing={2}
       sx={{
         height: '100%',
+        position: 'relative',
       }}
     >
-      {measureUnitsLoading || isDeleteLoading ? (
+      {measureUnitsLoading ? (
         <Box
           sx={{
             display: 'flex',
@@ -111,6 +110,26 @@ export const ManageMeasureUnitsForm = () => {
         </Box>
       ) : (
         <>
+          {/* Loading overlay during delete operation */}
+          {isDeleteLoading && (
+            <Box
+              sx={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                backgroundColor: 'rgba(255, 255, 255, 0.7)',
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                zIndex: 10,
+              }}
+            >
+              <CircularProgress size={40} color="secondary" />
+            </Box>
+          )}
+
           <TextField
             variant="outlined"
             placeholder={t(i18n)`Search`}

--- a/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
@@ -96,7 +96,7 @@ export const ProductForm = ({
         }}
       >
         <Grid container direction="column" rowSpacing={3}>
-          <Grid item style={{ maxWidth: '100%' }}>
+          <Grid item>
             <RHFTextField
               label={t(i18n)`Name`}
               name="name"
@@ -106,7 +106,7 @@ export const ProductForm = ({
             />
           </Grid>
 
-          <Grid item style={{ maxWidth: '100%' }}>
+          <Grid item>
             <RHFTextField
               label={t(i18n)`Description`}
               name="description"
@@ -117,7 +117,7 @@ export const ProductForm = ({
             />
           </Grid>
 
-          <Grid item style={{ maxWidth: '100%' }}>
+          <Grid item>
             <RHFRadioGroup
               label={t(i18n)`Type`}
               name="type"
@@ -135,7 +135,7 @@ export const ProductForm = ({
             />
           </Grid>
 
-          <Grid item style={{ maxWidth: '100%' }}>
+          <Grid item>
             <Grid container spacing={2}>
               <Grid item xs={6}>
                 <Controller
@@ -187,7 +187,7 @@ export const ProductForm = ({
                 />
               </Grid>
 
-              <Grid item xs={6} style={{ maxWidth: '100%' }}>
+              <Grid item xs={6}>
                 <RHFTextField
                   label={t(i18n)`Minimum quantity`}
                   name="smallestAmount"

--- a/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
@@ -84,10 +84,6 @@ export const ProductForm = ({
     return option === MANAGE_MEASURE_UNITS_ID;
   }
 
-  useEffect(() => {
-    reset(defaultValues);
-  }, [reset, defaultValues]);
-
   return (
     <FormProvider {...methods}>
       <form
@@ -100,7 +96,7 @@ export const ProductForm = ({
         }}
       >
         <Grid container direction="column" rowSpacing={3}>
-          <Grid item>
+          <Grid item style={{ maxWidth: '100%' }}>
             <RHFTextField
               label={t(i18n)`Name`}
               name="name"
@@ -110,7 +106,7 @@ export const ProductForm = ({
             />
           </Grid>
 
-          <Grid item>
+          <Grid item style={{ maxWidth: '100%' }}>
             <RHFTextField
               label={t(i18n)`Description`}
               name="description"
@@ -121,7 +117,7 @@ export const ProductForm = ({
             />
           </Grid>
 
-          <Grid item>
+          <Grid item style={{ maxWidth: '100%' }}>
             <RHFRadioGroup
               label={t(i18n)`Type`}
               name="type"
@@ -139,7 +135,7 @@ export const ProductForm = ({
             />
           </Grid>
 
-          <Grid item>
+          <Grid item style={{ maxWidth: '100%' }}>
             <Grid container spacing={2}>
               <Grid item xs={6}>
                 <Controller
@@ -191,7 +187,7 @@ export const ProductForm = ({
                 />
               </Grid>
 
-              <Grid item xs={6}>
+              <Grid item xs={6} style={{ maxWidth: '100%' }}>
                 <RHFTextField
                   label={t(i18n)`Minimum quantity`}
                   name="smallestAmount"
@@ -203,7 +199,7 @@ export const ProductForm = ({
             </Grid>
           </Grid>
 
-          <Grid item>
+          <Grid item style={{ maxWidth: '100%' }}>
             <Grid container spacing={2}>
               <Grid item xs={6}>
                 <RHFTextField

--- a/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
+++ b/packages/sdk-react/src/components/products/ProductDetails/components/ProductForm/ProductForm.tsx
@@ -73,7 +73,6 @@ export const ProductForm = ({
     control,
     formState: { isDirty },
     handleSubmit,
-    reset,
   } = methods;
 
   useEffect(() => onChanged?.(isDirty), [isDirty, onChanged]);

--- a/packages/sdk-react/src/core/theme/mui-monite/index.ts
+++ b/packages/sdk-react/src/core/theme/mui-monite/index.ts
@@ -1132,6 +1132,9 @@ export const getTheme = (theme: ThemeConfig): ThemeOptions => {
       styleOverrides: {
         root: {
           fontSize: '12px',
+          maxWidth: '100%',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
         },
       },
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Loading overlay with spinner shown during measure-unit deletions.

- Improvements
  - Product form stays mounted when switching to measure-units, preserving inputs and context.
  - Measure-units UI now displays alongside the product form for smoother switching.
  - Helper text constrained and truncated to prevent overflow; layout adjusted for full-width content.

- Bug Fixes
  - Removed automatic form reset on open.
  - Loading refined to block only when measure-units data is loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->