### PR TITLE
feat(proposal): Add payables setting to customize Payabes Table columns

### DIFF
--- a/.changeset/gold-badgers-cross.md
+++ b/.changeset/gold-badgers-cross.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Add displayColumns setting for payables that allows to customize which columns to show on the Payables Table 

--- a/packages/sdk-playground/src/components/app-monite-provider.tsx
+++ b/packages/sdk-playground/src/components/app-monite-provider.tsx
@@ -1,8 +1,7 @@
-import { type ComponentProps, type ReactNode, useMemo } from 'react';
-
 import { fetchToken } from '@/services/fetch-token';
 import { getLoginEnvData } from '@/services/login-env-data';
 import { MoniteProvider } from '@monite/sdk-react';
+import { type ComponentProps, type ReactNode, useMemo } from 'react';
 
 type AppMoniteProvider = {
   children: ReactNode;
@@ -33,6 +32,21 @@ const AppMoniteProvider = ({ children }: AppMoniteProvider) => {
       componentSettings={{
         receivables: {
           enableEntityBankAccount: true,
+        },
+        payables: {
+          // TODO: remove after testing. Just for testing purposes
+          displayColumns: [
+            'document_id',
+            // 'counterpart_id',
+            'created_at',
+            // 'issued_at',
+            'due_date',
+            'status',
+            'amount',
+            // 'amount_to_pay',
+            'amount_paid',
+            'pay',
+          ],
         },
       }}
     >

--- a/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
+++ b/packages/sdk-react/src/components/payables/PayablesTable/PayablesTable.tsx
@@ -119,6 +119,8 @@ export interface PayableGridSortModel {
  * const componentSettings = {
  *   payables: {
  *     fieldOrder: ['document_id', 'counterpart_id', 'created_at', 'issued_at', 'due_date', 'status', 'amount', 'pay'],
+ *     requiredColumns: ['document_id', 'status', 'amount', 'pay'],
+ *     displayColumns: ['document_id', 'counterpart_id', 'status', 'amount', 'pay'],
  *     summaryCardFilters: {
  *       'Overdue Invoices': {
  *         status__in: ['waiting_to_be_paid'],
@@ -154,6 +156,7 @@ const PayablesTableBase = ({
     isShowingSummaryCards,
     fieldOrder,
     requiredColumns,
+    displayColumns,
     summaryCardFilters,
   } = usePayableTableThemeProps(inProps);
 
@@ -533,7 +536,15 @@ const PayablesTableBase = ({
   ]);
 
   const columns = useMemo<GridColDef[]>(() => {
-    return columnsConfig.sort((a, b) => {
+    // Filter columns based on displayColumns prop
+    const filteredColumns = displayColumns
+      ? columnsConfig.filter((column) =>
+          displayColumns.includes(column.field as any)
+        )
+      : columnsConfig;
+
+    // Sort columns based on calculatedFieldOrder prop
+    return filteredColumns.sort((a, b) => {
       const aIndex = calculatedFieldOrder.indexOf(a.field);
       const bIndex = calculatedFieldOrder.indexOf(b.field);
 
@@ -541,7 +552,7 @@ const PayablesTableBase = ({
 
       return aIndex - bIndex;
     });
-  }, [columnsConfig, calculatedFieldOrder]);
+  }, [columnsConfig, calculatedFieldOrder, displayColumns]);
 
   const gridApiRef = useAutosizeGridColumns(
     payables?.data,
@@ -717,5 +728,7 @@ const usePayableTableThemeProps = (
       componentSettings?.payables?.summaryCardFilters,
     requiredColumns:
       inProps?.requiredColumns ?? componentSettings?.payables?.requiredColumns,
+    displayColumns:
+      inProps?.displayColumns ?? componentSettings?.payables?.displayColumns,
   };
 };

--- a/packages/sdk-react/src/components/payables/PayablesTable/consts.ts
+++ b/packages/sdk-react/src/components/payables/PayablesTable/consts.ts
@@ -33,3 +33,17 @@ export const DEFAULT_CARDS_ORDER: ExtendedPayableStateEnum[] = [
 
 export const DEFAULT_REQUIRED_COLUMNS: [FieldValueTypes, ...FieldValueTypes[]] =
   ['document_id'];
+
+export const DEFAULT_DISPLAY_COLUMNS: [FieldValueTypes, ...FieldValueTypes[]] =
+  [
+    'document_id',
+    'counterpart_id',
+    'created_at',
+    'issued_at',
+    'due_date',
+    'status',
+    'amount',
+    'amount_to_pay',
+    'amount_paid',
+    'pay',
+  ];

--- a/packages/sdk-react/src/components/payables/PayablesTable/types.ts
+++ b/packages/sdk-react/src/components/payables/PayablesTable/types.ts
@@ -1,12 +1,11 @@
-import { components } from '@/api';
-import { API } from '@/api/client';
-
 import {
   FILTER_TYPE_SUMMARY_CARD,
   FILTER_TYPE_DUE_DATE,
   FILTER_TYPE_SEARCH,
   FILTER_TYPE_STATUS,
 } from './consts';
+import { components } from '@/api';
+import { API } from '@/api/client';
 
 export type Sort = {
   sort: components['schemas']['PayableCursorFields'];
@@ -46,6 +45,7 @@ export interface MonitePayableTableProps {
   fieldOrder?: [FieldValueTypes, ...FieldValueTypes[]];
   summaryCardFilters?: Record<string, PayablesTabFilter | null>;
   requiredColumns?: [FieldValueTypes, ...FieldValueTypes[]];
+  displayColumns?: [FieldValueTypes, ...FieldValueTypes[]];
 }
 
 export type PayablesTabFilter = NonNullable<

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -358,11 +358,17 @@ export const getDefaultComponentSettings = (
     fieldOrder:
       componentSettings?.payables?.fieldOrder || defaultPayableFieldOrder,
     summaryCardFilters: componentSettings?.payables?.summaryCardFilters,
+    /**
+     * Specifies which columns are required in the table. Meaning that the user can't remove them from the table.
+     * If not provided, defaults to ['document_id'].
+     * @example ['document_id', 'counterpart_id', 'status', 'amount', 'pay']
+     */
     requiredColumns:
       componentSettings?.payables?.requiredColumns || defaultRequiredColumns,
     /**
      * Specifies which columns to display in the table.
-     * If not provided, all available columns will be displayed by default.
+     * Takes precedence over requiredColumns, meaning that columns not in displayColumns will be removed from the table even if they are required.
+     * If not provided, defaults to all available columns.
      * @example ['document_id', 'counterpart_id', 'status', 'amount', 'pay']
      */
     displayColumns:

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -1,3 +1,7 @@
+import {
+  defaultAvailableCountries,
+  defaultAvailableCurrencies,
+} from '../utils';
 import { components } from '@/api';
 import { CustomerTypes } from '@/components/counterparts/types';
 import { FINANCING_LABEL } from '@/components/financing/consts';
@@ -5,6 +9,7 @@ import { FinanceStep } from '@/components/financing/types';
 import { MonitePayableDetailsInfoProps } from '@/components/payables/PayableDetails/PayableDetailsForm';
 import {
   DEFAULT_REQUIRED_COLUMNS as defaultRequiredColumns,
+  DEFAULT_DISPLAY_COLUMNS as defaultDisplayColumns,
   DEFAULT_FIELD_ORDER as defaultPayableFieldOrder,
 } from '@/components/payables/PayablesTable/consts';
 import { MonitePayableTableProps } from '@/components/payables/PayablesTable/types';
@@ -16,11 +21,6 @@ import {
 import type { MoniteIconWrapperProps } from '@/ui/iconWrapper';
 import type { I18n } from '@lingui/core';
 import { t } from '@lingui/macro';
-
-import {
-  defaultAvailableCountries,
-  defaultAvailableCurrencies,
-} from '../utils';
 
 interface ReceivableSettings extends MoniteReceivablesTableProps {
   pageSizeOptions: number[];
@@ -196,13 +196,13 @@ export interface TemplateSettings {
 
 /**
  * Action handlers for custom payment flows in payable operations.
- * 
+ *
  * These handlers provide fine-grained control over payment workflows, allowing customers to:
  * - Integrate external payment providers
  * - Implement custom approval processes or multi-step authentication
  * - Add specialized banking solutions or enterprise payment workflows
  * - Control UI feedback and data refresh timing after payment completion
- * 
+ *
  * @example Custom payment provider integration:
  * ```typescript
  * const onPay = (id: string, _data?: unknown, actions?: PayActionHandlers) => {
@@ -220,19 +220,19 @@ export interface TemplateSettings {
  * ```
  */
 export type PayActionHandlers = {
-  /** 
+  /**
    * Call when a custom payment flow has been successfully initiated/completed.
-   * This triggers SDK's built-in state management: refreshes payable data, 
+   * This triggers SDK's built-in state management: refreshes payable data,
    * payment records, and optionally displays success feedback to the user.
-   * 
+   *
    * @param options.showToast - Whether to display a success toast notification
    */
   resolve: (options?: { showToast?: boolean }) => void;
-  /** 
+  /**
    * Call when a custom payment flow failed or was cancelled by the user.
    * This triggers SDK's built-in state management: refreshes payable data,
    * payment records, and optionally displays error feedback to the user.
-   * 
+   *
    * @param error - Optional error details from the failed payment attempt
    * @param options.showToast - Whether to display an error toast notification
    */
@@ -253,14 +253,14 @@ interface PayableSettings
   onDeleted?: (id: string) => void;
   /**
    * Called when the user clicks Pay button on a payable.
-   * 
+   *
    * **Legacy Usage (Backward Compatible):**
    * ```typescript
    * onPay: (id: string) => {
    *   console.log('Payment initiated for:', id);
    * }
    * ```
-   * 
+   *
    * **Enhanced Usage (Custom Payment Flow):**
    * ```typescript
    * onPay: (id: string, _data?: unknown, actions?: PayActionHandlers) => {
@@ -270,11 +270,11 @@ interface PayableSettings
    *     .catch(err => actions?.reject(err, { showToast: true }));
    * }
    * ```
-   * 
+   *
    * @param id - The payable ID being paid
    * @param _data - Reserved for future use (currently undefined)
    * @param actions - Optional handlers for custom payment flows. When provided,
-   *                  enables custom payment integration. Call actions.resolve() 
+   *                  enables custom payment integration. Call actions.resolve()
    *                  on success or actions.reject() on failure to update SDK state.
    */
   onPay?: (id: string, _data?: unknown, actions?: PayActionHandlers) => void;
@@ -358,6 +358,13 @@ export const getDefaultComponentSettings = (
     summaryCardFilters: componentSettings?.payables?.summaryCardFilters,
     requiredColumns:
       componentSettings?.payables?.requiredColumns || defaultRequiredColumns,
+    /**
+     * Specifies which columns to display in the table.
+     * If not provided, all available columns will be displayed by default.
+     * @example ['document_id', 'counterpart_id', 'status', 'amount', 'pay']
+     */
+    displayColumns:
+      componentSettings?.payables?.displayColumns || defaultDisplayColumns,
     optionalFields: componentSettings?.payables?.optionalFields,
     ocrRequiredFields: componentSettings?.payables?.ocrRequiredFields,
     ocrMismatchFields: componentSettings?.payables?.ocrMismatchFields ?? {


### PR DESCRIPTION
# Description

Added payables component setting and PayablesTable component prop to customize the columns to display.

# Implementation

- Adjusted componentSettings to support displayColumns configuration.
- Enhanced MonitePayableTableProps interface to include displayColumns property.
- Introduced DEFAULT_DISPLAY_COLUMNS constant to define default columns for the PayablesTable.

# Remarks

The default value for DEFAULT_DISPLAY_COLUMNS is the list of the current columns, i.e: 
- document_id,
- counterpart_id,
- created_at,
- issued_at,
- due_date,
- status,
- amount,
- amount_to_pay,
- amount_paid,
- pay

# Steps to test

For testing purposes, this PR will deploy a temporary URL for the Playground app with the the following payables componentSettings:
```
displayColumns: [
    'document_id',
    // 'counterpart_id',
    'created_at',
    // 'issued_at',
    'due_date',
    'status',
    'amount',
    // 'amount_to_pay',
    'amount_paid',
    'pay',
  ],
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payables Table now supports customizable columns via a new displayColumns setting.
  * Can be configured globally via component settings or per-instance on the table component.
  * Sensible default column set provided (document ID, counterpart, dates, status, amounts, pay action).
  * Table rendering respects the selected subset and preserves configured order for tailored views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->