### PR TITLE
feat(proposal): Add payables setting to customize Payabes edit form

### DIFF
--- a/.changeset/slimy-memes-knock.md
+++ b/.changeset/slimy-memes-knock.md
@@ -1,0 +1,5 @@
+---
+'@monite/sdk-react': patch
+---
+
+Add settings and props to customize the Payable edit view: hide the discount button, hide the "add bank account" option on the counterpart bank account input

--- a/packages/sdk-playground/src/components/app-monite-provider.tsx
+++ b/packages/sdk-playground/src/components/app-monite-provider.tsx
@@ -1,8 +1,7 @@
-import { type ComponentProps, type ReactNode, useMemo } from 'react';
-
 import { fetchToken } from '@/services/fetch-token';
 import { getLoginEnvData } from '@/services/login-env-data';
 import { MoniteProvider } from '@monite/sdk-react';
+import { type ComponentProps, type ReactNode, useMemo } from 'react';
 
 type AppMoniteProvider = {
   children: ReactNode;
@@ -33,6 +32,10 @@ const AppMoniteProvider = ({ children }: AppMoniteProvider) => {
       componentSettings={{
         receivables: {
           enableEntityBankAccount: true,
+        },
+        payables: {
+          hideAddDiscountButton: true,
+          hideAddBankAccountButton: true,
         },
       }}
     >

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetails.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetails.tsx
@@ -1,5 +1,7 @@
-import { useId, useState } from 'react';
-
+import { OptionalFields } from '../types';
+import { PayableDetailsForceActionDialog } from './PayableDetailsApprovalFlow/PayableDetailsForceActionDialog';
+import { PayableDetailsForm } from './PayableDetailsForm';
+import { usePayableDetails, UsePayableDetailsProps } from './usePayableDetails';
 import { ScopedCssBaselineContainerClassName } from '@/components/ContainerCssBaseline';
 import { CustomerTypes } from '@/components/counterparts/types';
 import { PayableDetailsAttachFile } from '@/components/payables/PayableDetails/PayableDetailsAttachFile';
@@ -9,25 +11,22 @@ import { PayableDetailsNoAttachedFile } from '@/components/payables/PayableDetai
 import { useMoniteContext } from '@/core/context/MoniteContext';
 import { MoniteScopedProviders } from '@/core/context/MoniteScopedProviders';
 import { useIsActionAllowed } from '@/core/queries/usePermissions';
-import { AccessRestriction } from '@/ui/accessRestriction';
 import { FileViewer } from '@/ui/FileViewer';
+import { AccessRestriction } from '@/ui/accessRestriction';
 import { LoadingPage } from '@/ui/loadingPage';
 import { NotFound } from '@/ui/notFound';
 import { classNames } from '@/utils/css-utils';
 import { t } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 import { Alert, Backdrop, Box, DialogContent, Grid } from '@mui/material';
-
-import { OptionalFields } from '../types';
-import { PayableDetailsForceActionDialog } from './PayableDetailsApprovalFlow/PayableDetailsForceActionDialog';
-import { PayableDetailsForm } from './PayableDetailsForm';
-import { usePayableDetails, UsePayableDetailsProps } from './usePayableDetails';
+import { useId, useState } from 'react';
 
 export interface PayablesDetailsProps extends UsePayableDetailsProps {
   optionalFields?: OptionalFields;
   /** @see {@link CustomerTypes} */
   customerTypes?: CustomerTypes;
   enableGLCodes?: boolean;
+  hideAddDiscountButton?: boolean;
   onClose?: () => void;
 }
 
@@ -42,6 +41,7 @@ const PayableDetailsBase = ({
   optionalFields,
   customerTypes,
   enableGLCodes,
+  hideAddDiscountButton,
   onClose,
   onSaved,
   onCanceled,
@@ -238,6 +238,10 @@ const PayableDetailsBase = ({
                     componentSettings?.counterparts?.customerTypes
                   }
                   enableGLCodes={enableGLCodes}
+                  hideAddDiscountButton={
+                    hideAddDiscountButton ??
+                    componentSettings?.payables?.hideAddDiscountButton
+                  }
                 />
               ) : (
                 payable && (

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetails.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetails.tsx
@@ -27,6 +27,7 @@ export interface PayablesDetailsProps extends UsePayableDetailsProps {
   customerTypes?: CustomerTypes;
   enableGLCodes?: boolean;
   hideAddDiscountButton?: boolean;
+  hideAddBankAccountButton?: boolean;
   onClose?: () => void;
 }
 
@@ -42,6 +43,7 @@ const PayableDetailsBase = ({
   customerTypes,
   enableGLCodes,
   hideAddDiscountButton,
+  hideAddBankAccountButton,
   onClose,
   onSaved,
   onCanceled,
@@ -241,6 +243,10 @@ const PayableDetailsBase = ({
                   hideAddDiscountButton={
                     hideAddDiscountButton ??
                     componentSettings?.payables?.hideAddDiscountButton
+                  }
+                  hideAddBankAccountButton={
+                    hideAddBankAccountButton ??
+                    componentSettings?.payables?.hideAddBankAccountButton
                   }
                 />
               ) : (

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -94,6 +94,7 @@ export interface PayableDetailsFormProps extends MonitePayableDetailsInfoProps {
   customerTypes?: CustomerTypes;
   enableGLCodes?: boolean;
   hideAddDiscountButton?: boolean;
+  hideAddBankAccountButton?: boolean;
 }
 
 /**
@@ -159,6 +160,7 @@ const PayableDetailsFormBase = forwardRef<
       customerTypes,
       enableGLCodes,
       hideAddDiscountButton,
+      hideAddBankAccountButton,
       ...inProps
     },
     ref
@@ -485,19 +487,23 @@ const PayableDetailsFormBase = forwardRef<
                                   .length === 0
                               }
                             >
-                              <Button
-                                variant="text"
-                                startIcon={<AddIcon />}
-                                fullWidth
-                                sx={{
-                                  justifyContent: 'flex-start',
-                                  px: 2,
-                                  py: 1,
-                                }}
-                                onClick={() => setIsEditCounterpartOpened(true)}
-                              >
-                                {t(i18n)`Add new bank account`}
-                              </Button>
+                              {!hideAddBankAccountButton && (
+                                <Button
+                                  variant="text"
+                                  startIcon={<AddIcon />}
+                                  fullWidth
+                                  sx={{
+                                    justifyContent: 'flex-start',
+                                    px: 2,
+                                    py: 1,
+                                  }}
+                                  onClick={() =>
+                                    setIsEditCounterpartOpened(true)
+                                  }
+                                >
+                                  {t(i18n)`Add new bank account`}
+                                </Button>
+                              )}
                               {counterpartBankAccountQuery?.data?.data.map(
                                 (bankAccount) => (
                                   <MenuItem

--- a/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
+++ b/packages/sdk-react/src/components/payables/PayableDetails/PayableDetailsForm/PayableDetailsForm.tsx
@@ -93,6 +93,7 @@ export interface PayableDetailsFormProps extends MonitePayableDetailsInfoProps {
   /** @see {@link CustomerTypes} */
   customerTypes?: CustomerTypes;
   enableGLCodes?: boolean;
+  hideAddDiscountButton?: boolean;
 }
 
 /**
@@ -131,6 +132,7 @@ export interface PayableDetailsFormProps extends MonitePayableDetailsInfoProps {
  * @param {components['schemas']['LineItemResponse'][]} [lineItems] - Array of line items associated with the payable.
  * @param {Record<string, boolean> | undefined} [ocrRequiredFields] - Array of required fields that should be provided by OCR.
  * @param {string} payableDetailsFormId - Unique identifier for the form.
+ * @param {boolean} [hideAddDiscountButton] - If true, hides the "Add Discount" button in the totals section.
  *
  * @returns {JSX.Element} The PayableDetailsForm component.
  */
@@ -156,6 +158,7 @@ const PayableDetailsFormBase = forwardRef<
       payableDetailsFormId,
       customerTypes,
       enableGLCodes,
+      hideAddDiscountButton,
       ...inProps
     },
     ref
@@ -630,19 +633,20 @@ const PayableDetailsFormBase = forwardRef<
                               justifyContent="flex-end"
                               display="flex"
                             >
-                              {currentDiscount === null && (
-                                <Button
-                                  startIcon={<AddIcon />}
-                                  size="small"
-                                  sx={{ pl: 1.25, pr: 2, py: 0 }}
-                                  onClick={() => {
-                                    const setValue = methods.setValue;
-                                    setValue('discount', 0);
-                                  }}
-                                >
-                                  {t(i18n)`Add Discount`}
-                                </Button>
-                              )}
+                              {currentDiscount === null &&
+                                !hideAddDiscountButton && (
+                                  <Button
+                                    startIcon={<AddIcon />}
+                                    size="small"
+                                    sx={{ pl: 1.25, pr: 2, py: 0 }}
+                                    onClick={() => {
+                                      const setValue = methods.setValue;
+                                      setValue('discount', 0);
+                                    }}
+                                  >
+                                    {t(i18n)`Add Discount`}
+                                  </Button>
+                                )}
                               {totals.subtotal && currentCurrency
                                 ? formatCurrencyToDisplay(
                                     formatToMinorUnits(

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -244,6 +244,7 @@ interface PayableSettings
   pageSizeOptions: number[];
   enableGLCodes?: boolean;
   hideAddDiscountButton?: boolean;
+  hideAddBankAccountButton?: boolean;
   onSaved?: (id: string) => void;
   onCanceled?: (id: string) => void;
   onSubmitted?: (id: string) => void;
@@ -369,6 +370,9 @@ export const getDefaultComponentSettings = (
     /** Whether to hide the "Add Discount" button in the totals section **/
     hideAddDiscountButton:
       componentSettings?.payables?.hideAddDiscountButton ?? false,
+    /** Whether to hide the "Add new bank account" button in the counterpart bank account select **/
+    hideAddBankAccountButton:
+      componentSettings?.payables?.hideAddBankAccountButton ?? false,
     onSaved: componentSettings?.payables?.onSaved,
     onCanceled: componentSettings?.payables?.onCanceled,
     onSubmitted: componentSettings?.payables?.onSubmitted,

--- a/packages/sdk-react/src/core/componentSettings/index.ts
+++ b/packages/sdk-react/src/core/componentSettings/index.ts
@@ -1,3 +1,7 @@
+import {
+  defaultAvailableCountries,
+  defaultAvailableCurrencies,
+} from '../utils';
 import { components } from '@/api';
 import { CustomerTypes } from '@/components/counterparts/types';
 import { FINANCING_LABEL } from '@/components/financing/consts';
@@ -16,11 +20,6 @@ import {
 import type { MoniteIconWrapperProps } from '@/ui/iconWrapper';
 import type { I18n } from '@lingui/core';
 import { t } from '@lingui/macro';
-
-import {
-  defaultAvailableCountries,
-  defaultAvailableCurrencies,
-} from '../utils';
 
 interface ReceivableSettings extends MoniteReceivablesTableProps {
   pageSizeOptions: number[];
@@ -196,13 +195,13 @@ export interface TemplateSettings {
 
 /**
  * Action handlers for custom payment flows in payable operations.
- * 
+ *
  * These handlers provide fine-grained control over payment workflows, allowing customers to:
  * - Integrate external payment providers
  * - Implement custom approval processes or multi-step authentication
  * - Add specialized banking solutions or enterprise payment workflows
  * - Control UI feedback and data refresh timing after payment completion
- * 
+ *
  * @example Custom payment provider integration:
  * ```typescript
  * const onPay = (id: string, _data?: unknown, actions?: PayActionHandlers) => {
@@ -220,19 +219,19 @@ export interface TemplateSettings {
  * ```
  */
 export type PayActionHandlers = {
-  /** 
+  /**
    * Call when a custom payment flow has been successfully initiated/completed.
-   * This triggers SDK's built-in state management: refreshes payable data, 
+   * This triggers SDK's built-in state management: refreshes payable data,
    * payment records, and optionally displays success feedback to the user.
-   * 
+   *
    * @param options.showToast - Whether to display a success toast notification
    */
   resolve: (options?: { showToast?: boolean }) => void;
-  /** 
+  /**
    * Call when a custom payment flow failed or was cancelled by the user.
    * This triggers SDK's built-in state management: refreshes payable data,
    * payment records, and optionally displays error feedback to the user.
-   * 
+   *
    * @param error - Optional error details from the failed payment attempt
    * @param options.showToast - Whether to display an error toast notification
    */
@@ -244,6 +243,7 @@ interface PayableSettings
     MonitePayableDetailsInfoProps {
   pageSizeOptions: number[];
   enableGLCodes?: boolean;
+  hideAddDiscountButton?: boolean;
   onSaved?: (id: string) => void;
   onCanceled?: (id: string) => void;
   onSubmitted?: (id: string) => void;
@@ -253,14 +253,14 @@ interface PayableSettings
   onDeleted?: (id: string) => void;
   /**
    * Called when the user clicks Pay button on a payable.
-   * 
+   *
    * **Legacy Usage (Backward Compatible):**
    * ```typescript
    * onPay: (id: string) => {
    *   console.log('Payment initiated for:', id);
    * }
    * ```
-   * 
+   *
    * **Enhanced Usage (Custom Payment Flow):**
    * ```typescript
    * onPay: (id: string, _data?: unknown, actions?: PayActionHandlers) => {
@@ -270,11 +270,11 @@ interface PayableSettings
    *     .catch(err => actions?.reject(err, { showToast: true }));
    * }
    * ```
-   * 
+   *
    * @param id - The payable ID being paid
    * @param _data - Reserved for future use (currently undefined)
    * @param actions - Optional handlers for custom payment flows. When provided,
-   *                  enables custom payment integration. Call actions.resolve() 
+   *                  enables custom payment integration. Call actions.resolve()
    *                  on success or actions.reject() on failure to update SDK state.
    */
   onPay?: (id: string, _data?: unknown, actions?: PayActionHandlers) => void;
@@ -366,6 +366,9 @@ export const getDefaultComponentSettings = (
     },
     isTagsDisabled: componentSettings?.payables?.isTagsDisabled,
     enableGLCodes: componentSettings?.payables?.enableGLCodes ?? false,
+    /** Whether to hide the "Add Discount" button in the totals section **/
+    hideAddDiscountButton:
+      componentSettings?.payables?.hideAddDiscountButton ?? false,
     onSaved: componentSettings?.payables?.onSaved,
     onCanceled: componentSettings?.payables?.onCanceled,
     onSubmitted: componentSettings?.payables?.onSubmitted,


### PR DESCRIPTION
# Description

Added payables component setting and PayableDetails component prop to customize the edit form: hide the discount button, hide the "add bank account" option on the counterpart bank account input.

# Implementation

- Adjusted componentSettings to support hideAddDiscountButton configuration.
- Adjusted componentSettings to support hideAddBankAccountButton configuration.

# Steps to test

For testing purposes, this PR will deploy a temporary URL for the Playground app with the the following payables componentSettings:
```
payables: {
    hideAddDiscountButton: true,
    hideAddBankAccountButton: true,
  },
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added settings and component props to customize the Payables edit view: hide the “Add Discount” button and hide the “Add bank account” option. Configurable via provider settings or per-component props. Defaults keep existing behavior.

- Documentation
  - Updated in-code docs to describe the new customization flags.

- Chores
  - Added a changeset for a patch release.
  - Updated the playground configuration to showcase the new Payables settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->